### PR TITLE
Fix memory leaks in _synctex_decode_string

### DIFF
--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -4821,6 +4821,7 @@ static _synctex_ss_s _synctex_decode_string(synctex_scanner_p scanner) {
     size_t already_len = 0;
     _synctex_zs_s zs = {0,0};
     char * string = NULL;
+    char * new_string = NULL;
     if (NULL == scanner) {
         return (_synctex_ss_s){NULL,SYNCTEX_STATUS_BAD_ARGUMENT};
     }
@@ -4829,8 +4830,10 @@ static _synctex_ss_s _synctex_decode_string(synctex_scanner_p scanner) {
 more_characters:
         zs = _synctex_buffer_get_available_size(scanner,1);
         if (zs.status < SYNCTEX_STATUS_EOF) {
+            free(string);
             return (_synctex_ss_s){NULL,zs.status};
         } else if (0 == zs.size) {
+            free(string);
             return (_synctex_ss_s){NULL,SYNCTEX_STATUS_EOF};
         }
     }
@@ -4847,7 +4850,9 @@ more_characters:
      *      or *end == '\n' */
     len = end - SYNCTEX_CUR;
     if (len<UINT_MAX-already_len) {
-        if ((string = realloc(string,len+already_len+1)) != NULL) {
+        if ((new_string = realloc(string,len+already_len+1)) != NULL) {
+            string = new_string;
+            new_string = NULL;
             if (memcpy(string+already_len,SYNCTEX_CUR,len)) {
                 already_len += len;
                 string[already_len]='\0'; /*  Terminate the string */
@@ -4872,6 +4877,7 @@ more_characters:
             return (_synctex_ss_s){NULL,SYNCTEX_STATUS_ERROR};
         }
     }
+    free(string);
     _synctex_error("could not (re)allocate memory (1).");
     return (_synctex_ss_s){NULL,SYNCTEX_STATUS_ERROR};
 }


### PR DESCRIPTION
Found by Okular's code quality scanner, see e.g. https://invent.kde.org/graphics/okular/-/merge_requests/1061.

> Critical - Common realloc mistake: 'string' nulled but not freed upon failure (CWE-401)

(May be makes sense to setup a code quality scanner here too?)

Explanation of changes:
1. https://en.cppreference.com/w/c/memory/realloc:
    
    > If there is not enough memory, **the old memory block is not freed** and null pointer is returned.
1. The code after `realloc` can go to `more_characters`, which may return an error without freeing the string.