### PR TITLE
Fix compilation wit clang when checking format-nonliteral

### DIFF
--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -8389,6 +8389,7 @@ struct synctex_updater_t {
     int length;             /*  the number of chars appended */
 };
 
+__attribute__((__format__ (__printf__, 2, 3)))
 static int _synctex_updater_print(synctex_updater_p updater, const char * format, ...) {
     int result = 0;
     if (updater) {
@@ -8425,6 +8426,7 @@ static int vasprintf(char **ret,
 /**
  *  gzvprintf is not available until OSX 10.10
  */
+__attribute__((__format__ (__printf__, 2, 3)))
 static int _synctex_updater_print_gz(synctex_updater_p updater, const char * format, ...) {
     int result = 0;
     if (updater) {

--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -86,6 +86,7 @@ void _synctex_free(void * ptr) {
 #   include <syslog.h>
 #endif
 
+__attribute__((__format__ (__printf__, 3, 0)))
 static int _synctex_log(int level, const char * prompt, const char * reason,va_list arg) {
 	int result;
 #	ifdef SYNCTEX_RECENT_WINDOWS
@@ -132,6 +133,7 @@ static int _synctex_log(int level, const char * prompt, const char * reason,va_l
 	return result;
 }
 
+__attribute__((__format__ (__printf__, 1, 2)))
 int _synctex_error(const char * reason,...) {
     va_list arg;
     int result;
@@ -145,6 +147,7 @@ int _synctex_error(const char * reason,...) {
     return result;
 }
 
+__attribute__((__format__ (__printf__, 1, 2)))
 int _synctex_debug(const char * reason,...) {
     va_list arg;
     int result;


### PR DESCRIPTION
clang is stricter than gcc when compiling with `-Wformat-nonliteral`
and requires annotate the function parameters when passing an
argument to a `va_list` that contains these arguments.

https://clang.llvm.org/docs/AttributeReference.html#format