### PR TITLE
Fix implicit declaration of vasprintf

### DIFF
--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -83,6 +83,11 @@
  *  First level objects are sheets and forms, containing boxes, glues, kerns...
  *  The third tree allows to browse leaves according to tag and line.
  */
+/* Declare _GNU_SOURCE for accessing vasprintf. For MSC compiler, vasprintf is
+ * defined in this file
+ */
+#define _GNU_SOURCE
+
 #   if defined(SYNCTEX_USE_LOCAL_HEADER)
 #       include "synctex_parser_local.h"
 #   else


### PR DESCRIPTION
Fix build when compiling with `-Werror=implicit-function-declaration`.