### PR TITLE
End the va_list before returning from _synctex_merge_strings.

### DIFF
--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -351,6 +351,7 @@ char * _synctex_merge_strings(const char * first,...) {
 		size_t len = strlen(temp);
 		if(UINT_MAX-len<size) {
 			_synctex_error("!  _synctex_merge_strings: Capacity exceeded.");
+			va_end(arg);
 			return NULL;
 		}
 		size+=len;
@@ -371,6 +372,7 @@ char * _synctex_merge_strings(const char * first,...) {
 						_synctex_error("!  _synctex_merge_strings: Copy problem");
 						free(result);
 						result = NULL;
+						va_end(arg);
 						return NULL;
 					}
 					dest += size;


### PR DESCRIPTION
This adds a va_end() call to _synctex_merge_strings in two places
where it would return without ending the va_list first.

I added the `va_end()` calls since `cppcheck` complains that the `va_list` was not closed; the message it says is:
```
Checking synctex_parser_utils.c ...
[synctex_parser_utils.c:425]: (error) Memory leak: core_name
[synctex_parser_utils.c:447]: (error) Memory leak: dir_name
[synctex_parser_utils.c:354]: (error) va_list 'arg' was opened but not closed by va_end().
Checking synctex_parser_utils.c: SYNCTEX_USE_SYSLOG...
Checking synctex_parser_utils.c: _WIN32...
Checking synctex_parser_utils.c: _WIN32;__TOS_WIN__;__WIN32__;__WINDOWS__...
Checking synctex_parser_utils.c: __OS2__...  
```
According to `man va_end`, "each invocation of va_start() must be matched by a corresponding invocation of va_end() in the same function."

I have already submitted this as a [merge request](https://gitlab.gnome.org/GNOME/evince/merge_requests/108) to GNOME but they said to make an upstream pull request here.