### PR TITLE
Use clang-format

### DIFF
--- a/meson/.clang-format
+++ b/meson/.clang-format
@@ -1,0 +1,88 @@
+---
+# SPDX-FileCopyrightText: 2019 Christoph Cullmann <cullmann@kde.org>
+# SPDX-FileCopyrightText: 2019 Gernot Gebhard <gebhard@absint.com>
+#
+# SPDX-License-Identifier: MIT
+
+# Based on KDE ECM (extra-cmake-modules) setup.
+# See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for the config options
+# and https://community.kde.org/Policies/Frameworks_Coding_Style#Clang-format_automatic_code_formatting
+# for clang-format tips & tricks
+---
+
+# Style for C++
+Language: Cpp
+
+# base is WebKit coding style: https://webkit.org/code-style-guidelines/
+# below are only things set that diverge from this style!
+BasedOnStyle: WebKit
+
+# enforce C++11 (e.g. for std::vector<std::vector<lala>>
+Standard: Cpp11
+
+# 4 spaces indent
+TabWidth: 4
+
+# 2 * 80 wide lines
+ColumnLimit: 160
+
+# sort includes inside line separated groups
+SortIncludes: true
+
+# break before braces on function, namespace and class definitions.
+BreakBeforeBraces: Linux
+
+# CrlInstruction *a;
+PointerAlignment: Right
+
+# horizontally aligns arguments after an open bracket.
+AlignAfterOpenBracket: Align
+
+# don't move all parameters to new line
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# no single line functions
+AllowShortFunctionsOnASingleLine: None
+
+# no single line enums
+AllowShortEnumsOnASingleLine: false
+
+# always break before you encounter multi line strings
+AlwaysBreakBeforeMultilineStrings: true
+
+# don't move arguments to own lines if they are not all on the same
+BinPackArguments: false
+
+# don't move parameters to own lines if they are not all on the same
+BinPackParameters: false
+
+# In case we have an if statement with multiple lines the operator should be at the beginning of the line
+# but we do not want to break assignments
+BreakBeforeBinaryOperators: NonAssignment
+
+# format C++11 braced lists like function calls
+Cpp11BracedListStyle: true
+
+# do not put a space before C++11 braced lists
+SpaceBeforeCpp11BracedList: false
+
+# remove empty lines
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# no namespace indentation to keep indent level low
+NamespaceIndentation: None
+
+# we use template< without space.
+SpaceAfterTemplateKeyword: false
+
+# Always break after template declaration
+AlwaysBreakTemplateDeclarations: true
+
+# macros for which the opening brace stays attached.
+ForEachMacros: []
+
+# keep lambda formatting multi-line if not empty
+AllowShortLambdasOnASingleLine: Empty
+
+# We do not want clang-format to put all arguments on a new line
+AllowAllArgumentsOnNextLine: false

--- a/meson/.clang-format-include
+++ b/meson/.clang-format-include
@@ -1,0 +1,7 @@
+# Since the meson & sources directory structure is kind of backwards,
+# we need to explicitly include files in the parent directory
+../*.c
+../*.h
+
+../synctex test files/code/*.c
+../synctex test files/code/*.h

--- a/meson/README.md
+++ b/meson/README.md
@@ -3,9 +3,11 @@
 The main tool is `meson`, see downloading instructions from the [official meson site](https://mesonbuild.com/).
 
 ## Clone
+
 First retrieve the source code. You can use the green code button from the [main SyncTeX page](https://github.com/jlaurens/synctex). If you plan to contribute to the code, it is recommanded to clone the GitHub synctex repository and use GitHub desktop application if available on your operating system.
 
 ## Building
+
 Instructions below are given to build the `synctex` command line tool on possibly various operating systems.
 Building is made through the command line.
 
@@ -57,7 +59,7 @@ meson compile -C build
 
 If `meson` is not suitable, next instructions were used for Xcode 7 but they might apply as well for other versions. The `build` folder and project are created out of the `.../synctexdir/` folder.
 
-### create a new project
+### Create a new project
 
 - create a new project
 - choose a command line tool project
@@ -80,7 +82,7 @@ you then have both folders `synctex` and `synctexdir` in the same directory.
 - go to the build phase pane
 - remove `Readme.md` from the compile sources list
 
-You end with 3 sources : `synctex_main.c`, `synctex_parser.c`, `synctex_parser_utils.c`
+You end with 3 sources: `synctex_main.c`, `synctex_parser.c`, `synctex_parser_utils.c`
 
 ### Setup project
 
@@ -104,6 +106,7 @@ More details in the `.../synctexdir/test standalone/README.md`.
 ## How to
 
 ### Develop for TeXLive
+
 Use case: a default TeX distribution for everyday use, for example TeXLive 2024, and a different TeX distribution for SyncTeX development, for example TeXLive checked out with svn. If you want to use TeX engine binaries from the development TeX distribution, you can specify
 
 ```sh
@@ -353,6 +356,7 @@ TEXMFCNF=$TEXMFROOT/texmf-dist/web2c \
 ```
 
 ## Real setup on MacOS
+
 This setup was used to develop the `\synctexmark` command.
 We start with a fresh check out of TeXLive that we then build.
 Then we build a `.texdist` structure from scratch to point to this TeXLive check out. One can duplicate an
@@ -372,6 +376,7 @@ make pdftex && fmtutil --sys --byfmt pdftex
 ```
 
 ## Print debug information
+
 During test, some supplemental information may help: use
 ```sh
 meson test -C build --test-args='--debug'

--- a/synctex test files/code/synctex_parser_tests.c
+++ b/synctex test files/code/synctex_parser_tests.c
@@ -1,14 +1,14 @@
 /*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the SyncTeX package.
- 
+
  Latest Revision: Tue Mar  5 21:16:33 UTC 2024
- 
+
  Version: 1.19
- 
+
  See synctex_parser_readme.txt for more details
- 
+
  License:
  --------
  Permission is hereby granted, free of charge, to any person
@@ -19,10 +19,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -31,17 +31,17 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  Nota Bene:
  ----------
  If you include or use a significant part of the synctex package into a software,
  I would appreciate to be listed as contributor and see "SyncTeX" highlighted.
- 
+
  */
 
 #include "synctex_parser_private.h"

--- a/synctex test files/code/synctex_parser_tests.c
+++ b/synctex test files/code/synctex_parser_tests.c
@@ -47,7 +47,8 @@
 #include "synctex_parser_private.h"
 #include "synctex_parser_utils.h"
 
-int synctex_parser_test_all() {
+int synctex_parser_test_all()
+{
     int TC = 0;
     synctex_scanner_p scanner = synctex_scanner_new();
     /*  Here we assume that int are smaller than void * */
@@ -67,7 +68,7 @@ int synctex_parser_test_all() {
     TC += synctex_test_sheet_2();
     TC += synctex_test_charindex();
     TC += synctex_test_form();
-/*
- */
+    /*
+     */
     return TC;
 }

--- a/synctex test files/code/synctex_parser_tests.h
+++ b/synctex test files/code/synctex_parser_tests.h
@@ -1,14 +1,14 @@
 /*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the SyncTeX package.
- 
+
  Latest Revision: Tue Mar  5 21:16:33 UTC 2024
- 
+
  Version: 1.19
- 
+
  See synctex_parser_readme.txt for more details
- 
+
  License:
  --------
  Permission is hereby granted, free of charge, to any person
@@ -19,10 +19,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -31,17 +31,17 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  Nota Bene:
  ----------
  If you include or use a significant part of the synctex package into a software,
  I would appreciate to be listed as contributor and see "SyncTeX" highlighted.
- 
+
  */
 
 /**

--- a/synctex_main.c
+++ b/synctex_main.c
@@ -1,15 +1,15 @@
-/* 
+/*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
- 
+
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
- 
+
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,29 +30,29 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  Acknowledgments:
  ----------------
  The author received useful remarks from the pdfTeX developers, especially Hahn The Thanh,
  and significant help from XeTeX developer Jonathan Kew
- 
+
  Nota Bene:
  ----------
  If you include or use a significant part of the synctex package into a software,
  I would appreciate to be listed as contributor and see "SyncTeX" highlighted.
- 
+
  History:
  --------
- 
+
  - the -d option for an input directory
  - the --parse_int_policy global option
  - the --interactive global option
- 
+
  Important notice:
  -----------------
  This file is named "synctex_main.c".
@@ -474,7 +474,7 @@ void synctex_help_view(const char * error,...) {
 
 /**
  * @brief Data structure for view queries
- * 
+ *
  */
 typedef struct {
     /** The line number*/
@@ -1138,7 +1138,7 @@ next_argument:
         }
         goto prepare_next_argument;
     }
-    
+
     /* Arguments parsed */
     updater = synctex_updater_new_with_output_file(output,directory);
     synctex_updater_append_magnification(updater,magnification);
@@ -1281,7 +1281,7 @@ int synctex_dump(int argc, char *argv[]) {
     synctex_node_p sheet;
     /** The first form, its siblings are the other forms */
     synctex_node_p form;
-    /** The first form ref node in sheet, its friends are the other form ref nodes */    
+    /** The first form ref node in sheet, its friends are the other form ref nodes */
     synctex_node_p ref_in_sheet;
     /** The first form ref node, its friends are the other form ref nodes in sheet */
     synctex_node_p ref_in_form;

--- a/synctex_main.c
+++ b/synctex_main.c
@@ -59,31 +59,31 @@
  This is the command line interface to the synctex_parser.c.
  */
 
-#   ifdef __linux__
-#       define _ISOC99_SOURCE /* to get the fmax() prototype */
-#   endif
+#ifdef __linux__
+#define _ISOC99_SOURCE /* to get the fmax() prototype */
+#endif
 
-#   if defined(SYNCTEX_STANDALONE)
-#       include <synctex_parser_c-auto.h>
+#if defined(SYNCTEX_STANDALONE)
+#include <synctex_parser_c-auto.h>
 /*      for inline && HAVE_xxx */
-#   else
-#       include <w2c/c-auto.h>
+#else
+#include <w2c/c-auto.h>
 /*      for inline && HAVE_xxx */
-#   endif
+#endif
 
-#   include <stdlib.h>
-#   include <errno.h>
-#   include <stdio.h>
-#   include <string.h>
-#   include <stdarg.h>
-#   include <math.h>
-#   include <poll.h>
-#   include <unistd.h>
-#   include <sys/types.h>
-#   include <sys/stat.h>
-#   include "synctex_version.h"
-#   include "synctex_parser_advanced.h"
-#   include "synctex_parser_utils.h"
+#include "synctex_parser_advanced.h"
+#include "synctex_parser_utils.h"
+#include "synctex_version.h"
+#include <errno.h>
+#include <math.h>
+#include <poll.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 /*  The code below uses strlcat and strlcpy, which avoids security warnings with some compilers.
     However, if these are not available we simply use the old, unchecked versions;
@@ -91,14 +91,17 @@
     allocated based on measuring the strings involved.
  */
 #ifndef HAVE_STRLCAT
-#   define strlcat(dst, src, size) strcat((dst), (src))
+#define strlcat(dst, src, size) strcat((dst), (src))
 #endif
 #ifndef HAVE_STRLCPY
-#   define strlcpy(dst, src, size) strcpy((dst), (src))
+#define strlcpy(dst, src, size) strcpy((dst), (src))
 #endif
 #ifndef HAVE_FMAX
-#   define fmax my_fmax
-inline static double my_fmax(double x, double y) { return (x < y) ? y : x; }
+#define fmax my_fmax
+inline static double my_fmax(double x, double y)
+{
+    return (x < y) ? y : x;
+}
 #endif
 
 /* I use the definition in kpathsea --ak
@@ -108,32 +111,31 @@ inline static double my_fmax(double x, double y) { return (x < y) ? y : x; }
 */
 
 #if defined(WIN32) && defined(SYNCTEX_STANDALONE)
-#   define snprintf _snprintf
+#define snprintf _snprintf
 #endif
 
 #if defined(WIN32) && !defined(SYNCTEX_STANDALONE)
-#   include <kpathsea/progname.h>
+#include <kpathsea/progname.h>
 #endif
 
-
 #if SYNCTEX_DEBUG
-#   define SYNCTEX_DUMP 1
-#   ifdef WIN32
-#       include <direct.h>
-#       define getcwd _getcwd
-#   else
-#       include <unistd.h>
-#   endif
+#define SYNCTEX_DUMP 1
+#ifdef WIN32
+#include <direct.h>
+#define getcwd _getcwd
+#else
+#include <unistd.h>
+#endif
 #endif
 
 int main(int argc, char *argv[]);
 
-void synctex_help(const char * error,...);
-void synctex_help_view(const char * error,...);
-void synctex_help_edit(const char * error,...);
-void synctex_help_update(const char * error,...);
-void synctex_help_options(const char * error,...);
-void synctex_help_dump(const char * error,...);
+void synctex_help(const char *error, ...);
+void synctex_help_view(const char *error, ...);
+void synctex_help_edit(const char *error, ...);
+void synctex_help_update(const char *error, ...);
+void synctex_help_options(const char *error, ...);
+void synctex_help_dump(const char *error, ...);
 
 int synctex_view(int argc, char *argv[]);
 int synctex_edit(int argc, char *argv[]);
@@ -157,19 +159,19 @@ int main(int argc, char *argv[])
 #endif
     printf("This is SyncTeX command line utility, version " SYNCTEX_CLI_VERSION_STRING "\n");
     /* Loop for global options */
-    while(++i<argc) {
-        if(0==strcmp("-v",argv[i]) || 0==strcmp("--version",argv[i])) {
+    while (++i < argc) {
+        if (0 == strcmp("-v", argv[i]) || 0 == strcmp("--version", argv[i])) {
             synctex_help(NULL);
             return 0;
-        } else if(0==strcmp("--interactive",argv[i])) {
+        } else if (0 == strcmp("--interactive", argv[i])) {
             g_interactive = 1;
-        } else if(0==strcmp("--parse_int_policy",argv[i])) {
-            if(++i<argc) {
-                if(0==strcmp("C",argv[i])) {
+        } else if (0 == strcmp("--parse_int_policy", argv[i])) {
+            if (++i < argc) {
+                if (0 == strcmp("C", argv[i])) {
                     synctex_parse_int_policy(synctex_parse_int_policy_C);
-                } else if(0==strcmp("raw1",argv[i])) {
+                } else if (0 == strcmp("raw1", argv[i])) {
                     synctex_parse_int_policy(synctex_parse_int_policy_raw1);
-                } else if(0==strcmp("raw2",argv[i])) {
+                } else if (0 == strcmp("raw2", argv[i])) {
                     synctex_parse_int_policy(synctex_parse_int_policy_raw2);
                 } else {
                     synctex_help("Unknown policy.");
@@ -182,15 +184,15 @@ int main(int argc, char *argv[])
         } else {
             /* Loop for other options */
             do {
-                if(0==strcmp("--interactive",argv[i])) {
+                if (0 == strcmp("--interactive", argv[i])) {
                     g_interactive = 1;
-                } else if(0==strcmp("--parse_int_policy",argv[i])) {
-                    if(++i<argc) {
-                        if(0==strcmp("C",argv[i])) {
+                } else if (0 == strcmp("--parse_int_policy", argv[i])) {
+                    if (++i < argc) {
+                        if (0 == strcmp("C", argv[i])) {
                             synctex_parse_int_policy(synctex_parse_int_policy_C);
-                        } else if(0==strcmp("raw1",argv[i])) {
+                        } else if (0 == strcmp("raw1", argv[i])) {
                             synctex_parse_int_policy(synctex_parse_int_policy_raw1);
-                        } else if(0==strcmp("raw2",argv[i])) {
+                        } else if (0 == strcmp("raw2", argv[i])) {
                             synctex_parse_int_policy(synctex_parse_int_policy_raw2);
                         } else {
                             synctex_help("Unknown policy.");
@@ -200,41 +202,41 @@ int main(int argc, char *argv[])
                     }
                     synctex_help(NULL);
                     return 0;
-                } else if(0==strcmp("help",argv[i])) {
-                    if(++i<argc) {
-                        if(0==strcmp("view",argv[i])) {
+                } else if (0 == strcmp("help", argv[i])) {
+                    if (++i < argc) {
+                        if (0 == strcmp("view", argv[i])) {
                             synctex_help_view(NULL);
                             return 0;
-                        } else if(0==strcmp("edit",argv[i])) {
+                        } else if (0 == strcmp("edit", argv[i])) {
                             synctex_help_edit(NULL);
                             return 0;
-                        } else if(0==strcmp("update",argv[i])) {
+                        } else if (0 == strcmp("update", argv[i])) {
                             synctex_help_update(NULL);
                             return 0;
-                        } else if(0==strcmp("options",argv[i])) {
+                        } else if (0 == strcmp("options", argv[i])) {
                             synctex_help_options(NULL);
                             return 0;
-                        } else if(0==strcmp("dump",argv[i])) {
+                        } else if (0 == strcmp("dump", argv[i])) {
                             synctex_help_dump(NULL);
                             return 0;
                         }
                     }
                     synctex_help(NULL);
                     return 0;
-                } else if(0==strcmp("view",argv[i])) {
-                    status = synctex_view(argc-i-1,argv+i+1);
+                } else if (0 == strcmp("view", argv[i])) {
+                    status = synctex_view(argc - i - 1, argv + i + 1);
                     return synctex_return(status);
-                } else if(0==strcmp("edit",argv[i])) {
-                    status = synctex_edit(argc-i-1,argv+i+1);
+                } else if (0 == strcmp("edit", argv[i])) {
+                    status = synctex_edit(argc - i - 1, argv + i + 1);
                     return synctex_return(status);
-                } else if(0==strcmp("update",argv[i])) {
-                    return synctex_update(argc-i-1,argv+i+1);
-                } else if(0==strcmp("test",argv[i])) {
-                    return synctex_test(argc-i-1,argv+i+1);
-                } else if(0==strcmp("dump",argv[i])) {
-                    return synctex_dump(argc-i-1,argv+i+1);
+                } else if (0 == strcmp("update", argv[i])) {
+                    return synctex_update(argc - i - 1, argv + i + 1);
+                } else if (0 == strcmp("test", argv[i])) {
+                    return synctex_test(argc - i - 1, argv + i + 1);
+                } else if (0 == strcmp("dump", argv[i])) {
+                    return synctex_dump(argc - i - 1, argv + i + 1);
                 }
-            } while (++i<argc);
+            } while (++i < argc);
             break;
         }
     }
@@ -242,10 +244,10 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-char * synctex_view_i(char *);
+char *synctex_view_i(char *);
 int synctex_view_proceed();
 
-char * synctex_edit_o(char *);
+char *synctex_edit_o(char *);
 int synctex_edit_proceed();
 
 synctex_scanner_p g_scanner = NULL;
@@ -253,12 +255,13 @@ time_t g_last_modification_time = 0;
 
 int synctex_synchronize();
 
-char * g_output   = NULL;
-char * g_directory = NULL;
-char * g_file = NULL;
+char *g_output = NULL;
+char *g_directory = NULL;
+char *g_file = NULL;
 
-int synctex_synchronize() {
-    const char * dot_synctex;
+int synctex_synchronize()
+{
+    const char *dot_synctex;
     int status = 0;
     struct stat attr;
     if (g_scanner) {
@@ -269,41 +272,42 @@ int synctex_synchronize() {
         }
         status = 1;
     }
-    g_scanner = synctex_scanner_new_with_output_file(g_output,g_directory,1);
+    g_scanner = synctex_scanner_new_with_output_file(g_output, g_directory, 1);
     dot_synctex = synctex_scanner_get_synctex(g_scanner);
     stat(dot_synctex, &attr);
     g_last_modification_time = attr.st_mtime;
     return status;
 }
 
-#   define SYNCTEX_BUFFER_SIZE 2048
+#define SYNCTEX_BUFFER_SIZE 2048
 
-int synctex_return(int status) {
+int synctex_return(int status)
+{
     fflush(stdout);
     if (!status && g_interactive) {
         struct pollfd poll_stdin = {0, POLLIN, 0};
-        char * buffer = (char *)malloc(SYNCTEX_BUFFER_SIZE+1);
+        char *buffer = (char *)malloc(SYNCTEX_BUFFER_SIZE + 1);
         if (buffer) {
-            while(1) {
+            while (1) {
                 printf("synctex (? for help)> ");
                 fflush(stdout);
                 if (poll(&poll_stdin, 1, 0)) {
                     break;
                 }
                 int length = read(0, buffer, 1024);
-                char * p = buffer;
-                while(length>0) {
-                    if (p[length-1]=='\r') {
-                    --length;
-                    } else if (p[length-1]=='\n') {
-                    --length;
-                    } else if (p[length-1]==' ') {
-                    --length;
+                char *p = buffer;
+                while (length > 0) {
+                    if (p[length - 1] == '\r') {
+                        --length;
+                    } else if (p[length - 1] == '\n') {
+                        --length;
+                    } else if (p[length - 1] == ' ') {
+                        --length;
                     } else {
                         break;
                     }
                 }
-                while(p[0]==' ') {
+                while (p[0] == ' ') {
                     ++p;
                     --length;
                 };
@@ -318,22 +322,19 @@ int synctex_return(int status) {
                     puts("Done");
                     break;
                 }
-                char * q = strchr(buffer, ' ');
+                char *q = strchr(buffer, ' ');
                 if (!q) {
                     puts("Bad entry");
                     continue;
                 }
                 *q = '\0';
-                if (synctex_synchronize()>0) {
-                    printf(
-                        "%s file synchronized\n",
-                        synctex_scanner_get_synctex(g_scanner)
-                    );
+                if (synctex_synchronize() > 0) {
+                    printf("%s file synchronized\n", synctex_scanner_get_synctex(g_scanner));
                 }
-                if (0==strcmp(p, "v")) {
+                if (0 == strcmp(p, "v")) {
                     ++q;
-                    if ( q[0] == '"' && q[strlen(q)-1] == '"') {
-                        q[strlen(q)-1] = '\0';
+                    if (q[0] == '"' && q[strlen(q) - 1] == '"') {
+                        q[strlen(q) - 1] = '\0';
                         ++q;
                     }
                     synctex_view_i(q);
@@ -341,10 +342,10 @@ int synctex_return(int status) {
                         puts("Synctex result begin");
                         puts("Synctex result end");
                     }
-                } else if (0==strcmp(p, "e")) {
+                } else if (0 == strcmp(p, "e")) {
                     ++q;
-                    if ( q[0] == '"' && q[strlen(q)-1] == '"') {
-                        q[strlen(q)-1] = '\0';
+                    if (q[0] == '"' && q[strlen(q) - 1] == '"') {
+                        q[strlen(q) - 1] = '\0';
                         ++q;
                     }
                     synctex_edit_o(q);
@@ -366,47 +367,50 @@ int synctex_return(int status) {
     return status;
 }
 
-static void synctex_usage(const char * error,va_list ap) {
-    if(error) {
-        fprintf(stderr,"SyncTeX ERROR: ");
-        vfprintf(stderr,error,ap);
-        fprintf(stderr,"\n");
+static void synctex_usage(const char *error, va_list ap)
+{
+    if (error) {
+        fprintf(stderr, "SyncTeX ERROR: ");
+        vfprintf(stderr, error, ap);
+        fprintf(stderr, "\n");
     }
-    fprintf((error?stderr:stdout),
-        "usage: synctex [global option] <subcommand> [options] [args]\n"
-        "Synchronize TeXnology command-line client, version " SYNCTEX_VERSION_STRING "\n\n"
-        "The Synchronization TeXnology by Jérôme Laurens is a feature of most TeX engines.\n"
-        "It allows to synchronize between input and output, which means to\n"
-        "navigate from the source document to the typeset material and vice versa.\n\n"
-    );
+    fprintf((error ? stderr : stdout),
+            "usage: synctex [global option] <subcommand> [options] [args]\n"
+            "Synchronize TeXnology command-line client, version " SYNCTEX_VERSION_STRING
+            "\n\n"
+            "The Synchronization TeXnology by Jérôme Laurens is a feature of most TeX engines.\n"
+            "It allows to synchronize between input and output, which means to\n"
+            "navigate from the source document to the typeset material and vice versa.\n\n");
     return;
 }
 
-void synctex_help(const char * error,...) {
+void synctex_help(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
     va_end(v);
-    fprintf((error?stderr:stdout),
-        "Available subcommands:\n"
-        "   view     to perform forwards synchronization\n"
-        "   edit     to perform backwards synchronization\n"
-        "   update   to update a synctex file after a dvi/xdv to pdf filter\n"
-        "   help     this help\n\n"
-        "Type 'synctex help <subcommand>' for help on a specific subcommand.\n"
-        "There is also an undocumented test subcommand.\n"
-        "Type 'synctex help options' for help on global options,\n"
-        "including the interactive mode.\n"
-    );
+    fprintf((error ? stderr : stdout),
+            "Available subcommands:\n"
+            "   view     to perform forwards synchronization\n"
+            "   edit     to perform backwards synchronization\n"
+            "   update   to update a synctex file after a dvi/xdv to pdf filter\n"
+            "   help     this help\n\n"
+            "Type 'synctex help <subcommand>' for help on a specific subcommand.\n"
+            "There is also an undocumented test subcommand.\n"
+            "Type 'synctex help options' for help on global options,\n"
+            "including the interactive mode.\n");
     return;
 }
 
-void synctex_help_view(const char * error,...) {
+void synctex_help_view(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
     va_end(v);
-    fputs("synctex view: forwards or direct synchronization,\n"
+    fputs(
+        "synctex view: forwards or direct synchronization,\n"
         "command sent by the editor to view the output corresponding to the position under the mouse\n"
         "\n"
         "usage: synctex view -i line:column:[page_hint:]input -o output [-d directory] [-x viewer-command] [-h before/offset:middle/after]\n"
@@ -454,7 +458,7 @@ void synctex_help_view(const char * error,...) {
         "       To synchronize by content, %{before} is the word before,\n"
         "       %{offset} is the offset specifier, %{middle} is the middle word, and %{after} is the word after.\n"
         "\n"
-          "       If no viewer command is provided, the content of the SYNCTEX_VIEWER environment variable is used instead.\n"
+        "       If no viewer command is provided, the content of the SYNCTEX_VIEWER environment variable is used instead.\n"
         "\n"
         "-h before/offset:middle/after\n"
         "       This hint allows a forwards synchronization by contents.\n"
@@ -467,8 +471,7 @@ void synctex_help_view(const char * error,...) {
         "       \n"
         "The result is a list of records. In general the first one is the most accurate but\n"
         "it is the responsibility of the client to decide which one best fits the user needs.\n",
-        (error?stderr:stdout)
-    );
+        (error ? stderr : stdout));
     return;
 }
 
@@ -486,39 +489,40 @@ typedef struct {
     /** The offset hint */
     unsigned int offset;
     /** name of the input file */
-    char * input;
+    char *input;
     /** name of the output file */
-    char * output;
+    char *output;
     /** name of the directory, defaults to the current working directory */
-    char * directory;
+    char *directory;
     /** command to launch the viewer */
-    char * viewer;
+    char *viewer;
     /** text before hint */
-    char * before;
+    char *before;
     /** middle text hint */
-    char * middle;
+    char *middle;
     /** after text hint */
-    char * after;
+    char *after;
 } _synctex_view_t;
 
-_synctex_view_t g_view = {-1,0,0,-1,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
+_synctex_view_t g_view = {-1, 0, 0, -1, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
-char * synctex_view_i(char * arg) {
-    char * ans;
-    g_view.line = synctex_parse_int(arg,&ans);
-    if(ans>arg && *ans==':') {
-        arg = ans+1;
-        g_view.column = synctex_parse_int(arg,&ans);
-        if(ans == arg || g_view.column < 0) {
+char *synctex_view_i(char *arg)
+{
+    char *ans;
+    g_view.line = synctex_parse_int(arg, &ans);
+    if (ans > arg && *ans == ':') {
+        arg = ans + 1;
+        g_view.column = synctex_parse_int(arg, &ans);
+        if (ans == arg || g_view.column < 0) {
             g_view.column = 0;
         }
-        if(*ans==':') {
-            arg = ans+1;
-            g_view.page = synctex_parse_int(arg,&ans);
-            if(ans == arg) {
+        if (*ans == ':') {
+            arg = ans + 1;
+            g_view.page = synctex_parse_int(arg, &ans);
+            if (ans == arg) {
                 // This was not a page hint but an input
                 g_view.page = 0;
-            } else if(*ans==':') {
+            } else if (*ans == ':') {
                 // this is a page hint followed by an input
                 ++ans;
             } else {
@@ -526,8 +530,8 @@ char * synctex_view_i(char * arg) {
                 ans = arg;
                 g_view.page = 0;
             }
-            if (ans[0] == '"' && ans[strlen(ans)-1] == '"') {
-                ans[strlen(ans)-1] = '\0';
+            if (ans[0] == '"' && ans[strlen(ans) - 1] == '"') {
+                ans[strlen(ans) - 1] = '\0';
                 ++ans;
             }
             g_view.input = ans;
@@ -538,28 +542,29 @@ char * synctex_view_i(char * arg) {
 }
 
 /* "usage: synctex view -i line:column:input -o output [-d directory] [-x viewer-command] [-h before/offset:middle/after]\n" */
-int synctex_view(int argc, char *argv[]) {
+int synctex_view(int argc, char *argv[])
+{
     /* required */
     int i = 0;
-    if((i>=argc) || strcmp("-i",argv[i]) || (++i>=argc)) {
+    if ((i >= argc) || strcmp("-i", argv[i]) || (++i >= argc)) {
         synctex_help_view("Missing -i required argument");
         return -1;
     }
     if (synctex_view_i(argv[i]) <= argv[i]) {
-    synctex_help_view("Bad -i argument");
-    return -1;
+        synctex_help_view("Bad -i argument");
+        return -1;
     }
-    if((++i>=argc) || strcmp("-o",argv[i]) || (++i>=argc)) {
+    if ((++i >= argc) || strcmp("-o", argv[i]) || (++i >= argc)) {
         synctex_help_view("Missing -o required argument");
         return -1;
     }
     g_output = argv[i];
     /* now scan the optional arguments */
-    if(++i<argc) {
-        if(0 == strcmp("-d",argv[i])) {
-            if(++i<argc) {
+    if (++i < argc) {
+        if (0 == strcmp("-d", argv[i])) {
+            if (++i < argc) {
                 g_directory = argv[i];
-                if(++i>=argc) {
+                if (++i >= argc) {
                     return synctex_view_proceed();
                 }
             } else {
@@ -568,12 +573,12 @@ int synctex_view(int argc, char *argv[]) {
             }
         }
         // Scan the optional command
-        if(0 == strcmp("-x",argv[i])) {
-            if(++i<argc) {
-                if(strcmp("-",argv[i])) {
+        if (0 == strcmp("-x", argv[i])) {
+            if (++i < argc) {
+                if (strcmp("-", argv[i])) {
                     /* next option does not start with '-', this is a command */
                     g_view.viewer = argv[i];
-                    if(++i>=argc) {
+                    if (++i >= argc) {
                         return synctex_view_proceed();
                     }
                 } else {
@@ -586,19 +591,19 @@ int synctex_view(int argc, char *argv[]) {
             }
         }
         // scan the optional hint
-        if(0 == strcmp("-h",argv[i]) && ++i<argc) {
+        if (0 == strcmp("-h", argv[i]) && ++i < argc) {
             /* modify the argument */;
-            g_view.after = strchr(argv[i],'/');
-            if(NULL != g_view.after) {
+            g_view.after = strchr(argv[i], '/');
+            if (NULL != g_view.after) {
                 g_view.before = argv[i];
                 *g_view.after = '\0';
                 ++g_view.after;
-                g_view.offset = (int)strtoul(g_view.after,&g_view.middle,10);
-                if(g_view.middle>g_view.after && strlen(g_view.middle)>2) {
-                    g_view.after = strchr(++g_view.middle,'/');
-                    if(NULL != g_view.after) {
+                g_view.offset = (int)strtoul(g_view.after, &g_view.middle, 10);
+                if (g_view.middle > g_view.after && strlen(g_view.middle) > 2) {
+                    g_view.after = strchr(++g_view.middle, '/');
+                    if (NULL != g_view.after) {
                         *g_view.after = '\0';
-                        if(g_view.offset<strlen(g_view.middle)) {
+                        if (g_view.offset < strlen(g_view.middle)) {
                             ++g_view.after;
                             return synctex_view_proceed();
                         }
@@ -611,113 +616,116 @@ int synctex_view(int argc, char *argv[]) {
     }
     return synctex_view_proceed();
 }
-int synctex_view_proceed() {
+int synctex_view_proceed()
+{
     size_t size = 0;
 #if SYNCTEX_DEBUG
-    printf("line:%i\n",g_view.line);
-    printf("column:%i\n",g_view.column);
-    printf("page:%i\n",g_view.page);
-    printf("input:%s\n",g_view.input);
-    printf("viewer:%s\n",g_view.viewer);
-    printf("before:%s\n",g_view.before);
-    printf("offset:%u\n",g_view.offset);
-    printf("middle:%s\n",g_view.middle);
-    printf("after:%s\n",g_view.after);
-    printf("output:%s\n",g_output);
-    printf("cwd:%s\n",getcwd(NULL,0));
+    printf("line:%i\n", g_view.line);
+    printf("column:%i\n", g_view.column);
+    printf("page:%i\n", g_view.page);
+    printf("input:%s\n", g_view.input);
+    printf("viewer:%s\n", g_view.viewer);
+    printf("before:%s\n", g_view.before);
+    printf("offset:%u\n", g_view.offset);
+    printf("middle:%s\n", g_view.middle);
+    printf("after:%s\n", g_view.after);
+    printf("output:%s\n", g_output);
+    printf("cwd:%s\n", getcwd(NULL, 0));
 #endif
     /*  We assume that viewer is not so big: */
-#   define SYNCTEX_STR_SIZE 65536
-    if(g_view.viewer && strlen(g_view.viewer)>=SYNCTEX_STR_SIZE) {
+#define SYNCTEX_STR_SIZE 65536
+    if (g_view.viewer && strlen(g_view.viewer) >= SYNCTEX_STR_SIZE) {
         synctex_help_view("Viewer command is too long");
         return -1;
     }
     synctex_synchronize();
-    if(g_scanner && synctex_display_query(g_scanner,g_view.input,g_view.line,g_view.column,g_view.page)) {
+    if (g_scanner && synctex_display_query(g_scanner, g_view.input, g_view.line, g_view.column, g_view.page)) {
         synctex_node_p node = NULL;
-        if((node = synctex_scanner_next_result(g_scanner)) != NULL) {
+        if ((node = synctex_scanner_next_result(g_scanner)) != NULL) {
             /* filtering the command */
-            if(g_view.viewer && strlen(g_view.viewer)) {
-                char * viewer = g_view.viewer;
-                char * where = NULL;
-                char * buffer = NULL;
-                char * buffer_cur = NULL;
+            if (g_view.viewer && strlen(g_view.viewer)) {
+                char *viewer = g_view.viewer;
+                char *where = NULL;
+                char *buffer = NULL;
+                char *buffer_cur = NULL;
                 int status = 0;
                 /* Preparing the buffer where everything will be printed */
-                size = strlen(viewer)+3*sizeof(int)+6*sizeof(float)+4*(SYNCTEX_STR_SIZE);
-                buffer = malloc(size+1);
-                if(NULL == buffer) {
+                size = strlen(viewer) + 3 * sizeof(int) + 6 * sizeof(float) + 4 * (SYNCTEX_STR_SIZE);
+                buffer = malloc(size + 1);
+                if (NULL == buffer) {
                     synctex_help_view("No memory available");
                     return -1;
                 }
                 /*  Properly terminate the buffer, no bad access for string related functions. */
                 buffer[size] = '\0';
                 /* Replace %{ by &{, then remove all unescaped '%'*/
-                while((where = strstr(viewer,"%{")) != NULL) {
+                while ((where = strstr(viewer, "%{")) != NULL) {
                     *where = '&';
                 }
                 /* find all the unescaped '%', change to a safe character */
                 where = viewer;
-                while(where && (where = strchr(where,'%'))) {
+                while (where && (where = strchr(where, '%'))) {
                     /*  Find the next occurrence of a "%",
                      *  if it is not followed by another "%",
                      *  replace it by a "&" */
-                    if(strlen(++where)) {
-                        if(*where == '%') {
+                    if (strlen(++where)) {
+                        if (*where == '%') {
                             ++where;
                         } else {
-                            *(where-1)='&';
+                            *(where - 1) = '&';
                         }
                     }
                 }
                 buffer_cur = buffer;
                 /*  find the next occurrence of a format key */
                 where = viewer;
-                while(viewer && (where = strstr(viewer,"&{"))) {
-#                   define TEST(KEY,FORMAT,WHAT)\
-                    if(!strncmp(where,KEY,strlen(KEY))) {\
-                        size_t printed = where-viewer;\
-                        if(buffer_cur != memcpy(buffer_cur,viewer,(size_t)printed)) {\
-                            synctex_help_view("Memory copy problem");\
-                            free(buffer);\
-                            return -1;\
-                        }\
-                        buffer_cur += printed;size-=printed;\
-                        printed = snprintf(buffer_cur,size,FORMAT,WHAT);\
-                        if((unsigned)printed >= (unsigned)size) {\
-                            synctex_help_view("Snprintf problem");\
-                            free(buffer);\
-                            return -1;\
-                        }\
-                        buffer_cur += printed;size-=printed;\
-                        *buffer_cur='\0';\
-                        viewer = where+strlen(KEY);\
-                        continue;\
-                    }
-                    TEST("&{output}","%s",synctex_scanner_get_output(g_scanner));
-                    TEST("&{page}",  "%i",synctex_node_page(node)-1);
-                    TEST("&{page+1}","%i",synctex_node_page(node));
-                    TEST("&{x}",     "%f",synctex_node_visible_h(node));
-                    TEST("&{y}",     "%f",synctex_node_visible_v(node));
-                    TEST("&{h}",     "%f",synctex_node_box_visible_h(node));
-                    TEST("&{v}",     "%f",synctex_node_box_visible_v(node)+synctex_node_box_visible_depth(node));
-                    TEST("&{width}", "%f",fabs(synctex_node_box_visible_width(node)));
-                    TEST("&{height}","%f",fmax(synctex_node_box_visible_height(node)+synctex_node_box_visible_depth(node),1));
-                    TEST("&{before}","%s",(g_view.before && strlen(g_view.before)<SYNCTEX_STR_SIZE?g_view.before:""));
-                    TEST("&{offset}","%u",g_view.offset);
-                    TEST("&{middle}","%s",(g_view.middle && strlen(g_view.middle)<SYNCTEX_STR_SIZE?g_view.middle:""));
-                    TEST("&{after}", "%s",(g_view.after && strlen(g_view.after)<SYNCTEX_STR_SIZE?g_view.after:""));
-#                   undef TEST
+                while (viewer && (where = strstr(viewer, "&{"))) {
+#define TEST(KEY, FORMAT, WHAT)                                                                                                                                \
+    if (!strncmp(where, KEY, strlen(KEY))) {                                                                                                                   \
+        size_t printed = where - viewer;                                                                                                                       \
+        if (buffer_cur != memcpy(buffer_cur, viewer, (size_t)printed)) {                                                                                       \
+            synctex_help_view("Memory copy problem");                                                                                                          \
+            free(buffer);                                                                                                                                      \
+            return -1;                                                                                                                                         \
+        }                                                                                                                                                      \
+        buffer_cur += printed;                                                                                                                                 \
+        size -= printed;                                                                                                                                       \
+        printed = snprintf(buffer_cur, size, FORMAT, WHAT);                                                                                                    \
+        if ((unsigned)printed >= (unsigned)size) {                                                                                                             \
+            synctex_help_view("Snprintf problem");                                                                                                             \
+            free(buffer);                                                                                                                                      \
+            return -1;                                                                                                                                         \
+        }                                                                                                                                                      \
+        buffer_cur += printed;                                                                                                                                 \
+        size -= printed;                                                                                                                                       \
+        *buffer_cur = '\0';                                                                                                                                    \
+        viewer = where + strlen(KEY);                                                                                                                          \
+        continue;                                                                                                                                              \
+    }
+                    TEST("&{output}", "%s", synctex_scanner_get_output(g_scanner));
+                    TEST("&{page}", "%i", synctex_node_page(node) - 1);
+                    TEST("&{page+1}", "%i", synctex_node_page(node));
+                    TEST("&{x}", "%f", synctex_node_visible_h(node));
+                    TEST("&{y}", "%f", synctex_node_visible_v(node));
+                    TEST("&{h}", "%f", synctex_node_box_visible_h(node));
+                    TEST("&{v}", "%f", synctex_node_box_visible_v(node) + synctex_node_box_visible_depth(node));
+                    TEST("&{width}", "%f", fabs(synctex_node_box_visible_width(node)));
+                    TEST("&{height}", "%f", fmax(synctex_node_box_visible_height(node) + synctex_node_box_visible_depth(node), 1));
+                    TEST("&{before}", "%s", (g_view.before && strlen(g_view.before) < SYNCTEX_STR_SIZE ? g_view.before : ""));
+                    TEST("&{offset}", "%u", g_view.offset);
+                    TEST("&{middle}", "%s", (g_view.middle && strlen(g_view.middle) < SYNCTEX_STR_SIZE ? g_view.middle : ""));
+                    TEST("&{after}", "%s", (g_view.after && strlen(g_view.after) < SYNCTEX_STR_SIZE ? g_view.after : ""));
+#undef TEST
                     break;
                 }
                 /* copy the rest of viewer into the buffer */
-                if(buffer_cur != strncpy(buffer_cur,viewer,size + 1)) {
+                if (buffer_cur != strncpy(buffer_cur, viewer, size + 1)) {
                     synctex_help_view("Memory copy problem");
                     free(buffer);
                     return -1;
                 }
                 buffer_cur[size] = '\0';
-                printf("SyncTeX: Executing\n%s\n",buffer);
+                printf("SyncTeX: Executing\n%s\n", buffer);
                 status = system(buffer);
                 free(buffer);
                 buffer = NULL;
@@ -726,7 +734,8 @@ int synctex_view_proceed() {
                 /* just print out the results */
                 puts("SyncTeX result begin");
                 do {
-                    printf("Output:%s\n"
+                    printf(
+                        "Output:%s\n"
                         "Page:%i\n"
                         "x:%f\n"
                         "y:%f\n"
@@ -743,14 +752,14 @@ int synctex_view_proceed() {
                         synctex_node_visible_h(node),
                         synctex_node_visible_v(node),
                         synctex_node_box_visible_h(node),
-                        synctex_node_box_visible_v(node)+synctex_node_box_visible_depth(node),
+                        synctex_node_box_visible_v(node) + synctex_node_box_visible_depth(node),
                         synctex_node_box_visible_width(node),
-                        synctex_node_box_visible_height(node)+synctex_node_box_visible_depth(node),
-                        (g_view.before?g_view.before:""),
+                        synctex_node_box_visible_height(node) + synctex_node_box_visible_depth(node),
+                        (g_view.before ? g_view.before : ""),
                         g_view.offset,
-                        (g_view.middle?g_view.middle:""),
-                        (g_view.after?g_view.after:""));
-                } while((node = synctex_scanner_next_result(g_scanner)) != NULL);
+                        (g_view.middle ? g_view.middle : ""),
+                        (g_view.after ? g_view.after : ""));
+                } while ((node = synctex_scanner_next_result(g_scanner)) != NULL);
                 puts("SyncTeX result end");
             }
         }
@@ -758,7 +767,8 @@ int synctex_view_proceed() {
     return 0;
 }
 
-void synctex_help_edit(const char * error,...) {
+void synctex_help_edit(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
@@ -804,8 +814,7 @@ void synctex_help_edit(const char * error,...) {
         "       You give a context including the character at the mouse location, and\n"
         "       the offset of this character relative to the beginning of this bunch of text.\n"
         "       \n",
-        (error?stderr:stdout)
-          );
+        (error ? stderr : stdout));
     return;
 }
 
@@ -814,24 +823,25 @@ typedef struct {
     float x;
     float y;
     unsigned int offset;
-    char * output;
-    char * directory;
-    char * editor;
-    char * context;
+    char *output;
+    char *directory;
+    char *editor;
+    char *context;
 } _synctex_edit_t;
 
-_synctex_edit_t g_edit = {0,0,0,0,NULL,NULL,NULL,NULL};
+_synctex_edit_t g_edit = {0, 0, 0, 0, NULL, NULL, NULL, NULL};
 
-char * synctex_edit_o(char * arg) {
-    char * ans;
-    g_edit.page = synctex_parse_int(arg,&ans);
-    if(ans>arg && *ans==':') {
-        arg = ans+1;
-        g_edit.x = strtod(arg,&ans);
-        if(ans>arg && *ans==':') {
-            arg = ans+1;
-            g_edit.y = strtod(arg,&ans);
-            if(ans>arg && *ans==':') {
+char *synctex_edit_o(char *arg)
+{
+    char *ans;
+    g_edit.page = synctex_parse_int(arg, &ans);
+    if (ans > arg && *ans == ':') {
+        arg = ans + 1;
+        g_edit.x = strtod(arg, &ans);
+        if (ans > arg && *ans == ':') {
+            arg = ans + 1;
+            g_edit.y = strtod(arg, &ans);
+            if (ans > arg && *ans == ':') {
                 g_output = ++ans;
                 return ans;
             }
@@ -841,25 +851,26 @@ char * synctex_edit_o(char * arg) {
 }
 
 /*  "usage: synctex edit -o page:x:y:output [-d directory] [-x editor-command] [-h offset:context]\n"  */
-int synctex_edit(int argc, char *argv[]) {
+int synctex_edit(int argc, char *argv[])
+{
     int i = 0;
     NULL;
     /* required */
-    if((i>=argc) || strcmp("-o",argv[i]) || (++i>=argc)) {
+    if ((i >= argc) || strcmp("-o", argv[i]) || (++i >= argc)) {
         synctex_help_edit("Missing -o required argument");
         return -1;
     }
-    char * arg = argv[i];
+    char *arg = argv[i];
     if (synctex_edit_o(arg) <= arg) {
-    synctex_help_edit("Bad -o argument");
-    return -1;
+        synctex_help_edit("Bad -o argument");
+        return -1;
     }
     /* now scan the optional arguments */
-    if(++i<argc) {
-        if(0 == strcmp("-d",argv[i])) {
-            if(++i<argc) {
+    if (++i < argc) {
+        if (0 == strcmp("-d", argv[i])) {
+            if (++i < argc) {
                 g_directory = argv[i];
-                if(++i>=argc) {
+                if (++i >= argc) {
                     return synctex_edit_proceed();
                 }
             } else {
@@ -868,12 +879,12 @@ int synctex_edit(int argc, char *argv[]) {
             }
         }
         // scan the command
-        if(0 == strcmp("-x",argv[i])) {
-            if(++i<argc) {
-                if(strcmp("-",argv[i])) {
+        if (0 == strcmp("-x", argv[i])) {
+            if (++i < argc) {
+                if (strcmp("-", argv[i])) {
                     /* next argument does not start with '-', this is a command */
                     g_edit.editor = argv[i];
-                    if(++i>=argc) {
+                    if (++i >= argc) {
                         return synctex_edit_proceed();
                     }
                 } else {
@@ -886,11 +897,11 @@ int synctex_edit(int argc, char *argv[]) {
             }
         }
         // scan optional hint
-        if(0 == strcmp("-h",argv[i]) && ++i<argc) {
-            char * end = NULL;
-            g_edit.offset = synctex_parse_int(argv[i],&end);
-            if(end>argv[i] && *end==':') {
-                g_edit.context = end+1;
+        if (0 == strcmp("-h", argv[i]) && ++i < argc) {
+            char *end = NULL;
+            g_edit.offset = synctex_parse_int(argv[i], &end);
+            if (end > argv[i] && *end == ':') {
+                g_edit.context = end + 1;
                 return synctex_edit_proceed();
             }
             synctex_help_edit("Bad -h argument");
@@ -900,103 +911,97 @@ int synctex_edit(int argc, char *argv[]) {
     return synctex_edit_proceed();
 }
 
-int synctex_edit_proceed() {
+int synctex_edit_proceed()
+{
 #if SYNCTEX_DEBUG
-    printf("page:%i\n",g_edit.page);
-    printf("x:%f\n",g_edit.x);
-    printf("y:%f\n",g_edit.y);
-    printf("almost output:%s\n",g_output);
-    printf("editor:%s\n",g_edit.editor);
-    printf("offset:%u\n",g_edit.offset);
-    printf("context:%s\n",g_edit.context);
-    printf("cwd:%s\n",getcwd(NULL,0));
+    printf("page:%i\n", g_edit.page);
+    printf("x:%f\n", g_edit.x);
+    printf("y:%f\n", g_edit.y);
+    printf("almost output:%s\n", g_output);
+    printf("editor:%s\n", g_edit.editor);
+    printf("offset:%u\n", g_edit.offset);
+    printf("context:%s\n", g_edit.context);
+    printf("cwd:%s\n", getcwd(NULL, 0));
 #endif
     synctex_synchronize();
-    if(NULL == g_scanner) {
-        synctex_help_edit(
-            "No SyncTeX available for %s",
-            g_output
-        );
+    if (NULL == g_scanner) {
+        synctex_help_edit("No SyncTeX available for %s", g_output);
         return -1;
     }
-    if(synctex_edit_query(
-        g_scanner,
-        g_edit.page,
-        g_edit.x,
-        g_edit.y
-    )) {
+    if (synctex_edit_query(g_scanner, g_edit.page, g_edit.x, g_edit.y)) {
         synctex_node_p node = NULL;
-        const char * input = NULL;
-        if(NULL != (node = synctex_scanner_next_result(g_scanner))
-            && NULL != (input = synctex_scanner_get_name(g_scanner,synctex_node_tag(node)))) {
+        const char *input = NULL;
+        if (NULL != (node = synctex_scanner_next_result(g_scanner)) && NULL != (input = synctex_scanner_get_name(g_scanner, synctex_node_tag(node)))) {
             /* filtering the command */
-            if(g_edit.editor && strlen(g_edit.editor)) {
+            if (g_edit.editor && strlen(g_edit.editor)) {
                 size_t size = 0;
-                char * where = NULL;
-                char * buffer = NULL;
-                char * buffer_cur = NULL;
+                char *where = NULL;
+                char *buffer = NULL;
+                char *buffer_cur = NULL;
                 int status;
-                size = strlen(g_edit.editor)+3*sizeof(int)+3*SYNCTEX_STR_SIZE;
-                buffer = malloc(size+1);
-                if(NULL == buffer) {
+                size = strlen(g_edit.editor) + 3 * sizeof(int) + 3 * SYNCTEX_STR_SIZE;
+                buffer = malloc(size + 1);
+                if (NULL == buffer) {
                     printf("SyncTeX ERROR: No memory available\n");
                     return -1;
                 }
-                buffer[size]='\0';
+                buffer[size] = '\0';
                 /* Replace %{ by &{, then remove all unescaped '%'*/
-                while((where = strstr(g_edit.editor,"%{")) != NULL) {
+                while ((where = strstr(g_edit.editor, "%{")) != NULL) {
                     *where = '&';
                 }
                 where = g_edit.editor;
-                while(where &&(where = strchr(where,'%'))) {
-                    if(strlen(++where)) {
-                        if(*where == '%') {
+                while (where && (where = strchr(where, '%'))) {
+                    if (strlen(++where)) {
+                        if (*where == '%') {
                             ++where;
                         } else {
-                            *(where-1)='&';
+                            *(where - 1) = '&';
                         }
                     }
                 }
                 buffer_cur = buffer;
                 /*  find the next occurrence of a format key */
                 where = g_edit.editor;
-                while(g_edit.editor && (where = strstr(g_edit.editor,"&{"))) {
-#                   define TEST(KEY,FORMAT,WHAT)\
-                    if(!strncmp(where,KEY,strlen(KEY))) {\
-                        size_t printed = where-g_edit.editor;\
-                        if(buffer_cur != memcpy(buffer_cur,g_edit.editor,(size_t)printed)) {\
-                            synctex_help_edit("Memory copy problem");\
-                            free(buffer);\
-                            return -1;\
-                        }\
-                        buffer_cur += printed;size-=printed;\
-                        printed = snprintf(buffer_cur,size,FORMAT,WHAT);\
-                        if((unsigned)printed >= (unsigned)size) {\
-                            synctex_help_edit("Snprintf problem");\
-                            free(buffer);\
-                            return -1;\
-                        }\
-                        buffer_cur += printed;size-=printed;\
-                        *buffer_cur='\0';\
-                        g_edit.editor = where+strlen(KEY);\
-                        continue;\
-                    }
-                    TEST("&{output}", "%s",g_output);
-                    TEST("&{input}",  "%s",input);
-                    TEST("&{line}",   "%i",synctex_node_line(node));
-                    TEST("&{column}", "%i",-1);
-                    TEST("&{offset}", "%u",g_edit.offset);
-                    TEST("&{context}","%s",g_edit.context);
-#                   undef TEST
+                while (g_edit.editor && (where = strstr(g_edit.editor, "&{"))) {
+#define TEST(KEY, FORMAT, WHAT)                                                                                                                                \
+    if (!strncmp(where, KEY, strlen(KEY))) {                                                                                                                   \
+        size_t printed = where - g_edit.editor;                                                                                                                \
+        if (buffer_cur != memcpy(buffer_cur, g_edit.editor, (size_t)printed)) {                                                                                \
+            synctex_help_edit("Memory copy problem");                                                                                                          \
+            free(buffer);                                                                                                                                      \
+            return -1;                                                                                                                                         \
+        }                                                                                                                                                      \
+        buffer_cur += printed;                                                                                                                                 \
+        size -= printed;                                                                                                                                       \
+        printed = snprintf(buffer_cur, size, FORMAT, WHAT);                                                                                                    \
+        if ((unsigned)printed >= (unsigned)size) {                                                                                                             \
+            synctex_help_edit("Snprintf problem");                                                                                                             \
+            free(buffer);                                                                                                                                      \
+            return -1;                                                                                                                                         \
+        }                                                                                                                                                      \
+        buffer_cur += printed;                                                                                                                                 \
+        size -= printed;                                                                                                                                       \
+        *buffer_cur = '\0';                                                                                                                                    \
+        g_edit.editor = where + strlen(KEY);                                                                                                                   \
+        continue;                                                                                                                                              \
+    }
+                    TEST("&{output}", "%s", g_output);
+                    TEST("&{input}", "%s", input);
+                    TEST("&{line}", "%i", synctex_node_line(node));
+                    TEST("&{column}", "%i", -1);
+                    TEST("&{offset}", "%u", g_edit.offset);
+                    TEST("&{context}", "%s", g_edit.context);
+#undef TEST
                     break;
                 }
                 /* copy the rest of editor into the buffer */
-                if(buffer_cur != memcpy(buffer_cur,g_edit.editor,strlen(g_edit.editor))) {
-                    fputs("!  synctex_edit: Memory copy problem",stderr);
+                if (buffer_cur != memcpy(buffer_cur, g_edit.editor, strlen(g_edit.editor))) {
+                    fputs("!  synctex_edit: Memory copy problem", stderr);
                     free(buffer);
                     return -1;
-                }\
-                printf("SyncTeX: Executing\n%s\n",buffer);
+                }
+                printf("SyncTeX: Executing\n%s\n", buffer);
                 status = system(buffer);
                 free(buffer);
                 buffer = NULL;
@@ -1005,7 +1010,8 @@ int synctex_edit_proceed() {
                 /* just print out the results */
                 puts("SyncTeX result begin");
                 do {
-                    printf( "Output:%s\n"
+                    printf(
+                        "Output:%s\n"
                         "Input:%s\n"
                         "Line:%i\n"
                         "Column:%i\n"
@@ -1016,8 +1022,8 @@ int synctex_edit_proceed() {
                         synctex_node_line(node),
                         synctex_node_column(node),
                         g_edit.offset,
-                        (g_edit.context?g_edit.context:""));
-                } while((node = synctex_scanner_next_result(g_scanner)) != NULL);
+                        (g_edit.context ? g_edit.context : ""));
+                } while ((node = synctex_scanner_next_result(g_scanner)) != NULL);
                 puts("SyncTeX result end");
             }
         }
@@ -1025,7 +1031,8 @@ int synctex_edit_proceed() {
     return 0;
 }
 
-void synctex_help_update(const char * error,...) {
+void synctex_help_update(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
@@ -1049,12 +1056,12 @@ void synctex_help_update(const char * error,...) {
         "-x dimension  Set horizontal offset\n"
         "-y dimension  Set vertical offset\n"
         "In general, these are exactly the same options provided to the dvi/xdv to pdf filter.\n",
-        (error?stderr:stdout)
-        );
+        (error ? stderr : stdout));
     return;
 }
 
-void synctex_help_options(const char * error,...) {
+void synctex_help_options(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
@@ -1077,61 +1084,61 @@ void synctex_help_options(const char * error,...) {
         "   `raw' selects a faster integer parser that saves time when opening synctex files.\n"
         "   This is the default behavior. `C' selects a parser based on C strtol.\n"
         "   Choose `C' if `raw' gives wrong results.\n",
-        (error?stderr:stdout)
-        );
+        (error ? stderr : stdout));
     return;
 }
 
 /*  "usage: synctex update -o output [-d directory] [-m number] [-x dimension] [-y dimension]\n"  */
-int synctex_update(int argc, char *argv[]) {
+int synctex_update(int argc, char *argv[])
+{
     int arg_index = 0;
     synctex_updater_p updater = NULL;
-    char * magnification = NULL;
-    char * x = NULL;
-    char * y = NULL;
-    char * output = NULL;
-    char * directory = NULL;
+    char *magnification = NULL;
+    char *x = NULL;
+    char *y = NULL;
+    char *output = NULL;
+    char *directory = NULL;
 #define SYNCTEX_fprintf (*synctex_fprintf)
-    if(arg_index>=argc) {
+    if (arg_index >= argc) {
         synctex_help_update("Bad update command");
         return -1;
     }
     /* required */
-    if((arg_index>=argc) || strcmp("-o",argv[arg_index]) || (++arg_index>=argc)) {
+    if ((arg_index >= argc) || strcmp("-o", argv[arg_index]) || (++arg_index >= argc)) {
         synctex_help_update("Missing -o required argument");
         return -1;
     }
     output = argv[arg_index];
-    if(++arg_index>=argc) {
+    if (++arg_index >= argc) {
         return 0;
     }
 next_argument:
-    if(0 == strcmp("-m",argv[arg_index])) {
-        if(++arg_index>=argc) {
+    if (0 == strcmp("-m", argv[arg_index])) {
+        if (++arg_index >= argc) {
             synctex_help_update("Missing magnification");
             return -1;
         }
         magnification = argv[arg_index];
     prepare_next_argument:
-        if(++arg_index<argc) {
+        if (++arg_index < argc) {
             goto next_argument;
         }
-    } else if(0 == strcmp("-x",argv[arg_index])) {
-        if(++arg_index>=argc) {
+    } else if (0 == strcmp("-x", argv[arg_index])) {
+        if (++arg_index >= argc) {
             synctex_help_update("Missing x offset");
             return -1;
         }
         x = argv[arg_index];
         goto prepare_next_argument;
-    } else if(0 == strcmp("-y",argv[arg_index])) {
-        if(++arg_index>=argc) {
+    } else if (0 == strcmp("-y", argv[arg_index])) {
+        if (++arg_index >= argc) {
             synctex_help_update("Missing y offset");
             return -1;
         }
         y = argv[arg_index];
         goto prepare_next_argument;
-    } else if(0 == strcmp("-d",argv[arg_index])) {
-        if(++arg_index<argc) {
+    } else if (0 == strcmp("-d", argv[arg_index])) {
+        if (++arg_index < argc) {
             directory = argv[arg_index];
         } else {
             directory = getenv("SYNCTEX_BUILD_DIRECTORY");
@@ -1140,47 +1147,48 @@ next_argument:
     }
 
     /* Arguments parsed */
-    updater = synctex_updater_new_with_output_file(output,directory);
-    synctex_updater_append_magnification(updater,magnification);
-    synctex_updater_append_x_offset(updater,x);
-    synctex_updater_append_y_offset(updater,y);
+    updater = synctex_updater_new_with_output_file(output, directory);
+    synctex_updater_append_magnification(updater, magnification);
+    synctex_updater_append_x_offset(updater, x);
+    synctex_updater_append_y_offset(updater, y);
     synctex_updater_free(updater);
     return 0;
 }
 
-int synctex_test_file (int argc, char *argv[]);
+int synctex_test_file(int argc, char *argv[]);
 
 /*  "usage: synctex test subcommand options\n"  */
-int synctex_test(int argc, char *argv[]) {
-    if(argc) {
-        if(0==strcmp("file",argv[0])) {
-            return synctex_test_file(argc-1,argv+1);
+int synctex_test(int argc, char *argv[])
+{
+    if (argc) {
+        if (0 == strcmp("file", argv[0])) {
+            return synctex_test_file(argc - 1, argv + 1);
         }
     }
     return 0;
 }
 
-int synctex_test_file (int argc, char *argv[])
+int synctex_test_file(int argc, char *argv[])
 {
     int arg_index = 0;
-    char * output = NULL;
-    char * directory = NULL;
-    char * synctex_name = NULL;
+    char *output = NULL;
+    char *directory = NULL;
+    char *synctex_name = NULL;
     synctex_io_mode_t mode = 0;
-    if(arg_index>=argc) {
+    if (arg_index >= argc) {
         _synctex_error("!  usage: synctex test file -o output [-d directory]\n");
         return -1;
     }
     /* required */
-    if((arg_index>=argc) || strcmp("-o",argv[arg_index]) || (++arg_index>=argc)) {
+    if ((arg_index >= argc) || strcmp("-o", argv[arg_index]) || (++arg_index >= argc)) {
         _synctex_error("!  usage: synctex test file -o output [-d directory]\n");
         return -1;
     }
     output = argv[arg_index];
     /* optional */
-    if(++arg_index<argc) {
-        if(0 == strcmp("-d",argv[arg_index])) {
-            if(++arg_index<argc) {
+    if (++arg_index < argc) {
+        if (0 == strcmp("-d", argv[arg_index])) {
+            if (++arg_index < argc) {
                 directory = argv[arg_index];
             } else {
                 directory = getenv("SYNCTEX_BUILD_DIRECTORY");
@@ -1188,24 +1196,26 @@ int synctex_test_file (int argc, char *argv[])
         }
     }
     /* Arguments parsed */
-    if(_synctex_get_name(output, directory, &synctex_name, &mode)) {
+    if (_synctex_get_name(output, directory, &synctex_name, &mode)) {
         _synctex_error("!  TEST FAILED\n");
     } else {
-        printf("output:%s\n"
-             "directory:%s\n"
-             "file name:%s\n"
-             "io mode:%s\n",
-             output,
-             directory,
-             synctex_name,
-             _synctex_get_io_mode_name(mode));
+        printf(
+            "output:%s\n"
+            "directory:%s\n"
+            "file name:%s\n"
+            "io mode:%s\n",
+            output,
+            directory,
+            synctex_name,
+            _synctex_get_io_mode_name(mode));
     }
     return 0;
 }
 
-int synctex_dump(int argc, char *argv[]) {
+int synctex_dump(int argc, char *argv[])
+{
     int i = 0;
-    if(strcmp("-o",argv[i]) || (++i>=argc)) {
+    if (strcmp("-o", argv[i]) || (++i >= argc)) {
         printf("argv[%i]==<%s>\n", i, argv[i]);
         synctex_help_dump("Missing -o required argument\n");
         return -1;
@@ -1215,27 +1225,27 @@ int synctex_dump(int argc, char *argv[]) {
     g_directory = NULL;
     g_file = NULL;
     ++i;
-    while(i<argc) {
-        if(0 == strcmp("-d",argv[i])) {
-            if(++i<argc) {
+    while (i < argc) {
+        if (0 == strcmp("-d", argv[i])) {
+            if (++i < argc) {
                 g_directory = argv[i];
             } else {
                 g_directory = getenv("SYNCTEX_BUILD_DIRECTORY");
             }
-        } else if(0 == strcmp("-f",argv[i])) {
-            if(++i<argc) {
+        } else if (0 == strcmp("-f", argv[i])) {
+            if (++i < argc) {
                 g_file = argv[i];
             } else {
-              synctex_help_dump("Missing -f argument\n");
+                synctex_help_dump("Missing -f argument\n");
             }
         } else {
             synctex_help_dump("Unsupported argument\n");
-            return(-1);
+            return (-1);
         }
     }
-    if (synctex_synchronize()<0) {
+    if (synctex_synchronize() < 0) {
         _synctex_error("Something wrong happened!\n");
-        return(-1);
+        return (-1);
     }
 #if 0
 /*
@@ -1301,10 +1311,11 @@ int synctex_dump(int argc, char *argv[]) {
     synctex_scanner_dump(g_scanner, &printf);
     synctex_scanner_free(g_scanner);
     g_scanner = NULL;
-    return(0);
+    return (0);
 }
 
-void synctex_help_dump(const char * error,...) {
+void synctex_help_dump(const char *error, ...)
+{
     va_list v;
     va_start(v, error);
     synctex_usage(error, v);
@@ -1325,6 +1336,5 @@ void synctex_help_dump(const char * error,...) {
         "-f <file>\n"
         "   when provided, writes the dumped data to <file>.\n"
         "   By default dumped data are written to stdout.\n",
-        (error?stderr:stdout)
-    );
+        (error ? stderr : stdout));
 }

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -89,24 +89,24 @@
 /** @cond */
 #define _GNU_SOURCE
 
-#   if defined(SYNCTEX_USE_LOCAL_HEADER)
-#       include "synctex_parser_local.h"
-#   else
-#       define HAVE_LOCALE_H 1
-#       define HAVE_SETLOCALE 1
-#       if defined(_MSC_VER)
-#          define SYNCTEX_INLINE __inline
-#       else
-#          define SYNCTEX_INLINE inline
-#       endif
-#   endif
+#if defined(SYNCTEX_USE_LOCAL_HEADER)
+#include "synctex_parser_local.h"
+#else
+#define HAVE_LOCALE_H 1
+#define HAVE_SETLOCALE 1
+#if defined(_MSC_VER)
+#define SYNCTEX_INLINE __inline
+#else
+#define SYNCTEX_INLINE inline
+#endif
+#endif
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(HAVE_LOCALE_H)
 #include <locale.h>
@@ -114,16 +114,17 @@
 
 /* Mark unused parameters, so that there will be no compile warnings. */
 #ifdef __DARWIN_UNIX03
-#   define SYNCTEX_UNUSED(x) SYNCTEX_PRAGMA(unused(x))
-#   define SYNCTEX_PRAGMA(x) _Pragma ( #x )
+#define SYNCTEX_UNUSED(x) SYNCTEX_PRAGMA(unused(x))
+#define SYNCTEX_PRAGMA(x) _Pragma(#x)
 #else
-#   define SYNCTEX_UNUSED(x) (void)(x);
+#define SYNCTEX_UNUSED(x) (void)(x);
 #endif
 
 #include "synctex_parser_advanced.h"
 
-SYNCTEX_INLINE static int _synctex_abs(int x) {
-    return x>0? x: -x;
+SYNCTEX_INLINE static int _synctex_abs(int x)
+{
+    return x > 0 ? x : -x;
 }
 
 /** @endcond */
@@ -132,16 +133,16 @@ SYNCTEX_INLINE static int _synctex_abs(int x) {
 /**
  * @brief Extension of uncompressed synctex file
  */
-const char * synctex_suffix = ".synctex";
+const char *synctex_suffix = ".synctex";
 /**
  * @brief Extension of compressed synctex file
  */
-const char * synctex_suffix_gz = ".gz";
+const char *synctex_suffix_gz = ".gz";
 
 /** @cond */
 
-typedef synctex_node_p(*_synctex_node_new_f)(synctex_scanner_p);
-typedef void(*_synctex_node_fld_f)(synctex_node_p);
+typedef synctex_node_p (*_synctex_node_new_f)(synctex_scanner_p);
+typedef void (*_synctex_node_fld_f)(synctex_node_p);
 typedef char *(*_synctex_node_str_f)(synctex_node_p);
 
 /**
@@ -174,7 +175,7 @@ typedef struct synctex_tree_model_t {
  * @brief A pointer to a constant tree model structure
  * @author: Jérôme LAURENS
  */
-typedef const _synctex_tree_model_s * _synctex_tree_model_p;
+typedef const _synctex_tree_model_s *_synctex_tree_model_p;
 
 typedef struct _synctex_data_model_t {
     int tag;
@@ -201,7 +202,7 @@ typedef struct _synctex_data_model_t {
  * @brief A pointer to a constant data model structure
  * @author: Jérôme LAURENS
  */
-typedef const _synctex_data_model_s * _synctex_data_model_p;
+typedef const _synctex_data_model_s *_synctex_data_model_p;
 
 /**
  * @brief node -> integer function type
@@ -222,8 +223,9 @@ typedef struct _synctex_tlcpector_t {
     /** column getter */
     _synctex_int_getter_f column;
 } _synctex_tlcpector_s;
-typedef const _synctex_tlcpector_s * _synctex_tlcpector_p;
-static int _synctex_int_none(synctex_node_p node) {
+typedef const _synctex_tlcpector_s *_synctex_tlcpector_p;
+static int _synctex_int_none(synctex_node_p node)
+{
     SYNCTEX_UNUSED(node)
     return 0;
 }
@@ -249,7 +251,7 @@ typedef struct _synctex_inspector_t {
     /** depth getter */
     _synctex_int_getter_f depth;
 } _synctex_inspector_s;
-typedef const _synctex_inspector_s * _synctex_inspector_p;
+typedef const _synctex_inspector_s *_synctex_inspector_p;
 static const _synctex_inspector_s synctex_inspector_none = {
     &_synctex_int_none, /* h */
     &_synctex_int_none, /* v */
@@ -275,7 +277,8 @@ typedef struct _synctex_vispector_t {
     /** depth attribute getter */
     _synctex_float_getter_f depth;
 } _synctex_vispector_s;
-static float _synctex_float_none(synctex_node_p node) {
+static float _synctex_float_none(synctex_node_p node)
+{
     SYNCTEX_UNUSED(node)
     return 0;
 }
@@ -286,7 +289,7 @@ static const _synctex_vispector_s synctex_vispector_none = {
     &_synctex_float_none, /* height */
     &_synctex_float_none, /* depth */
 };
-typedef const _synctex_vispector_s * _synctex_vispector_p;
+typedef const _synctex_vispector_s *_synctex_vispector_p;
 
 struct _synctex_class_t {
     synctex_scanner_p scanner;
@@ -313,10 +316,10 @@ struct _synctex_class_t {
 typedef synctex_node_p _synctex_proxy_p;
 typedef synctex_node_p _synctex_noxy_p;
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Abstract OBJECTS and METHODS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Abstract OBJECTS and METHODS
+#endif
 
 /**
  *  @def SYNCTEX_MSG_SEND
@@ -324,74 +327,69 @@ typedef synctex_node_p _synctex_noxy_p;
  *  - parameter NODE: of type synctex_node_p
  *  - parameter SELECTOR: one of the class_ pointer properties
  */
-#   define SYNCTEX_MSG_SEND(NODE,SELECTOR) do {\
-    synctex_node_p N__ = NODE;\
-    if (N__ && N__->class_->SELECTOR) {\
-        (*(N__->class_->SELECTOR))(N__);\
-    }\
-} while (synctex_NO)
+#define SYNCTEX_MSG_SEND(NODE, SELECTOR)                                                                                                                       \
+    do {                                                                                                                                                       \
+        synctex_node_p N__ = NODE;                                                                                                                             \
+        if (N__ && N__->class_->SELECTOR) {                                                                                                                    \
+            (*(N__->class_->SELECTOR))(N__);                                                                                                                   \
+        }                                                                                                                                                      \
+    } while (synctex_NO)
 
 /**
  *  Free the given node by sending the free message.
  *  - parameter NODE: of type synctex_node_p
  */
-static void _synctex_node_free(synctex_node_p node) {
-    SYNCTEX_MSG_SEND(node,free);
+static void _synctex_node_free(synctex_node_p node)
+{
+    SYNCTEX_MSG_SEND(node, free);
 }
-#   if defined(SYNCTEX_TESTING)
-#       if !defined(SYNCTEX_USE_HANDLE)
-#           define SYNCTEX_USE_HANDLE 1
-#       endif
-#       if !defined(SYNCTEX_USE_CHARINDEX)
-#           define SYNCTEX_USE_CHARINDEX 1
-#       endif
-#   endif
+#if defined(SYNCTEX_TESTING)
+#if !defined(SYNCTEX_USE_HANDLE)
+#define SYNCTEX_USE_HANDLE 1
+#endif
+#if !defined(SYNCTEX_USE_CHARINDEX)
+#define SYNCTEX_USE_CHARINDEX 1
+#endif
+#endif
 SYNCTEX_INLINE static synctex_node_p _synctex_new_handle_with_target(synctex_node_p target);
-#   if defined(SYNCTEX_USE_HANDLE)
-#       define SYNCTEX_SCANNER_FREE_HANDLE(SCANR) \
-__synctex_scanner_free_handle(SCANR)
-#       define SYNCTEX_SCANNER_REMOVE_HANDLE_TO(WHAT) \
-__synctex_scanner_remove_handle_to(WHAT)
-#       define SYNCTEX_REGISTER_HANDLE_TO(NODE) \
-__synctex_scanner_register_handle_to(NODE)
-#   else
-#       define SYNCTEX_SCANNER_FREE_HANDLE(SCANR)
-#       define SYNCTEX_SCANNER_REMOVE_HANDLE_TO(WHAT)
-#       define SYNCTEX_REGISTER_HANDLE_TO(NODE)
-#   endif
+#if defined(SYNCTEX_USE_HANDLE)
+#define SYNCTEX_SCANNER_FREE_HANDLE(SCANR) __synctex_scanner_free_handle(SCANR)
+#define SYNCTEX_SCANNER_REMOVE_HANDLE_TO(WHAT) __synctex_scanner_remove_handle_to(WHAT)
+#define SYNCTEX_REGISTER_HANDLE_TO(NODE) __synctex_scanner_register_handle_to(NODE)
+#else
+#define SYNCTEX_SCANNER_FREE_HANDLE(SCANR)
+#define SYNCTEX_SCANNER_REMOVE_HANDLE_TO(WHAT)
+#define SYNCTEX_REGISTER_HANDLE_TO(NODE)
+#endif
 
-#   if defined(SYNCTEX_USE_CHARINDEX)
-#       define SYNCTEX_CHARINDEX(NODE) (NODE->char_index)
-#       define SYNCTEX_LINEINDEX(NODE) (NODE->line_index)
-#       define SYNCTEX_PRINT_CHARINDEX_FMT "#%i"
-#       define SYNCTEX_PRINT_CHARINDEX_WHAT ,SYNCTEX_CHARINDEX(node)
-#       define SYNCTEX_PRINT_CHARINDEX \
-            printf(SYNCTEX_PRINT_CHARINDEX_FMT SYNCTEX_PRINT_CHARINDEX_WHAT)
-#       define SYNCTEX_PRINT_LINEINDEX_FMT "L#%i"
-#       define SYNCTEX_PRINT_LINEINDEX_WHAT ,SYNCTEX_LINEINDEX(node)
-#       define SYNCTEX_PRINT_LINEINDEX \
-            printf(SYNCTEX_PRINT_LINEINDEX_FMT SYNCTEX_PRINT_LINEINDEX_WHAT)
-#       define SYNCTEX_PRINT_CHARINDEX_NL \
-            printf(SYNCTEX_PRINT_CHARINDEX_FMT "\n" SYNCTEX_PRINT_CHARINDEX_WHAT)
-#       define SYNCTEX_PRINT_LINEINDEX_NL \
-            printf(SYNCTEX_PRINT_CHARINDEX_FMT "\n"SYNCTEX_PRINT_LINEINDEX_WHAT)
-#       define SYNCTEX_IMPLEMENT_CHARINDEX(NODE,CORRECTION)\
-            NODE->char_index = (synctex_charindex_t)(scanner->reader->charindex_offset+SYNCTEX_CUR-SYNCTEX_START+(CORRECTION)); \
-            NODE->line_index = scanner->reader->line_number;
-#   else
-#       define SYNCTEX_CHARINDEX(NODE) 0
-#       define SYNCTEX_LINEINDEX(NODE) 0
-#       define SYNCTEX_PRINT_CHARINDEX_FMT
-#       define SYNCTEX_PRINT_CHARINDEX_WHAT
-#       define SYNCTEX_PRINT_CHARINDEX
-#       define SYNCTEX_PRINT_CHARINDEX
-#       define SYNCTEX_PRINT_LINEINDEX_FMT
-#       define SYNCTEX_PRINT_LINEINDEX_WHAT
-#       define SYNCTEX_PRINT_LINEINDEX
-#       define SYNCTEX_PRINT_CHARINDEX_NL printf("\n")
-#       define SYNCTEX_PRINT_LINEINDEX_NL printf("\n")
-#       define SYNCTEX_IMPLEMENT_CHARINDEX(NODE,CORRECTION)
-#   endif
+#if defined(SYNCTEX_USE_CHARINDEX)
+#define SYNCTEX_CHARINDEX(NODE) (NODE->char_index)
+#define SYNCTEX_LINEINDEX(NODE) (NODE->line_index)
+#define SYNCTEX_PRINT_CHARINDEX_FMT "#%i"
+#define SYNCTEX_PRINT_CHARINDEX_WHAT , SYNCTEX_CHARINDEX(node)
+#define SYNCTEX_PRINT_CHARINDEX printf(SYNCTEX_PRINT_CHARINDEX_FMT SYNCTEX_PRINT_CHARINDEX_WHAT)
+#define SYNCTEX_PRINT_LINEINDEX_FMT "L#%i"
+#define SYNCTEX_PRINT_LINEINDEX_WHAT , SYNCTEX_LINEINDEX(node)
+#define SYNCTEX_PRINT_LINEINDEX printf(SYNCTEX_PRINT_LINEINDEX_FMT SYNCTEX_PRINT_LINEINDEX_WHAT)
+#define SYNCTEX_PRINT_CHARINDEX_NL printf(SYNCTEX_PRINT_CHARINDEX_FMT "\n" SYNCTEX_PRINT_CHARINDEX_WHAT)
+#define SYNCTEX_PRINT_LINEINDEX_NL printf(SYNCTEX_PRINT_CHARINDEX_FMT "\n" SYNCTEX_PRINT_LINEINDEX_WHAT)
+#define SYNCTEX_IMPLEMENT_CHARINDEX(NODE, CORRECTION)                                                                                                          \
+    NODE->char_index = (synctex_charindex_t)(scanner->reader->charindex_offset + SYNCTEX_CUR - SYNCTEX_START + (CORRECTION));                                  \
+    NODE->line_index = scanner->reader->line_number;
+#else
+#define SYNCTEX_CHARINDEX(NODE) 0
+#define SYNCTEX_LINEINDEX(NODE) 0
+#define SYNCTEX_PRINT_CHARINDEX_FMT
+#define SYNCTEX_PRINT_CHARINDEX_WHAT
+#define SYNCTEX_PRINT_CHARINDEX
+#define SYNCTEX_PRINT_CHARINDEX
+#define SYNCTEX_PRINT_LINEINDEX_FMT
+#define SYNCTEX_PRINT_LINEINDEX_WHAT
+#define SYNCTEX_PRINT_LINEINDEX
+#define SYNCTEX_PRINT_CHARINDEX_NL printf("\n")
+#define SYNCTEX_PRINT_LINEINDEX_NL printf("\n")
+#define SYNCTEX_IMPLEMENT_CHARINDEX(NODE, CORRECTION)
+#endif
 
 /**
  *  The next macros are used to access the node tree info
@@ -401,93 +399,99 @@ __synctex_scanner_register_handle_to(NODE)
  *  - parameter NODE: of type synctex_node_p
  *  If the name starts with "__", the argument is nonullable
  */
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Tree SETGET
-#   endif
-
-#if SYNCTEX_DEBUG > 1000
-#define SYNCTEX_PARAMETER_ASSERT(WHAT) \
-    do { \
-        if (!(WHAT)) { \
-            printf("! Parameter failure: %s\n",#WHAT); \
-        } \
-    } while (synctex_NO)
-#define DEFINE_SYNCTEX_TREE_HAS(WHAT)\
-static synctex_bool_t _synctex_tree_has_##WHAT(synctex_node_p node) {\
-    if (node) {\
-        if (node->class_->navigator->WHAT>=0) {\
-            return synctex_YES; \
-        } else {\
-            printf("WARNING: NO tree %s for %s\n", #WHAT, synctex_node_isa(node));\
-        }\
-    }\
-    return synctex_NO;\
-}
-#else
-#   define SYNCTEX_PARAMETER_ASSERT(WHAT)
-#   define DEFINE_SYNCTEX_TREE_HAS(WHAT) \
-SYNCTEX_INLINE static synctex_bool_t _synctex_tree_has_##WHAT(synctex_node_p node) {\
-    return (node && (node->class_->navigator->WHAT>=0));\
-}
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Tree SETGET
 #endif
 
-#   define DEFINE_SYNCTEX_TREE__GET(WHAT) \
-SYNCTEX_INLINE static synctex_node_p __synctex_tree_##WHAT(synctex_non_null_node_p node) {\
-    return node->data[node->class_->navigator->WHAT].as_node;\
-}
-#   define DEFINE_SYNCTEX_TREE_GET(WHAT) \
-DEFINE_SYNCTEX_TREE__GET(WHAT); \
-SYNCTEX_INLINE static synctex_node_p _synctex_tree_##WHAT(synctex_node_p node) {\
-    if (_synctex_tree_has_##WHAT(node)) {\
-        return __synctex_tree_##WHAT(node);\
-    }\
-    return NULL;\
-}
-#   define DEFINE_SYNCTEX_TREE__RESET(WHAT) \
-SYNCTEX_INLINE static synctex_node_p __synctex_tree_reset_##WHAT(synctex_non_null_node_p node) {\
-    synctex_node_p old = node->data[node->class_->navigator->WHAT].as_node;\
-    node->data[node->class_->navigator->WHAT].as_node=NULL;\
-    return old;\
-}
-#   define DEFINE_SYNCTEX_TREE_RESET(WHAT) \
-DEFINE_SYNCTEX_TREE__RESET(WHAT); \
-SYNCTEX_INLINE static synctex_node_p _synctex_tree_reset_##WHAT(synctex_node_p node) {\
-        return _synctex_tree_has_##WHAT(node)? \
-            __synctex_tree_reset_##WHAT(node): NULL; \
-}
-#   define DEFINE_SYNCTEX_TREE__SET(WHAT) \
-SYNCTEX_INLINE static synctex_node_p __synctex_tree_set_##WHAT(synctex_non_null_node_p node, synctex_node_p new_value) {\
-    synctex_node_p old = __synctex_tree_##WHAT(node);\
-    node->data[node->class_->navigator->WHAT].as_node=new_value;\
-    return old;\
-}
-#   define DEFINE_SYNCTEX_TREE_SET(WHAT) \
-DEFINE_SYNCTEX_TREE__SET(WHAT); \
-SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_##WHAT(synctex_node_p node, synctex_node_p new_value) {\
-    return _synctex_tree_has_##WHAT(node)?\
-        __synctex_tree_set_##WHAT(node,new_value):NULL;\
-}
-#   define DEFINE_SYNCTEX_TREE__GETSETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE__GET(WHAT); \
-DEFINE_SYNCTEX_TREE__SET(WHAT); \
-DEFINE_SYNCTEX_TREE__RESET(WHAT);
+#if SYNCTEX_DEBUG > 1000
+#define SYNCTEX_PARAMETER_ASSERT(WHAT)                                                                                                                         \
+    do {                                                                                                                                                       \
+        if (!(WHAT)) {                                                                                                                                         \
+            printf("! Parameter failure: %s\n", #WHAT);                                                                                                        \
+        }                                                                                                                                                      \
+    } while (synctex_NO)
+#define DEFINE_SYNCTEX_TREE_HAS(WHAT)                                                                                                                          \
+    static synctex_bool_t _synctex_tree_has_##WHAT(synctex_node_p node)                                                                                        \
+    {                                                                                                                                                          \
+        if (node) {                                                                                                                                            \
+            if (node->class_->navigator->WHAT >= 0) {                                                                                                          \
+                return synctex_YES;                                                                                                                            \
+            } else {                                                                                                                                           \
+                printf("WARNING: NO tree %s for %s\n", #WHAT, synctex_node_isa(node));                                                                         \
+            }                                                                                                                                                  \
+        }                                                                                                                                                      \
+        return synctex_NO;                                                                                                                                     \
+    }
+#else
+#define SYNCTEX_PARAMETER_ASSERT(WHAT)
+#define DEFINE_SYNCTEX_TREE_HAS(WHAT)                                                                                                                          \
+    SYNCTEX_INLINE static synctex_bool_t _synctex_tree_has_##WHAT(synctex_node_p node)                                                                         \
+    {                                                                                                                                                          \
+        return (node && (node->class_->navigator->WHAT >= 0));                                                                                                 \
+    }
+#endif
 
-#   define DEFINE_SYNCTEX_TREE_GETSET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT); \
-DEFINE_SYNCTEX_TREE_GET(WHAT); \
-DEFINE_SYNCTEX_TREE_SET(WHAT);
+#define DEFINE_SYNCTEX_TREE__GET(WHAT)                                                                                                                         \
+    SYNCTEX_INLINE static synctex_node_p __synctex_tree_##WHAT(synctex_non_null_node_p node)                                                                   \
+    {                                                                                                                                                          \
+        return node->data[node->class_->navigator->WHAT].as_node;                                                                                              \
+    }
+#define DEFINE_SYNCTEX_TREE_GET(WHAT)                                                                                                                          \
+    DEFINE_SYNCTEX_TREE__GET(WHAT);                                                                                                                            \
+    SYNCTEX_INLINE static synctex_node_p _synctex_tree_##WHAT(synctex_node_p node)                                                                             \
+    {                                                                                                                                                          \
+        if (_synctex_tree_has_##WHAT(node)) {                                                                                                                  \
+            return __synctex_tree_##WHAT(node);                                                                                                                \
+        }                                                                                                                                                      \
+        return NULL;                                                                                                                                           \
+    }
+#define DEFINE_SYNCTEX_TREE__RESET(WHAT)                                                                                                                       \
+    SYNCTEX_INLINE static synctex_node_p __synctex_tree_reset_##WHAT(synctex_non_null_node_p node)                                                             \
+    {                                                                                                                                                          \
+        synctex_node_p old = node->data[node->class_->navigator->WHAT].as_node;                                                                                \
+        node->data[node->class_->navigator->WHAT].as_node = NULL;                                                                                              \
+        return old;                                                                                                                                            \
+    }
+#define DEFINE_SYNCTEX_TREE_RESET(WHAT)                                                                                                                        \
+    DEFINE_SYNCTEX_TREE__RESET(WHAT);                                                                                                                          \
+    SYNCTEX_INLINE static synctex_node_p _synctex_tree_reset_##WHAT(synctex_node_p node)                                                                       \
+    {                                                                                                                                                          \
+        return _synctex_tree_has_##WHAT(node) ? __synctex_tree_reset_##WHAT(node) : NULL;                                                                      \
+    }
+#define DEFINE_SYNCTEX_TREE__SET(WHAT)                                                                                                                         \
+    SYNCTEX_INLINE static synctex_node_p __synctex_tree_set_##WHAT(synctex_non_null_node_p node, synctex_node_p new_value)                                     \
+    {                                                                                                                                                          \
+        synctex_node_p old = __synctex_tree_##WHAT(node);                                                                                                      \
+        node->data[node->class_->navigator->WHAT].as_node = new_value;                                                                                         \
+        return old;                                                                                                                                            \
+    }
+#define DEFINE_SYNCTEX_TREE_SET(WHAT)                                                                                                                          \
+    DEFINE_SYNCTEX_TREE__SET(WHAT);                                                                                                                            \
+    SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_##WHAT(synctex_node_p node, synctex_node_p new_value)                                               \
+    {                                                                                                                                                          \
+        return _synctex_tree_has_##WHAT(node) ? __synctex_tree_set_##WHAT(node, new_value) : NULL;                                                             \
+    }
+#define DEFINE_SYNCTEX_TREE__GETSETRESET(WHAT)                                                                                                                 \
+    DEFINE_SYNCTEX_TREE__GET(WHAT);                                                                                                                            \
+    DEFINE_SYNCTEX_TREE__SET(WHAT);                                                                                                                            \
+    DEFINE_SYNCTEX_TREE__RESET(WHAT);
 
-#   define DEFINE_SYNCTEX_TREE_GETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT); \
-DEFINE_SYNCTEX_TREE_GET(WHAT); \
-DEFINE_SYNCTEX_TREE_RESET(WHAT);
+#define DEFINE_SYNCTEX_TREE_GETSET(WHAT)                                                                                                                       \
+    DEFINE_SYNCTEX_TREE_HAS(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_GET(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_SET(WHAT);
 
-#   define DEFINE_SYNCTEX_TREE_GETSETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT); \
-DEFINE_SYNCTEX_TREE_GET(WHAT); \
-DEFINE_SYNCTEX_TREE_SET(WHAT); \
-DEFINE_SYNCTEX_TREE_RESET(WHAT);
+#define DEFINE_SYNCTEX_TREE_GETRESET(WHAT)                                                                                                                     \
+    DEFINE_SYNCTEX_TREE_HAS(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_GET(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_RESET(WHAT);
+
+#define DEFINE_SYNCTEX_TREE_GETSETRESET(WHAT)                                                                                                                  \
+    DEFINE_SYNCTEX_TREE_HAS(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_GET(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_SET(WHAT);                                                                                                                             \
+    DEFINE_SYNCTEX_TREE_RESET(WHAT);
 
 /*
  *  _synctex_tree_set_... methods return the old value.
@@ -935,66 +939,68 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(target);
 */
 
 #if SYNCTEX_DEBUG > 1000
-#   undef SYNCTEX_USE_NODE_COUNT
-#   define SYNCTEX_USE_NODE_COUNT 1
+#undef SYNCTEX_USE_NODE_COUNT
+#define SYNCTEX_USE_NODE_COUNT 1
 #endif
-#if SYNCTEX_USE_NODE_COUNT>0
-#   define SYNCTEX_DECLARE_NODE_COUNT int node_count;
-#   define SYNCTEX_INIT_NODE_COUNT \
-        do { node_count = 0; } while(synctex_NO)
+#if SYNCTEX_USE_NODE_COUNT > 0
+#define SYNCTEX_DECLARE_NODE_COUNT int node_count;
+#define SYNCTEX_INIT_NODE_COUNT                                                                                                                                \
+    do {                                                                                                                                                       \
+        node_count = 0;                                                                                                                                        \
+    } while (synctex_NO)
 #else
-#   define SYNCTEX_DECLARE_NODE_COUNT
-#   define SYNCTEX_INIT_NODE_COUNT
+#define SYNCTEX_DECLARE_NODE_COUNT
+#define SYNCTEX_INIT_NODE_COUNT
 #endif
 
-#if SYNCTEX_USE_NODE_COUNT>10
-#   define SYNCTEX_DID_NEW(N)   _synctex_did_new(N)
-#   define SYNCTEX_WILL_FREE(N) _synctex_will_free(N)
+#if SYNCTEX_USE_NODE_COUNT > 10
+#define SYNCTEX_DID_NEW(N) _synctex_did_new(N)
+#define SYNCTEX_WILL_FREE(N) _synctex_will_free(N)
 #else
-#   define SYNCTEX_DID_NEW(N)
-#   define SYNCTEX_WILL_FREE(N)
+#define SYNCTEX_DID_NEW(N)
+#define SYNCTEX_WILL_FREE(N)
 #endif
 
 #define SYNCTEX_HAS_CHILDREN(NODE) (NODE && _synctex_tree_child(NODE))
-#	ifdef	SYNCTEX_STANDALONE
-#		include "/usr/local/include/node/zlib.h"
-#	else
-#		include <zlib.h>
-#	endif
+#ifdef SYNCTEX_STANDALONE
+#include "/usr/local/include/node/zlib.h"
+#else
+#include <zlib.h>
+#endif
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark STATUS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark STATUS
+#endif
 /*  When the end of the synctex file has been reached: */
-#   define SYNCTEX_STATUS_EOF 0
+#define SYNCTEX_STATUS_EOF 0
 /*  When the function could not return the value it was asked for: */
-#   define SYNCTEX_STATUS_NOT_OK (SYNCTEX_STATUS_EOF+1)
+#define SYNCTEX_STATUS_NOT_OK (SYNCTEX_STATUS_EOF + 1)
 /*  When the function returns the value it was asked for:
  It must be the biggest one */
-#   define SYNCTEX_STATUS_OK (SYNCTEX_STATUS_NOT_OK+1)
+#define SYNCTEX_STATUS_OK (SYNCTEX_STATUS_NOT_OK + 1)
 /*  Generic error: */
-#   define SYNCTEX_STATUS_ERROR (SYNCTEX_STATUS_EOF-1)
+#define SYNCTEX_STATUS_ERROR (SYNCTEX_STATUS_EOF - 1)
 /*  Parameter error: */
-#   define SYNCTEX_STATUS_BAD_ARGUMENT (SYNCTEX_STATUS_ERROR-1)
+#define SYNCTEX_STATUS_BAD_ARGUMENT (SYNCTEX_STATUS_ERROR - 1)
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark File reader
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark File reader
+#endif
 
 /*  We ensure that SYNCTEX_BUFFER_SIZE < UINT_MAX, I don't know if it makes sense... */
 /*  Actually, the minimum buffer size is driven by integer and float parsing, including the unit.
  *  ±0.123456789e123??
  */
-#   define SYNCTEX_BUFFER_MIN_SIZE 32
-#   define SYNCTEX_BUFFER_SIZE 32768
+#define SYNCTEX_BUFFER_MIN_SIZE 32
+#define SYNCTEX_BUFFER_SIZE 32768
 
 #if SYNCTEX_BUFFER_SIZE >= UINT_MAX
-#   error BAD BUFFER SIZE(1)
+#error BAD BUFFER SIZE(1)
 #endif
 #if SYNCTEX_BUFFER_SIZE < SYNCTEX_BUFFER_MIN_SIZE
-#   error BAD BUFFER SIZE(2)
+#error BAD BUFFER SIZE(2)
 #endif
 /** @endcond */
 
@@ -1006,15 +1012,15 @@ typedef struct _synctex_reader_t {
     /** The (possibly compressed) file */
     gzFile file;
     /** The output file */
-    char * output;
+    char *output;
     /** The synctex file */
-    char * synctex;
+    char *synctex;
     /** current location in the buffer */
-    char * current;
+    char *current;
     /** start of the buffer */
-    char * start;
+    char *start;
     /** end of the buffer */
-    char * end;
+    char *end;
     /** Undocumented */
     size_t min_size;
     /** Undocumented */
@@ -1030,7 +1036,7 @@ typedef struct _synctex_reader_t {
  * @brief Reader structure
  *
  */
-typedef _synctex_reader_s * synctex_reader_p;
+typedef _synctex_reader_s *synctex_reader_p;
 
 /**
  * @brief Return structure
@@ -1041,7 +1047,7 @@ typedef struct {
     /** error status */
     synctex_status_t status;
     /** synctex file name */
-    char * synctex;
+    char *synctex;
     /** synctex file */
     gzFile file;
     /** mode */
@@ -1059,23 +1065,24 @@ typedef struct {
  *  - note: on success, the caller is the owner
  *      of the fields of the returned open structure.
  */
-static _synctex_open_s __synctex_open_v2(const char * output, synctex_io_mode_t io_mode, synctex_bool_t add_quotes) {
+static _synctex_open_s __synctex_open_v2(const char *output, synctex_io_mode_t io_mode, synctex_bool_t add_quotes)
+{
     _synctex_open_s open = {SYNCTEX_STATUS_ERROR, NULL, NULL, io_mode};
-    char * quoteless_synctex_name = NULL;
-    const char * mode = _synctex_get_io_mode_name(open.io_mode);
-    size_t size = strlen(output)+strlen(synctex_suffix)+strlen(synctex_suffix_gz)+1;
+    char *quoteless_synctex_name = NULL;
+    const char *mode = _synctex_get_io_mode_name(open.io_mode);
+    size_t size = strlen(output) + strlen(synctex_suffix) + strlen(synctex_suffix_gz) + 1;
     if (NULL == (open.synctex = (char *)malloc(size))) {
         _synctex_error("!  __synctex_open_v2: Memory problem (1)\n");
         return open;
     }
     /*  we have reserved for synctex enough memory to copy output (including its 2 eventual quotes), both suffices,
      *  including the terminating character. size is free now. */
-    if (open.synctex != strcpy(open.synctex,output)) {
+    if (open.synctex != strcpy(open.synctex, output)) {
         _synctex_error("!  __synctex_open_v2: Copy problem\n");
     return_on_error:
         free(open.synctex);
         open.synctex = NULL;
-        free(quoteless_synctex_name);/* We MUST have quoteless_synctex_name<>synctex_name */
+        free(quoteless_synctex_name); /* We MUST have quoteless_synctex_name<>synctex_name */
         return open;
     }
     /*  remove the last path extension if any */
@@ -1085,8 +1092,8 @@ static _synctex_open_s __synctex_open_v2(const char * output, synctex_io_mode_t 
     }
     /*  now insert quotes. */
     if (add_quotes) {
-        char * quoted = NULL;
-        if (_synctex_copy_with_quoting_last_path_component(open.synctex,&quoted,size) || quoted == NULL) {
+        char *quoted = NULL;
+        if (_synctex_copy_with_quoting_last_path_component(open.synctex, &quoted, size) || quoted == NULL) {
             /*	There was an error or quoting does not make sense: */
             goto return_on_error;
         }
@@ -1094,39 +1101,39 @@ static _synctex_open_s __synctex_open_v2(const char * output, synctex_io_mode_t 
         open.synctex = quoted;
     }
     /*	Now add to open.synctex the first path extension. */
-    if (open.synctex != strcat(open.synctex,synctex_suffix)){
-        _synctex_error("!  __synctex_open_v2: Concatenation problem (can't add suffix '%s')\n",synctex_suffix);
+    if (open.synctex != strcat(open.synctex, synctex_suffix)) {
+        _synctex_error("!  __synctex_open_v2: Concatenation problem (can't add suffix '%s')\n", synctex_suffix);
         goto return_on_error;
     }
     /*	Add to quoteless_synctex_name as well, if relevant. */
-    if (quoteless_synctex_name && (quoteless_synctex_name != strcat(quoteless_synctex_name,synctex_suffix))){
+    if (quoteless_synctex_name && (quoteless_synctex_name != strcat(quoteless_synctex_name, synctex_suffix))) {
         free(quoteless_synctex_name);
         quoteless_synctex_name = NULL;
     }
-    if (NULL == (open.file = gzopen(open.synctex,mode))) {
+    if (NULL == (open.file = gzopen(open.synctex, mode))) {
         /*  Could not open this file */
         if (errno != ENOENT) {
             /*  The file does exist, this is a lower level error, I can't do anything. */
-            _synctex_error("could not open %s, error %i\n",open.synctex,errno);
+            _synctex_error("could not open %s, error %i\n", open.synctex, errno);
             goto return_on_error;
         }
         /*  Apparently, there is no uncompressed synctex file. Try the compressed version */
-        if (open.synctex != strcat(open.synctex,synctex_suffix_gz)){
-            _synctex_error("!  __synctex_open_v2: Concatenation problem (can't add suffix '%s')\n",synctex_suffix_gz);
+        if (open.synctex != strcat(open.synctex, synctex_suffix_gz)) {
+            _synctex_error("!  __synctex_open_v2: Concatenation problem (can't add suffix '%s')\n", synctex_suffix_gz);
             goto return_on_error;
         }
         open.io_mode |= synctex_io_gz_mask;
         mode = _synctex_get_io_mode_name(open.io_mode); /* the file is a compressed and is a binary file, this caused errors on Windows */
         /*	Add the suffix to the quoteless_synctex_name as well. */
-        if (quoteless_synctex_name && (quoteless_synctex_name != strcat(quoteless_synctex_name,synctex_suffix_gz))){
+        if (quoteless_synctex_name && (quoteless_synctex_name != strcat(quoteless_synctex_name, synctex_suffix_gz))) {
             free(quoteless_synctex_name);
             quoteless_synctex_name = NULL;
         }
-        if (NULL == (open.file = gzopen(open.synctex,mode))) {
+        if (NULL == (open.file = gzopen(open.synctex, mode))) {
             /*  Could not open this file */
             if (errno != ENOENT) {
                 /*  The file does exist, this is a lower level error, I can't do anything. */
-                _synctex_error("Could not open %s, error %i\n",open.synctex,errno);
+                _synctex_error("Could not open %s, error %i\n", open.synctex, errno);
             }
             goto return_on_error;
         }
@@ -1135,25 +1142,25 @@ static _synctex_open_s __synctex_open_v2(const char * output, synctex_io_mode_t 
      *  If we are in the add_quotes mode, we change the file name by removing the quotes. */
     if (quoteless_synctex_name) {
         gzclose(open.file);
-        if (rename(open.synctex,quoteless_synctex_name)) {
-            _synctex_error("Could not rename %s to %s, error %i\n",open.synctex,quoteless_synctex_name,errno);
+        if (rename(open.synctex, quoteless_synctex_name)) {
+            _synctex_error("Could not rename %s to %s, error %i\n", open.synctex, quoteless_synctex_name, errno);
             /*	We could not rename, reopen the file with the quoted name. */
-            if (NULL == (open.file = gzopen(open.synctex,mode))) {
+            if (NULL == (open.file = gzopen(open.synctex, mode))) {
                 /*  No luck, could not re open this file, something has happened meanwhile */
                 if (errno != ENOENT) {
                     /*  The file does not exist any more, it has certainly be removed somehow
                      *  this is a lower level error, I can't do anything. */
-                    _synctex_error("Could not open again %s, error %i\n",open.synctex,errno);
+                    _synctex_error("Could not open again %s, error %i\n", open.synctex, errno);
                 }
                 goto return_on_error;
             }
         } else {
             /*  The file has been successfully renamed */
-            if (NULL == (open.file = gzopen(quoteless_synctex_name,mode))) {
+            if (NULL == (open.file = gzopen(quoteless_synctex_name, mode))) {
                 /*  Could not open this file */
                 if (errno != ENOENT) {
                     /*  The file does exist, this is a lower level error, I can't do anything. */
-                    _synctex_error("Could not open renamed %s, error %i\n",quoteless_synctex_name,errno);
+                    _synctex_error("Could not open renamed %s, error %i\n", quoteless_synctex_name, errno);
                 }
                 goto return_on_error;
             }
@@ -1175,19 +1182,20 @@ static _synctex_open_s __synctex_open_v2(const char * output, synctex_io_mode_t 
  *  - note: on success, the caller is the owner
  *      of the fields of the returned open structure.
  */
-static _synctex_open_s _synctex_open_v2(const char * output, const char * build_directory, synctex_io_mode_t io_mode, synctex_bool_t add_quotes) {
-    _synctex_open_s open = __synctex_open_v2(output,io_mode,add_quotes);
+static _synctex_open_s _synctex_open_v2(const char *output, const char *build_directory, synctex_io_mode_t io_mode, synctex_bool_t add_quotes)
+{
+    _synctex_open_s open = __synctex_open_v2(output, io_mode, add_quotes);
     if (open.status == SYNCTEX_STATUS_OK) {
         return open;
     }
     if (build_directory && strlen(build_directory)) {
-        char * build_output;
+        char *build_output;
         const char *lpc;
         size_t size;
         synctex_bool_t is_absolute;
         build_output = NULL;
         lpc = _synctex_last_path_component(output);
-        size = strlen(build_directory)+strlen(lpc)+2;   /*  One for the '/' and one for the '\0'.   */
+        size = strlen(build_directory) + strlen(lpc) + 2; /*  One for the '/' and one for the '\0'.   */
         is_absolute = _synctex_path_is_absolute(build_directory);
         if (!is_absolute) {
             size += strlen(output);
@@ -1196,33 +1204,34 @@ static _synctex_open_s _synctex_open_v2(const char * output, const char * build_
             if (is_absolute) {
                 build_output[0] = '\0';
             } else {
-                if (build_output != strcpy(build_output,output)) {
+                if (build_output != strcpy(build_output, output)) {
                     _synctex_free(build_output);
                     return open;
                 }
-                build_output[lpc-output]='\0';
+                build_output[lpc - output] = '\0';
             }
-            if (build_output == strcat(build_output,build_directory)) {
+            if (build_output == strcat(build_output, build_directory)) {
                 /*	Append a path separator if necessary. */
-                if (!SYNCTEX_IS_PATH_SEPARATOR(build_output[strlen(build_directory)-1])) {
-                    if (build_output != strcat(build_output,"/")) {
+                if (!SYNCTEX_IS_PATH_SEPARATOR(build_output[strlen(build_directory) - 1])) {
+                    if (build_output != strcat(build_output, "/")) {
                         _synctex_free(build_output);
                         return open;
                     }
                 }
                 /*	Append the last path component of the output. */
-                if (build_output != strcat(build_output,lpc)) {
+                if (build_output != strcat(build_output, lpc)) {
                     _synctex_free(build_output);
                     return open;
                 }
-                open = __synctex_open_v2(build_output,io_mode,add_quotes);
+                open = __synctex_open_v2(build_output, io_mode, add_quotes);
             }
             _synctex_free(build_output);
         } /* if ((build_output... */
     } /* if (build_directory...) */
     return open;
 }
-static void synctex_reader_free(synctex_reader_p reader) {
+static void synctex_reader_free(synctex_reader_p reader)
+{
     if (reader) {
         _synctex_free(reader->output);
         _synctex_free(reader->synctex);
@@ -1235,22 +1244,23 @@ static void synctex_reader_free(synctex_reader_p reader) {
  *  Return reader on success.
  *  Deallocate reader and return NULL on failure.
  */
-static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p reader, const char * output, const char * build_directory) {
+static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p reader, const char *output, const char *build_directory)
+{
     if (reader) {
         /*  now open the synctex file */
-        _synctex_open_s open = _synctex_open_v2(output,build_directory,0,synctex_ADD_QUOTES);
-        if (open.status<SYNCTEX_STATUS_OK) {
-            open = _synctex_open_v2(output,build_directory,0,synctex_DONT_ADD_QUOTES);
-            if (open.status<SYNCTEX_STATUS_OK) {
+        _synctex_open_s open = _synctex_open_v2(output, build_directory, 0, synctex_ADD_QUOTES);
+        if (open.status < SYNCTEX_STATUS_OK) {
+            open = _synctex_open_v2(output, build_directory, 0, synctex_DONT_ADD_QUOTES);
+            if (open.status < SYNCTEX_STATUS_OK) {
                 return NULL;
             }
         }
         reader->synctex = open.synctex;
         reader->file = open.file;
         /*  make a private copy of output */
-        if (NULL == (reader->output = (char *)_synctex_malloc(strlen(output)+1))){
+        if (NULL == (reader->output = (char *)_synctex_malloc(strlen(output) + 1))) {
             _synctex_error("!  synctex_scanner_new_with_output_file: Memory problem (2), reader's output is not reliable.");
-        } else if (reader->output != strcpy(reader->output,output)) {
+        } else if (reader->output != strcpy(reader->output, output)) {
             _synctex_free(reader->output);
             reader->output = NULL;
             _synctex_error("!  synctex_scanner_new_with_output_file: Copy problem, reader's output is not reliable.");
@@ -1258,8 +1268,7 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
         reader->start = reader->end = reader->current = NULL;
         reader->min_size = SYNCTEX_BUFFER_MIN_SIZE;
         reader->size = SYNCTEX_BUFFER_SIZE;
-        reader->start = reader->current =
-            (char *)_synctex_malloc(reader->size+1); /*  one more character for null termination */
+        reader->start = reader->current = (char *)_synctex_malloc(reader->size + 1); /*  one more character for null termination */
         if (NULL == reader->start) {
             _synctex_error("!  malloc error in synctex_reader_init_with_output_file.");
 #ifdef SYNCTEX_DEBUG
@@ -1269,29 +1278,29 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
             return NULL;
 #endif
         }
-        reader->end = reader->start+reader->size;
+        reader->end = reader->start + reader->size;
         /*  reader->end always points to a null terminating character.
          *  Maybe there is another null terminating character between reader->current and reader->end-1.
          *  At least, we are sure that reader->current points to a string covering a valid part of the memory. */
-#   if defined(SYNCTEX_USE_CHARINDEX)
+#if defined(SYNCTEX_USE_CHARINDEX)
         reader->charindex_offset = -reader->size;
-#   endif
+#endif
     }
     return reader;
 }
 
 /** @cond */
 
-#   if defined(SYNCTEX_USE_HANDLE)
-#       define SYNCTEX_DECLARE_HANDLE synctex_node_p handle;
-#   else
-#       define SYNCTEX_DECLARE_HANDLE
-#   endif
+#if defined(SYNCTEX_USE_HANDLE)
+#define SYNCTEX_DECLARE_HANDLE synctex_node_p handle;
+#else
+#define SYNCTEX_DECLARE_HANDLE
+#endif
 
-#   ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark SCANNER
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark SCANNER
+#endif
 
 /**
  *  The synctex scanner is the root object.
@@ -1305,7 +1314,7 @@ struct _synctex_scanner_t {
     SYNCTEX_DECLARE_NODE_COUNT
     SYNCTEX_DECLARE_HANDLE
     /** "dvi" or "pdf", not yet used */
-    char * output_fmt;
+    char *output_fmt;
     /** result iterator */
     synctex_iterator_p iterator;
     /** allways 1, not yet used */
@@ -1313,11 +1322,11 @@ struct _synctex_scanner_t {
     /** various flags */
     struct {
         /**  Whether the scanner has parsed its underlying synctex file. */
-        unsigned has_parsed:1;
+        unsigned has_parsed : 1;
         /*  Whether the scanner has parsed the postamble. */
-        unsigned postamble:1;
+        unsigned postamble : 1;
         /*  alignment */
-        unsigned reserved:sizeof(unsigned)-2;
+        unsigned reserved : sizeof(unsigned) - 2;
     } flags;
     /** magnification from the synctex preamble */
     int pre_magnification;
@@ -1354,7 +1363,7 @@ struct _synctex_scanner_t {
     /** The display switcher value*/
     int display_switcher;
     /** The display prompt */
-    char * display_prompt;
+    char *display_prompt;
 };
 
 /** @endcond */
@@ -1366,14 +1375,17 @@ struct _synctex_scanner_t {
  * @param type no type checking
  * @return synctex_node_p
  */
-synctex_node_p synctex_node_new(synctex_scanner_p scanner, synctex_node_type_t type) {
-    return scanner? scanner->class_[type].new(scanner):NULL;
+synctex_node_p synctex_node_new(synctex_scanner_p scanner, synctex_node_type_t type)
+{
+    return scanner ? scanner->class_[type].new(scanner) : NULL;
 }
-#   if defined(SYNCTEX_USE_HANDLE)
-SYNCTEX_INLINE static void __synctex_scanner_free_handle(synctex_scanner_p scanner) {
+#if defined(SYNCTEX_USE_HANDLE)
+SYNCTEX_INLINE static void __synctex_scanner_free_handle(synctex_scanner_p scanner)
+{
     _synctex_node_free(scanner->handle);
 }
-SYNCTEX_INLINE static void __synctex_scanner_remove_handle_to(synctex_node_p node) {
+SYNCTEX_INLINE static void __synctex_scanner_remove_handle_to(synctex_node_p node)
+{
     synctex_node_p arg_sibling = NULL;
     synctex_node_p handle = node->class_->scanner->handle;
     while (handle) {
@@ -1394,24 +1406,21 @@ SYNCTEX_INLINE static void __synctex_scanner_remove_handle_to(synctex_node_p nod
         handle = sibling;
     }
 }
-SYNCTEX_INLINE static void __synctex_scanner_register_handle_to(synctex_node_p  node) {
+SYNCTEX_INLINE static void __synctex_scanner_register_handle_to(synctex_node_p node)
+{
     synctex_node_p NNN = _synctex_new_handle_with_target(node);
-    __synctex_tree_set_sibling(NNN,node->class_->scanner->handle);
+    __synctex_tree_set_sibling(NNN, node->class_->scanner->handle);
     node->class_->scanner->handle = NNN;
 }
 #endif
-#if SYNCTEX_USE_NODE_COUNT>10
-SYNCTEX_INLINE static void _synctex_did_new(synctex_node_p node) {
-    printf("NODE CREATED # %i, %s, %p\n",
-           (node->class_->scanner->node_count)++,
-           synctex_node_isa(node),
-           node);
+#if SYNCTEX_USE_NODE_COUNT > 10
+SYNCTEX_INLINE static void _synctex_did_new(synctex_node_p node)
+{
+    printf("NODE CREATED # %i, %s, %p\n", (node->class_->scanner->node_count)++, synctex_node_isa(node), node);
 }
-SYNCTEX_INLINE static void _synctex_will_free(synctex_node_p node) {
-    printf("NODE DELETED # %i, %s, %p\n",
-           --(node->class_->scanner->node_count),
-           synctex_node_isa(node),
-           node);
+SYNCTEX_INLINE static void _synctex_will_free(synctex_node_p node)
+{
+    printf("NODE DELETED # %i, %s, %p\n", --(node->class_->scanner->node_count), synctex_node_isa(node), node);
 }
 #endif
 
@@ -1428,21 +1437,22 @@ SYNCTEX_INLINE static void _synctex_will_free(synctex_node_p node) {
  * The memory management should be enhanced to free everything all at once,
  * for example when we free a whole scanner.
  */
-static void _synctex_free_node(synctex_node_p node) {
+static void _synctex_free_node(synctex_node_p node)
+{
     if (node) {
         synctex_node_p sibling;
         synctex_node_p child;
         synctex_node_p parent = _synctex_tree_parent(node);
         synctex_node_p top_parent = parent;
         /* deep first traversal */
-find_deepest:
+    find_deepest:
         if ((child = _synctex_tree_child(node))) {
             parent = node;
             node = child;
             goto find_deepest;
         }
         /* node is the deepest one */
-deepest_found:
+    deepest_found:
         if ((sibling = __synctex_tree_reset_sibling(node))) {
             /* the sibling is detached */
             if (parent) {
@@ -1510,31 +1520,32 @@ static void _synctex_free_handle_old(synctex_node_p handle) {
   return;
 }
 */
-static void _synctex_free_handle(synctex_node_p handle) {
-  if (handle) {
-    synctex_node_p n = handle;
-    synctex_node_p nn;
-    __synctex_tree_set_parent(n, NULL);
-  down:
-    while ((nn = _synctex_tree_child(n))) {
-      __synctex_tree_set_parent(nn, n);
-      n = nn;
-    };
-  right:
-    nn = __synctex_tree_sibling(n);
-    if (nn) {
-      _synctex_free(n);
-      n = nn;
-      goto down;
+static void _synctex_free_handle(synctex_node_p handle)
+{
+    if (handle) {
+        synctex_node_p n = handle;
+        synctex_node_p nn;
+        __synctex_tree_set_parent(n, NULL);
+    down:
+        while ((nn = _synctex_tree_child(n))) {
+            __synctex_tree_set_parent(nn, n);
+            n = nn;
+        };
+    right:
+        nn = __synctex_tree_sibling(n);
+        if (nn) {
+            _synctex_free(n);
+            n = nn;
+            goto down;
+        }
+        nn = __synctex_tree_parent(n);
+        _synctex_free(n);
+        if (nn) {
+            n = nn;
+            goto right;
+        }
     }
-    nn = __synctex_tree_parent(n);
-    _synctex_free(n);
-    if (nn) {
-      n = nn;
-      goto right;
-    }
-  }
-  return;
+    return;
 }
 
 /**
@@ -1544,7 +1555,8 @@ static void _synctex_free_handle(synctex_node_p handle) {
  *  It is not owned by its parent, unless it is its first child.
  *  This destructor is for all nodes with no children.
  */
-static void _synctex_free_leaf(synctex_node_p node) {
+static void _synctex_free_leaf(synctex_node_p node)
+{
     if (node) {
         SYNCTEX_SCANNER_REMOVE_HANDLE_TO(node);
         SYNCTEX_WILL_FREE(node);
@@ -1557,9 +1569,9 @@ static void _synctex_free_leaf(synctex_node_p node) {
 /**
  SYNCTEX_CUR, SYNCTEX_START and SYNCTEX_END are convenient shortcuts
  */
-#   define SYNCTEX_CUR (scanner->reader->current)
-#   define SYNCTEX_START (scanner->reader->start)
-#   define SYNCTEX_END (scanner->reader->end)
+#define SYNCTEX_CUR (scanner->reader->current)
+#define SYNCTEX_START (scanner->reader->start)
+#define SYNCTEX_END (scanner->reader->end)
 
 /*  Here are gathered all the possible status that the next scanning functions will return.
  *  All these functions return a status, and pass their result through pointers.
@@ -1573,15 +1585,16 @@ static void _synctex_free_leaf(synctex_node_p node) {
  *  status<SYNCTEX_STATUS_EOF means an error
  */
 #if defined(SYNCTEX_USE_CHARINDEX)
-synctex_node_p synctex_scanner_handle(synctex_scanner_p scanner) {
-    return scanner? scanner->handle:NULL;
+synctex_node_p synctex_scanner_handle(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->handle : NULL;
 }
 #endif
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Decoding prototypes
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Decoding prototypes
+#endif
 
 typedef struct {
     int integer;
@@ -1600,131 +1613,143 @@ static _synctex_is_s _synctex_decode_int_v(synctex_scanner_p scanner);
  */
 typedef struct {
     /** string component */
-    char * string;
+    char *string;
     /** status component */
     synctex_status_t status;
 } _synctex_ss_s;
 
 static _synctex_ss_s _synctex_decode_string(synctex_scanner_p scanner);
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Data SETGET
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Data SETGET
+#endif
 
 /**
  *  The next macros are used to access the node data info
  *  through the class modelator integer fields.
-  *  - parameter NODE: of type synctex_node_p
+ *  - parameter NODE: of type synctex_node_p
  */
-#   define SYNCTEX_DATA(NODE) ((*((((NODE)->class_))->info))(NODE))
+#define SYNCTEX_DATA(NODE) ((*((((NODE)->class_))->info))(NODE))
 #if SYNCTEX_DEBUG > 1000
-#   define DEFINE_SYNCTEX_DATA_HAS(WHAT) \
-SYNCTEX_INLINE static synctex_bool_t __synctex_data_has_##WHAT(synctex_node_p node) {\
-    return (node && (node->class_->modelator->WHAT>=0));\
-}\
-SYNCTEX_INLINE static synctex_bool_t _synctex_data_has_##WHAT(synctex_node_p node) {\
-    if (node && (node->class_->modelator->WHAT<0)) {\
-        printf("WARNING: NO %s for %s\n", #WHAT, synctex_node_isa(node));\
-    }\
-    return __synctex_data_has_##WHAT(node);\
-}
+#define DEFINE_SYNCTEX_DATA_HAS(WHAT)                                                                                                                          \
+    SYNCTEX_INLINE static synctex_bool_t __synctex_data_has_##WHAT(synctex_node_p node)                                                                        \
+    {                                                                                                                                                          \
+        return (node && (node->class_->modelator->WHAT >= 0));                                                                                                 \
+    }                                                                                                                                                          \
+    SYNCTEX_INLINE static synctex_bool_t _synctex_data_has_##WHAT(synctex_node_p node)                                                                         \
+    {                                                                                                                                                          \
+        if (node && (node->class_->modelator->WHAT < 0)) {                                                                                                     \
+            printf("WARNING: NO %s for %s\n", #WHAT, synctex_node_isa(node));                                                                                  \
+        }                                                                                                                                                      \
+        return __synctex_data_has_##WHAT(node);                                                                                                                \
+    }
 #else
-#   define DEFINE_SYNCTEX_DATA_HAS(WHAT) \
-SYNCTEX_INLINE static synctex_bool_t __synctex_data_has_##WHAT(synctex_node_p node) {\
-    return (node && (node->class_->modelator->WHAT>=0));\
-}\
-SYNCTEX_INLINE static synctex_bool_t _synctex_data_has_##WHAT(synctex_node_p node) {\
-    return __synctex_data_has_##WHAT(node);\
-}
+#define DEFINE_SYNCTEX_DATA_HAS(WHAT)                                                                                                                          \
+    SYNCTEX_INLINE static synctex_bool_t __synctex_data_has_##WHAT(synctex_node_p node)                                                                        \
+    {                                                                                                                                                          \
+        return (node && (node->class_->modelator->WHAT >= 0));                                                                                                 \
+    }                                                                                                                                                          \
+    SYNCTEX_INLINE static synctex_bool_t _synctex_data_has_##WHAT(synctex_node_p node)                                                                         \
+    {                                                                                                                                                          \
+        return __synctex_data_has_##WHAT(node);                                                                                                                \
+    }
 #endif
 
-SYNCTEX_INLINE static synctex_data_p __synctex_data(synctex_node_p node) {
-    return node->data+node->class_->navigator->size;
+SYNCTEX_INLINE static synctex_data_p __synctex_data(synctex_node_p node)
+{
+    return node->data + node->class_->navigator->size;
 }
-#   define DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_HAS(WHAT);\
-static int _synctex_data_##WHAT(synctex_node_p node) {\
-    if (_synctex_data_has_##WHAT(node)) {\
-        return __synctex_data(node)[node->class_->modelator->WHAT].as_integer;\
-    }\
-    return 0;\
-}\
-static int _synctex_data_set_##WHAT(synctex_node_p node, int new_value) {\
-    int old = 0;\
-    if (_synctex_data_has_##WHAT(node)) {\
-        old = __synctex_data(node)[node->class_->modelator->WHAT].as_integer;\
-        __synctex_data(node)[node->class_->modelator->WHAT].as_integer=new_value;\
-    }\
-    return old;\
-}
-#define DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT) \
-static synctex_status_t _synctex_data_decode_##WHAT(synctex_node_p node) {\
-    if (_synctex_data_has_##WHAT(node)) {\
-        _synctex_is_s is = _synctex_decode_int(node->class_->scanner);\
-        if (is.status == SYNCTEX_STATUS_OK) {\
-            _synctex_data_set_##WHAT(node,is.integer);\
-        } \
-        return is.status;\
-    }\
-    return SYNCTEX_STATUS_BAD_ARGUMENT;\
-}
-#   define DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT) \
-static synctex_status_t _synctex_data_decode_##WHAT##_v(synctex_node_p node) {\
-    if (_synctex_data_has_##WHAT(node)) {\
-        _synctex_is_s is = _synctex_decode_int_v(node->class_->scanner);\
-        if (is.status == SYNCTEX_STATUS_OK) {\
-            _synctex_data_set_##WHAT(node,is.integer);\
-        } \
-        return is.status;\
-    }\
-    return SYNCTEX_STATUS_BAD_ARGUMENT;\
-}
-#define DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_HAS(WHAT);\
-static char * _synctex_data_##WHAT(synctex_node_p node) {\
-    if (_synctex_data_has_##WHAT(node)) {\
-        return node->data[node->class_->navigator->size+node->class_->modelator->WHAT].as_string;\
-    }\
-    return NULL;\
-}\
-static char * _synctex_data_set_##WHAT(synctex_node_p node, char * new_value) {\
-    char * old = "";\
-    if (_synctex_data_has_##WHAT(node)) {\
-        old = node->data[node->class_->navigator->size+node->class_->modelator->WHAT].as_string;\
-        node->data[node->class_->navigator->size+node->class_->modelator->WHAT].as_string =new_value;\
-    }\
-    return old;\
-}
-#define DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT) \
-static synctex_status_t _synctex_data_decode_##WHAT(synctex_node_p node) {\
-    if (_synctex_data_has_##WHAT(node)) {\
-        _synctex_ss_s ss = _synctex_decode_string(node->class_->scanner);\
-        if (ss.status == SYNCTEX_STATUS_OK) {\
-            _synctex_data_set_##WHAT(node,ss.string);\
-        } \
-        return ss.status;\
-    }\
-    return SYNCTEX_STATUS_BAD_ARGUMENT;\
-}
-#define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT); \
-DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT);
-#define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE_v(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT); \
-DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT);
-#define DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(WHAT) \
-DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT); \
-DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT);
+#define DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT)                                                                                                                   \
+    DEFINE_SYNCTEX_DATA_HAS(WHAT);                                                                                                                             \
+    static int _synctex_data_##WHAT(synctex_node_p node)                                                                                                       \
+    {                                                                                                                                                          \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            return __synctex_data(node)[node->class_->modelator->WHAT].as_integer;                                                                             \
+        }                                                                                                                                                      \
+        return 0;                                                                                                                                              \
+    }                                                                                                                                                          \
+    static int _synctex_data_set_##WHAT(synctex_node_p node, int new_value)                                                                                    \
+    {                                                                                                                                                          \
+        int old = 0;                                                                                                                                           \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            old = __synctex_data(node)[node->class_->modelator->WHAT].as_integer;                                                                              \
+            __synctex_data(node)[node->class_->modelator->WHAT].as_integer = new_value;                                                                        \
+        }                                                                                                                                                      \
+        return old;                                                                                                                                            \
+    }
+#define DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT)                                                                                                                   \
+    static synctex_status_t _synctex_data_decode_##WHAT(synctex_node_p node)                                                                                   \
+    {                                                                                                                                                          \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            _synctex_is_s is = _synctex_decode_int(node->class_->scanner);                                                                                     \
+            if (is.status == SYNCTEX_STATUS_OK) {                                                                                                              \
+                _synctex_data_set_##WHAT(node, is.integer);                                                                                                    \
+            }                                                                                                                                                  \
+            return is.status;                                                                                                                                  \
+        }                                                                                                                                                      \
+        return SYNCTEX_STATUS_BAD_ARGUMENT;                                                                                                                    \
+    }
+#define DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT)                                                                                                                 \
+    static synctex_status_t _synctex_data_decode_##WHAT##_v(synctex_node_p node)                                                                               \
+    {                                                                                                                                                          \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            _synctex_is_s is = _synctex_decode_int_v(node->class_->scanner);                                                                                   \
+            if (is.status == SYNCTEX_STATUS_OK) {                                                                                                              \
+                _synctex_data_set_##WHAT(node, is.integer);                                                                                                    \
+            }                                                                                                                                                  \
+            return is.status;                                                                                                                                  \
+        }                                                                                                                                                      \
+        return SYNCTEX_STATUS_BAD_ARGUMENT;                                                                                                                    \
+    }
+#define DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT)                                                                                                                   \
+    DEFINE_SYNCTEX_DATA_HAS(WHAT);                                                                                                                             \
+    static char *_synctex_data_##WHAT(synctex_node_p node)                                                                                                     \
+    {                                                                                                                                                          \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            return node->data[node->class_->navigator->size + node->class_->modelator->WHAT].as_string;                                                        \
+        }                                                                                                                                                      \
+        return NULL;                                                                                                                                           \
+    }                                                                                                                                                          \
+    static char *_synctex_data_set_##WHAT(synctex_node_p node, char *new_value)                                                                                \
+    {                                                                                                                                                          \
+        char *old = "";                                                                                                                                        \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            old = node->data[node->class_->navigator->size + node->class_->modelator->WHAT].as_string;                                                         \
+            node->data[node->class_->navigator->size + node->class_->modelator->WHAT].as_string = new_value;                                                   \
+        }                                                                                                                                                      \
+        return old;                                                                                                                                            \
+    }
+#define DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT)                                                                                                                   \
+    static synctex_status_t _synctex_data_decode_##WHAT(synctex_node_p node)                                                                                   \
+    {                                                                                                                                                          \
+        if (_synctex_data_has_##WHAT(node)) {                                                                                                                  \
+            _synctex_ss_s ss = _synctex_decode_string(node->class_->scanner);                                                                                  \
+            if (ss.status == SYNCTEX_STATUS_OK) {                                                                                                              \
+                _synctex_data_set_##WHAT(node, ss.string);                                                                                                     \
+            }                                                                                                                                                  \
+            return ss.status;                                                                                                                                  \
+        }                                                                                                                                                      \
+        return SYNCTEX_STATUS_BAD_ARGUMENT;                                                                                                                    \
+    }
+#define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(WHAT)                                                                                                            \
+    DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT);                                                                                                                      \
+    DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT);
+#define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE_v(WHAT)                                                                                                          \
+    DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT);                                                                                                                      \
+    DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT);
+#define DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(WHAT)                                                                                                            \
+    DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT);                                                                                                                      \
+    DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT);
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark OBJECTS, their creators and destructors.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark OBJECTS, their creators and destructors.
+#endif
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark input.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark input.
+#endif
 
 DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(tag);
 DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(line);
@@ -1734,7 +1759,7 @@ DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(name);
  *  The synctex information is the _synctex_data_tag and _synctex_data_name
  *  note: the input owns its name. */
 
-#   define SYNCTEX_INPUT_MARK "Input:"
+#define SYNCTEX_INPUT_MARK "Input:"
 
 static const _synctex_tree_model_s synctex_tree_model_input = {
     synctex_tree_sibling_idx, /* sibling */
@@ -1749,7 +1774,7 @@ static const _synctex_tree_model_s synctex_tree_model_input = {
 };
 static const _synctex_data_model_s synctex_data_model_input = {
     synctex_data_input_tag_idx, /* tag */
-    synctex_data_input_line_idx,/* line */
+    synctex_data_input_line_idx, /* line */
     -1, /* column */
     -1, /* h */
     -1, /* v */
@@ -1771,7 +1796,7 @@ static const _synctex_data_model_s synctex_data_model_input = {
 static synctex_node_p _synctex_new_input(synctex_scanner_p scanner);
 static void _synctex_free_input(synctex_node_p node);
 static void _synctex_log_input(synctex_node_p node);
-static char * _synctex_abstract_input(synctex_node_p node);
+static char *_synctex_abstract_input(synctex_node_p node);
 static void _synctex_display_input(synctex_node_p node);
 
 static const _synctex_tlcpector_s synctex_tlcpector_input = {
@@ -1781,18 +1806,18 @@ static const _synctex_tlcpector_s synctex_tlcpector_input = {
 };
 
 static _synctex_class_s _synctex_class_input = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_input,    /*  Node type */
-    &_synctex_new_input,        /*  creator */
-    &_synctex_free_input,       /*  destructor */
-    &_synctex_log_input,        /*  log */
-    &_synctex_display_input,    /*  display */
-    &_synctex_abstract_input,   /*  abstract */
-    &synctex_tree_model_input,  /*  tree model */
-    &synctex_data_model_input,  /*  data model */
-    &synctex_tlcpector_input,   /*  inspector */
-    &synctex_inspector_none,    /*  inspector */
-    &synctex_vispector_none,    /*  vispector */
+    NULL, /*  No scanner yet */
+    synctex_node_type_input, /*  Node type */
+    &_synctex_new_input, /*  creator */
+    &_synctex_free_input, /*  destructor */
+    &_synctex_log_input, /*  log */
+    &_synctex_display_input, /*  display */
+    &_synctex_abstract_input, /*  abstract */
+    &synctex_tree_model_input, /*  tree model */
+    &synctex_data_model_input, /*  data model */
+    &synctex_tlcpector_input, /*  inspector */
+    &synctex_inspector_none, /*  inspector */
+    &synctex_vispector_none, /*  vispector */
 };
 
 /**
@@ -1802,7 +1827,7 @@ static _synctex_class_s _synctex_class_input = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_s_input_max+synctex_data_input_tln_max];
+    _synctex_data_u data[synctex_tree_s_input_max + synctex_data_input_tln_max];
 } _synctex_input_s;
 
 /**
@@ -1811,13 +1836,14 @@ typedef struct {
  * @param scanner
  * @return synctex_node_p
  */
-static synctex_node_p _synctex_new_input(synctex_scanner_p scanner) {
+static synctex_node_p _synctex_new_input(synctex_scanner_p scanner)
+{
     if (scanner) {
         synctex_node_p node = _synctex_malloc(sizeof(_synctex_input_s));
         if (node) {
-            node->class_ = scanner->class_+synctex_node_type_input;
+            node->class_ = scanner->class_ + synctex_node_type_input;
             SYNCTEX_DID_NEW(node);
-            SYNCTEX_IMPLEMENT_CHARINDEX(node,0);
+            SYNCTEX_IMPLEMENT_CHARINDEX(node, 0);
             SYNCTEX_REGISTER_HANDLE_TO(node);
         }
         return node;
@@ -1830,7 +1856,8 @@ static synctex_node_p _synctex_new_input(synctex_scanner_p scanner) {
  *
  * @param node
  */
-static void _synctex_free_input(synctex_node_p node){
+static void _synctex_free_input(synctex_node_p node)
+{
     if (node) {
         SYNCTEX_SCANNER_REMOVE_HANDLE_TO(node);
         SYNCTEX_WILL_FREE(node);
@@ -1848,9 +1875,9 @@ static void _synctex_free_input(synctex_node_p node){
  *  This is the 1 based page index as given by TeX.
  */
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark sheet.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark sheet.
+#endif
 /**
  *  Every node has the same structure, but not the same size.
  */
@@ -1860,32 +1887,33 @@ DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(page);
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_scn_sheet_max+synctex_data_p_sheet_max];
+    _synctex_data_u data[synctex_tree_scn_sheet_max + synctex_data_p_sheet_max];
 } _synctex_node_sheet_s;
 
 /*  sheet node creator */
 
-#define DEFINE_synctex_new_scanned_NODE(NAME)\
-static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scanner) {\
-    if (scanner) {\
-        ++SYNCTEX_CUR;\
-        synctex_node_p node = _synctex_malloc(sizeof(_synctex_node_##NAME##_s));\
-        if (node) {\
-            node->class_ = scanner->class_+synctex_node_type_##NAME;\
-            SYNCTEX_DID_NEW(node); \
-            SYNCTEX_IMPLEMENT_CHARINDEX(node,-1);\
-            SYNCTEX_REGISTER_HANDLE_TO(node); \
-        }\
-        return node;\
-    }\
-    return NULL;\
-}
+#define DEFINE_synctex_new_scanned_NODE(NAME)                                                                                                                  \
+    static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scanner)                                                                                       \
+    {                                                                                                                                                          \
+        if (scanner) {                                                                                                                                         \
+            ++SYNCTEX_CUR;                                                                                                                                     \
+            synctex_node_p node = _synctex_malloc(sizeof(_synctex_node_##NAME##_s));                                                                           \
+            if (node) {                                                                                                                                        \
+                node->class_ = scanner->class_ + synctex_node_type_##NAME;                                                                                     \
+                SYNCTEX_DID_NEW(node);                                                                                                                         \
+                SYNCTEX_IMPLEMENT_CHARINDEX(node, -1);                                                                                                         \
+                SYNCTEX_REGISTER_HANDLE_TO(node);                                                                                                              \
+            }                                                                                                                                                  \
+            return node;                                                                                                                                       \
+        }                                                                                                                                                      \
+        return NULL;                                                                                                                                           \
+    }
 /*  NB: -1 in SYNCTEX_IMPLEMENT_CHARINDEX above because
  *  the first char of the line has been scanned
  */
 DEFINE_synctex_new_scanned_NODE(sheet);
 static void _synctex_log_sheet(synctex_node_p node);
-static char * _synctex_abstract_sheet(synctex_node_p node);
+static char *_synctex_abstract_sheet(synctex_node_p node);
 static void _synctex_display_sheet(synctex_node_p node);
 
 static const _synctex_tree_model_s synctex_tree_model_sheet = {
@@ -1920,35 +1948,35 @@ static const _synctex_data_model_s synctex_data_model_sheet = {
     synctex_data_p_sheet_max,
 };
 static _synctex_class_s _synctex_class_sheet = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_sheet,    /*  Node type */
-    &_synctex_new_sheet,        /*  creator */
-    &_synctex_free_node,        /*  destructor */
-    &_synctex_log_sheet,        /*  log */
-    &_synctex_display_sheet,    /*  display */
-    &_synctex_abstract_sheet,   /*  abstract */
-    &synctex_tree_model_sheet,  /*  tree model */
-    &synctex_data_model_sheet,  /*  data model */
-    &synctex_tlcpector_none,    /*  tlcpector */
-    &synctex_inspector_none,    /*  inspector */
-    &synctex_vispector_none,    /*  vispector */
+    NULL, /*  No scanner yet */
+    synctex_node_type_sheet, /*  Node type */
+    &_synctex_new_sheet, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_sheet, /*  log */
+    &_synctex_display_sheet, /*  display */
+    &_synctex_abstract_sheet, /*  abstract */
+    &synctex_tree_model_sheet, /*  tree model */
+    &synctex_data_model_sheet, /*  data model */
+    &synctex_tlcpector_none, /*  tlcpector */
+    &synctex_inspector_none, /*  inspector */
+    &synctex_vispector_none, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark form.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark form.
+#endif
 /**
  *  Every node has the same structure, but not the same size.
  */
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_sct_form_max+synctex_data_t_form_max];
+    _synctex_data_u data[synctex_tree_sct_form_max + synctex_data_t_form_max];
 } _synctex_node_form_s;
 
 DEFINE_synctex_new_scanned_NODE(form);
 
-static char * _synctex_abstract_form(synctex_node_p node);
+static char *_synctex_abstract_form(synctex_node_p node);
 static void _synctex_display_form(synctex_node_p node);
 static void _synctex_log_form(synctex_node_p node);
 
@@ -1988,26 +2016,27 @@ static const _synctex_tlcpector_s synctex_tlcpector_form = {
     &_synctex_data_tag, /* tag */
     &_synctex_int_none, /* line */
     &_synctex_int_none, /* column */
-};;
+};
+;
 
 static _synctex_class_s _synctex_class_form = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_form,     /*  Node type */
-    &_synctex_new_form,         /*  creator */
-    &_synctex_free_node,        /*  destructor */
-    &_synctex_log_form,         /*  log */
-    &_synctex_display_form,     /*  display */
-    &_synctex_abstract_form,    /*  abstract */
-    &synctex_tree_model_form,   /*  tree model */
-    &synctex_data_model_form,   /*  data model */
-    &synctex_tlcpector_form,   /*  tnspector */
-    &synctex_inspector_none,    /*  inspector */
-    &synctex_vispector_none,    /*  vispector */
+    NULL, /*  No scanner yet */
+    synctex_node_type_form, /*  Node type */
+    &_synctex_new_form, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_form, /*  log */
+    &_synctex_display_form, /*  display */
+    &_synctex_abstract_form, /*  abstract */
+    &synctex_tree_model_form, /*  tree model */
+    &synctex_data_model_form, /*  data model */
+    &synctex_tlcpector_form, /*  tnspector */
+    &synctex_inspector_none, /*  inspector */
+    &synctex_vispector_none, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark vbox.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark vbox.
+#endif
 
 /*  A box node contains navigation and synctex information
  *  There are different kinds of boxes.
@@ -2016,22 +2045,22 @@ static _synctex_class_s _synctex_class_form = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spcfl_vbox_max+synctex_data_box_max];
+    _synctex_data_u data[synctex_tree_spcfl_vbox_max + synctex_data_box_max];
 } _synctex_node_vbox_s;
 
 /*  vertical box node creator */
 DEFINE_synctex_new_scanned_NODE(vbox);
 
-static char * _synctex_abstract_vbox(synctex_node_p node);
+static char *_synctex_abstract_vbox(synctex_node_p node);
 static void _synctex_display_vbox(synctex_node_p node);
 static void _synctex_log_vbox(synctex_node_p node);
 
 static const _synctex_tree_model_s synctex_tree_model_vbox = {
-    synctex_tree_sibling_idx,       /* sibling */
-    synctex_tree_s_parent_idx,      /* parent */
-    synctex_tree_sp_child_idx,      /* child */
-    synctex_tree_spc_friend_idx,    /* friend */
-    synctex_tree_spcf_last_idx,     /* last */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
+    synctex_tree_sp_child_idx, /* child */
+    synctex_tree_spc_friend_idx, /* friend */
+    synctex_tree_spcf_last_idx, /* last */
     -1, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
@@ -2041,12 +2070,12 @@ static const _synctex_tree_model_s synctex_tree_model_vbox = {
 #define SYNCTEX_DFLT_COLUMN -1
 
 DEFINE_SYNCTEX_DATA_INT_GETSET(column);
-static synctex_status_t _synctex_data_decode_column(synctex_node_p node) {
+static synctex_status_t _synctex_data_decode_column(synctex_node_p node)
+{
     if (_synctex_data_has_column(node)) {
-        _synctex_is_s is = _synctex_decode_int_opt(node->class_->scanner,
-            SYNCTEX_DFLT_COLUMN);
+        _synctex_is_s is = _synctex_decode_int_opt(node->class_->scanner, SYNCTEX_DFLT_COLUMN);
         if (is.status == SYNCTEX_STATUS_OK) {
-            _synctex_data_set_column(node,is.integer);
+            _synctex_data_set_column(node, is.integer);
         }
         return is.status;
     }
@@ -2063,25 +2092,27 @@ DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(width);
 DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(height);
 DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(depth);
 
-SYNCTEX_INLINE static void _synctex_data_set_tlc(synctex_node_p node, synctex_node_p model) {
+SYNCTEX_INLINE static void _synctex_data_set_tlc(synctex_node_p node, synctex_node_p model)
+{
     _synctex_data_set_tag(node, _synctex_data_tag(model));
     _synctex_data_set_line(node, _synctex_data_line(model));
     _synctex_data_set_column(node, _synctex_data_column(model));
 }
-SYNCTEX_INLINE static void _synctex_data_set_tlchv(synctex_node_p node, synctex_node_p model) {
-    _synctex_data_set_tlc(node,model);
+SYNCTEX_INLINE static void _synctex_data_set_tlchv(synctex_node_p node, synctex_node_p model)
+{
+    _synctex_data_set_tlc(node, model);
     _synctex_data_set_h(node, _synctex_data_h(model));
     _synctex_data_set_v(node, _synctex_data_v(model));
 }
 
 static const _synctex_data_model_s synctex_data_model_box = {
     synctex_data_tag_idx, /* tag */
-    synctex_data_line_idx,  /* line */
-    synctex_data_column_idx,/* column */
-    synctex_data_h_idx,     /* h */
-    synctex_data_v_idx,     /* v */
+    synctex_data_line_idx, /* line */
+    synctex_data_column_idx, /* column */
+    synctex_data_h_idx, /* h */
+    synctex_data_v_idx, /* v */
     synctex_data_width_idx, /* width */
-    synctex_data_height_idx,/* height */
+    synctex_data_height_idx, /* height */
     synctex_data_depth_idx, /* depth */
     -1, /* mean_line */
     -1, /* weight */
@@ -2121,33 +2152,33 @@ static _synctex_vispector_s _synctex_vispector_box = {
 /*  These are static class objects, each scanner will make a copy of them and setup the scanner field.
  */
 static _synctex_class_s _synctex_class_vbox = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_vbox,     /*  Node type */
-    &_synctex_new_vbox,         /*  creator */
-    &_synctex_free_node,        /*  destructor */
-    &_synctex_log_vbox,         /*  log */
-    &_synctex_display_vbox,     /*  display */
-    &_synctex_abstract_vbox,    /*  abstract */
-    &synctex_tree_model_vbox,   /*  tree model */
-    &synctex_data_model_box,    /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_vbox, /*  Node type */
+    &_synctex_new_vbox, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_vbox, /*  log */
+    &_synctex_display_vbox, /*  display */
+    &_synctex_abstract_vbox, /*  abstract */
+    &synctex_tree_model_vbox, /*  tree model */
+    &synctex_data_model_box, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &_synctex_inspector_box,     /*  inspector */
-    &_synctex_vispector_box,     /*  vispector */
+    &_synctex_inspector_box, /*  inspector */
+    &_synctex_vispector_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark hbox.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark hbox.
+#endif
 
 /*  Horizontal boxes must contain visible size, because 0 width does not mean emptiness.
  *  They also contain an average of the line numbers of the containing nodes. */
 
 static const _synctex_tree_model_s synctex_tree_model_hbox = {
-    synctex_tree_sibling_idx,       /* sibling */
-    synctex_tree_s_parent_idx,      /* parent */
-    synctex_tree_sp_child_idx,      /* child */
-    synctex_tree_spc_friend_idx,    /* friend */
-    synctex_tree_spcf_last_idx,     /* last */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
+    synctex_tree_sp_child_idx, /* child */
+    synctex_tree_spc_friend_idx, /* friend */
+    synctex_tree_spcf_last_idx, /* last */
     synctex_tree_spcfl_next_hbox_idx, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
@@ -2175,12 +2206,12 @@ DEFINE_SYNCTEX_DATA_INT_GETSET(depth_V);
 
 static const _synctex_data_model_s synctex_data_model_hbox = {
     synctex_data_tag_idx, /* tag */
-    synctex_data_line_idx,  /* line */
-    synctex_data_column_idx,/* column */
-    synctex_data_h_idx,     /* h */
-    synctex_data_v_idx,     /* v */
+    synctex_data_line_idx, /* line */
+    synctex_data_column_idx, /* column */
+    synctex_data_h_idx, /* h */
+    synctex_data_v_idx, /* v */
     synctex_data_width_idx, /* width */
-    synctex_data_height_idx,/* height */
+    synctex_data_height_idx, /* height */
     synctex_data_depth_idx, /* depth */
     synctex_data_mean_line_idx, /* mean_line */
     synctex_data_weight_idx, /* weight */
@@ -2197,41 +2228,41 @@ static const _synctex_data_model_s synctex_data_model_hbox = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spcfln_hbox_max+synctex_data_hbox_max];
+    _synctex_data_u data[synctex_tree_spcfln_hbox_max + synctex_data_hbox_max];
 } _synctex_node_hbox_s;
 
 /*  horizontal box node creator */
 DEFINE_synctex_new_scanned_NODE(hbox);
 
 static void _synctex_log_hbox(synctex_node_p node);
-static char * _synctex_abstract_hbox(synctex_node_p node);
+static char *_synctex_abstract_hbox(synctex_node_p node);
 static void _synctex_display_hbox(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_hbox = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_hbox,     /*  Node type */
-    &_synctex_new_hbox,         /*  creator */
-    &_synctex_free_node,        /*  destructor */
-    &_synctex_log_hbox,         /*  log */
-    &_synctex_display_hbox,     /*  display */
-    &_synctex_abstract_hbox,    /*  abstract */
-    &synctex_tree_model_hbox,   /*  tree model */
-    &synctex_data_model_hbox,   /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_hbox, /*  Node type */
+    &_synctex_new_hbox, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_hbox, /*  log */
+    &_synctex_display_hbox, /*  display */
+    &_synctex_abstract_hbox, /*  abstract */
+    &synctex_tree_model_hbox, /*  tree model */
+    &synctex_data_model_hbox, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &_synctex_inspector_box,     /*  inspector */
-    &_synctex_vispector_box,     /*  vispector */
+    &_synctex_inspector_box, /*  inspector */
+    &_synctex_vispector_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark void vbox.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark void vbox.
+#endif
 
 /*  This void box node implementation is either horizontal or vertical
  *  It does not contain a child field.
  */
 static const _synctex_tree_model_s synctex_tree_model_spf = {
-    synctex_tree_sibling_idx,   /* sibling */
-    synctex_tree_s_parent_idx,  /* parent */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
     -1, /* child */
     synctex_tree_sp_friend_idx, /* friend */
     -1, /* last */
@@ -2243,79 +2274,79 @@ static const _synctex_tree_model_s synctex_tree_model_spf = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spf_max+synctex_data_box_max];
+    _synctex_data_u data[synctex_tree_spf_max + synctex_data_box_max];
 } _synctex_node_void_vbox_s;
 
 /*  vertical void box node creator */
 DEFINE_synctex_new_scanned_NODE(void_vbox);
 
 static void _synctex_log_void_box(synctex_node_p node);
-static char * _synctex_abstract_void_vbox(synctex_node_p node);
+static char *_synctex_abstract_void_vbox(synctex_node_p node);
 static void _synctex_display_void_vbox(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_void_vbox = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_void_vbox,/*  Node type */
-    &_synctex_new_void_vbox,    /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_void_box,     /*  log */
-    &_synctex_display_void_vbox,/*  display */
-    &_synctex_abstract_void_vbox,/*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_box,    /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_void_vbox, /*  Node type */
+    &_synctex_new_void_vbox, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_void_box, /*  log */
+    &_synctex_display_void_vbox, /*  display */
+    &_synctex_abstract_void_vbox, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_box, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &_synctex_inspector_box,     /*  inspector */
-    &_synctex_vispector_box,     /*  vispector */
+    &_synctex_inspector_box, /*  inspector */
+    &_synctex_vispector_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark void hbox.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark void hbox.
+#endif
 
 typedef _synctex_node_void_vbox_s _synctex_node_void_hbox_s;
 
 /*  horizontal void box node creator */
 DEFINE_synctex_new_scanned_NODE(void_hbox);
 
-static char * _synctex_abstract_void_hbox(synctex_node_p node);
+static char *_synctex_abstract_void_hbox(synctex_node_p node);
 static void _synctex_display_void_hbox(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_void_hbox = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_void_hbox,/*  Node type */
-    &_synctex_new_void_hbox,    /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_void_box,     /*  log */
-    &_synctex_display_void_hbox,/*  display */
-    &_synctex_abstract_void_hbox,/*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_box,    /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_void_hbox, /*  Node type */
+    &_synctex_new_void_hbox, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_void_box, /*  log */
+    &_synctex_display_void_hbox, /*  display */
+    &_synctex_abstract_void_hbox, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_box, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &_synctex_inspector_box,     /*  inspector */
-    &_synctex_vispector_box,     /*  vispector */
+    &_synctex_inspector_box, /*  inspector */
+    &_synctex_vispector_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark form ref.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark form ref.
+#endif
 
 /*  The form ref node.  */
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spfa_max+synctex_data_ref_thv_max];
+    _synctex_data_u data[synctex_tree_spfa_max + synctex_data_ref_thv_max];
 } _synctex_node_ref_s;
 
 /*  form ref node creator */
 DEFINE_synctex_new_scanned_NODE(ref);
 
 static void _synctex_log_ref(synctex_node_p node);
-static char * _synctex_abstract_ref(synctex_node_p node);
+static char *_synctex_abstract_ref(synctex_node_p node);
 static void _synctex_display_ref(synctex_node_p node);
 
 static const _synctex_tree_model_s synctex_tree_model_spfa = {
-    synctex_tree_sibling_idx,   /* sibling */
-    synctex_tree_s_parent_idx,  /* parent */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
     -1, /* child */
     synctex_tree_sp_friend_idx, /* friend */
     -1, /* last */
@@ -2345,22 +2376,22 @@ static const _synctex_data_model_s synctex_data_model_ref = {
     synctex_data_ref_thv_max, /* size */
 };
 static _synctex_class_s _synctex_class_ref = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_ref,      /*  Node type */
-    &_synctex_new_ref,          /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_ref,          /*  log */
-    &_synctex_display_ref,      /*  display */
-    &_synctex_abstract_ref,     /*  abstract */
-    &synctex_tree_model_spfa,   /*  navigator */
-    &synctex_data_model_ref,    /*  data model */
-    &synctex_tlcpector_none,    /*  tlcpector */
-    &synctex_inspector_none,    /*  inspector */
-    &synctex_vispector_none,    /*  vispector */
+    NULL, /*  No scanner yet */
+    synctex_node_type_ref, /*  Node type */
+    &_synctex_new_ref, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_ref, /*  log */
+    &_synctex_display_ref, /*  display */
+    &_synctex_abstract_ref, /*  abstract */
+    &synctex_tree_model_spfa, /*  navigator */
+    &synctex_data_model_ref, /*  data model */
+    &synctex_tlcpector_none, /*  tlcpector */
+    &synctex_inspector_none, /*  inspector */
+    &synctex_vispector_none, /*  vispector */
 };
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark small node.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark small node.
+#endif
 
 /*  The small nodes correspond to glue, penalty, math and boundary nodes. */
 static const _synctex_data_model_s synctex_data_model_tlchv = {
@@ -2387,21 +2418,21 @@ static const _synctex_data_model_s synctex_data_model_tlchv = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spf_max+synctex_data_tlchv_max];
+    _synctex_data_u data[synctex_tree_spf_max + synctex_data_tlchv_max];
 } _synctex_node_tlchv_s;
 
 static void _synctex_log_tlchv_node(synctex_node_p node);
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark math.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark math.
+#endif
 
 typedef _synctex_node_tlchv_s _synctex_node_math_s;
 
 /*  math node creator */
 DEFINE_synctex_new_scanned_NODE(math);
 
-static char * _synctex_abstract_math(synctex_node_p node);
+static char *_synctex_abstract_math(synctex_node_p node);
 static void _synctex_display_math(synctex_node_p node);
 static _synctex_inspector_s synctex_inspector_hv = {
     &_synctex_data_h,
@@ -2419,30 +2450,30 @@ static _synctex_vispector_s synctex_vispector_hv = {
 };
 
 static _synctex_class_s _synctex_class_math = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_math,     /*  Node type */
-    &_synctex_new_math,         /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_tlchv_node,   /*  log */
-    &_synctex_display_math,     /*  display */
-    &_synctex_abstract_math,    /*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_tlchv,  /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_math, /*  Node type */
+    &_synctex_new_math, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_tlchv_node, /*  log */
+    &_synctex_display_math, /*  display */
+    &_synctex_abstract_math, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_tlchv, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &synctex_inspector_hv,      /*  inspector */
-    &synctex_vispector_hv,      /*  vispector */
+    &synctex_inspector_hv, /*  inspector */
+    &synctex_vispector_hv, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark kern node.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark kern node.
+#endif
 
 static const _synctex_data_model_s synctex_data_model_tlchvw = {
-    synctex_data_tag_idx,   /* tag */
-    synctex_data_line_idx,  /* line */
-    synctex_data_column_idx,/* column */
-    synctex_data_h_idx,     /* h */
-    synctex_data_v_idx,     /* v */
+    synctex_data_tag_idx, /* tag */
+    synctex_data_line_idx, /* line */
+    synctex_data_column_idx, /* column */
+    synctex_data_h_idx, /* h */
+    synctex_data_v_idx, /* v */
     synctex_data_width_idx, /* width */
     -1, /* height */
     -1, /* depth */
@@ -2460,14 +2491,14 @@ static const _synctex_data_model_s synctex_data_model_tlchvw = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spf_max+synctex_data_tlchvw_max];
+    _synctex_data_u data[synctex_tree_spf_max + synctex_data_tlchvw_max];
 } _synctex_node_kern_s;
 
 /*  kern node creator */
 DEFINE_synctex_new_scanned_NODE(kern);
 
 static void _synctex_log_kern_node(synctex_node_p node);
-static char * _synctex_abstract_kern(synctex_node_p node);
+static char *_synctex_abstract_kern(synctex_node_p node);
 static void _synctex_display_kern(synctex_node_p node);
 
 static _synctex_inspector_s synctex_inspector_kern = {
@@ -2488,62 +2519,62 @@ static _synctex_vispector_s synctex_vispector_kern = {
 };
 
 static _synctex_class_s _synctex_class_kern = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_kern,     /*  Node type */
-    &_synctex_new_kern,         /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_kern_node,    /*  log */
-    &_synctex_display_kern,     /*  display */
-    &_synctex_abstract_kern,    /*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_kern, /*  Node type */
+    &_synctex_new_kern, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_kern_node, /*  log */
+    &_synctex_display_kern, /*  display */
+    &_synctex_abstract_kern, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
     &synctex_data_model_tlchvw, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &synctex_inspector_kern,    /*  inspector */
-    &synctex_vispector_kern,    /*  vispector */
+    &synctex_inspector_kern, /*  inspector */
+    &synctex_vispector_kern, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark glue.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark glue.
+#endif
 
 /*  glue node creator */
 typedef _synctex_node_tlchv_s _synctex_node_glue_s;
 DEFINE_synctex_new_scanned_NODE(glue);
 
-static char * _synctex_abstract_glue(synctex_node_p node);
+static char *_synctex_abstract_glue(synctex_node_p node);
 static void _synctex_display_glue(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_glue = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_glue,     /*  Node type */
-    &_synctex_new_glue,         /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_tlchv_node,   /*  log */
-    &_synctex_display_glue,     /*  display */
-    &_synctex_abstract_glue,    /*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_tlchv,  /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_glue, /*  Node type */
+    &_synctex_new_glue, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_tlchv_node, /*  log */
+    &_synctex_display_glue, /*  display */
+    &_synctex_abstract_glue, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_tlchv, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &synctex_inspector_hv,      /*  inspector */
-    &synctex_vispector_hv,      /*  vispector */
+    &synctex_inspector_hv, /*  inspector */
+    &synctex_vispector_hv, /*  vispector */
 };
 
 /*  The small nodes correspond to glue and boundary nodes.  */
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark rule.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark rule.
+#endif
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spf_max+synctex_data_box_max];
+    _synctex_data_u data[synctex_tree_spf_max + synctex_data_box_max];
 } _synctex_node_rule_s;
 
 DEFINE_synctex_new_scanned_NODE(rule);
 
 static void _synctex_log_rule(synctex_node_p node);
-static char * _synctex_abstract_rule(synctex_node_p node);
+static char *_synctex_abstract_rule(synctex_node_p node);
 static void _synctex_display_rule(synctex_node_p node);
 
 static float __synctex_rule_visible_h(synctex_node_p node);
@@ -2560,91 +2591,92 @@ static _synctex_vispector_s _synctex_vispector_rule = {
 };
 
 static _synctex_class_s _synctex_class_rule = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_rule,     /*  Node type */
-    &_synctex_new_rule,         /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_rule,         /*  log */
-    &_synctex_display_rule,     /*  display */
-    &_synctex_abstract_rule,    /*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_box,    /*  data model */
+    NULL, /*  No scanner yet */
+    synctex_node_type_rule, /*  Node type */
+    &_synctex_new_rule, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_rule, /*  log */
+    &_synctex_display_rule, /*  display */
+    &_synctex_abstract_rule, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_box, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &_synctex_inspector_box,     /*  inspector */
-    &_synctex_vispector_rule,    /*  vispector */
+    &_synctex_inspector_box, /*  inspector */
+    &_synctex_vispector_rule, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark boundary.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark boundary.
+#endif
 
 /*  boundary node creator */
 typedef _synctex_node_tlchv_s _synctex_node_boundary_s;
 DEFINE_synctex_new_scanned_NODE(boundary);
 
-static char * _synctex_abstract_boundary(synctex_node_p node);
+static char *_synctex_abstract_boundary(synctex_node_p node);
 static void _synctex_display_boundary(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_boundary = {
-    NULL,                       /*  No scanner yet */
+    NULL, /*  No scanner yet */
     synctex_node_type_boundary, /*  Node type */
-    &_synctex_new_boundary,     /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_tlchv_node,   /*  log */
+    &_synctex_new_boundary, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_tlchv_node, /*  log */
     &_synctex_display_boundary, /*  display */
-    &_synctex_abstract_boundary,/*  abstract */
-    &synctex_tree_model_spf,    /*  tree model */
-    &synctex_data_model_tlchv,  /*  data model */
+    &_synctex_abstract_boundary, /*  abstract */
+    &synctex_tree_model_spf, /*  tree model */
+    &synctex_data_model_tlchv, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &synctex_inspector_hv,      /*  inspector */
-    &synctex_vispector_hv,      /*  vispector */
+    &synctex_inspector_hv, /*  inspector */
+    &synctex_vispector_hv, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark box boundary.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark box boundary.
+#endif
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spfa_max+synctex_data_tlchv_max];
+    _synctex_data_u data[synctex_tree_spfa_max + synctex_data_tlchv_max];
 } _synctex_node_box_bdry_s;
 
-#define DEFINE_synctex_new_unscanned_NODE(NAME)\
-SYNCTEX_INLINE static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scanner) {\
-    if (scanner) {\
-        synctex_node_p node = _synctex_malloc(sizeof(_synctex_node_##NAME##_s));\
-        if (node) {\
-            node->class_ = scanner->class_+synctex_node_type_##NAME;\
-            SYNCTEX_DID_NEW(node); \
-        }\
-        return node;\
-    }\
-    return NULL;\
-}
+#define DEFINE_synctex_new_unscanned_NODE(NAME)                                                                                                                \
+    SYNCTEX_INLINE static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scanner)                                                                        \
+    {                                                                                                                                                          \
+        if (scanner) {                                                                                                                                         \
+            synctex_node_p node = _synctex_malloc(sizeof(_synctex_node_##NAME##_s));                                                                           \
+            if (node) {                                                                                                                                        \
+                node->class_ = scanner->class_ + synctex_node_type_##NAME;                                                                                     \
+                SYNCTEX_DID_NEW(node);                                                                                                                         \
+            }                                                                                                                                                  \
+            return node;                                                                                                                                       \
+        }                                                                                                                                                      \
+        return NULL;                                                                                                                                           \
+    }
 DEFINE_synctex_new_unscanned_NODE(box_bdry);
 
-static char * _synctex_abstract_box_bdry(synctex_node_p node);
+static char *_synctex_abstract_box_bdry(synctex_node_p node);
 static void _synctex_display_box_bdry(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_box_bdry = {
-    NULL,                       /*  No scanner yet */
+    NULL, /*  No scanner yet */
     synctex_node_type_box_bdry, /*  Node type */
-    &_synctex_new_box_bdry,     /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_tlchv_node,   /*  log */
+    &_synctex_new_box_bdry, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_tlchv_node, /*  log */
     &_synctex_display_box_bdry, /*  display */
-    &_synctex_abstract_box_bdry,/*  display */
-    &synctex_tree_model_spfa,   /*  tree model */
-    &synctex_data_model_tlchv,  /*  data model */
+    &_synctex_abstract_box_bdry, /*  display */
+    &synctex_tree_model_spfa, /*  tree model */
+    &synctex_data_model_tlchv, /*  data model */
     &synctex_tlcpector_default, /*  tlcpector */
-    &synctex_inspector_hv,      /*  inspector */
-    &synctex_vispector_hv,      /*  vispector */
+    &synctex_inspector_hv, /*  inspector */
+    &synctex_vispector_hv, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark hbox proxy.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark hbox proxy.
+#endif
 
 /**
  *  Standard nodes refer to TeX nodes: math, kern, boxes...
@@ -2719,12 +2751,12 @@ static _synctex_class_s _synctex_class_box_bdry = {
  */
 
 static const _synctex_tree_model_s synctex_tree_model_proxy_hbox = {
-    synctex_tree_sibling_idx,       /* sibling */
-    synctex_tree_s_parent_idx,      /* parent */
-    synctex_tree_sp_child_idx,      /* child */
-    synctex_tree_spc_friend_idx,    /* friend */
-    synctex_tree_spcf_last_idx,     /* last */
-    synctex_tree_spcfl_next_hbox_idx,   /* next_hbox */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
+    synctex_tree_sp_child_idx, /* child */
+    synctex_tree_spc_friend_idx, /* friend */
+    synctex_tree_spcf_last_idx, /* last */
+    synctex_tree_spcfl_next_hbox_idx, /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_spcfln_target_idx, /* target */
     synctex_tree_spcflnt_proxy_hbox_max,
@@ -2752,14 +2784,14 @@ static const _synctex_data_model_s synctex_data_model_proxy = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spcflnt_proxy_hbox_max+synctex_data_proxy_hv_max];
+    _synctex_data_u data[synctex_tree_spcflnt_proxy_hbox_max + synctex_data_proxy_hv_max];
 } _synctex_node_proxy_hbox_s;
 
 /*  box proxy node creator */
 DEFINE_synctex_new_unscanned_NODE(proxy_hbox);
 
 static void _synctex_log_proxy(synctex_node_p node);
-static char * _synctex_abstract_proxy_hbox(synctex_node_p node);
+static char *_synctex_abstract_proxy_hbox(synctex_node_p node);
 static void _synctex_display_proxy_hbox(synctex_node_p node);
 
 static int _synctex_proxy_tag(synctex_node_p);
@@ -2799,97 +2831,97 @@ static _synctex_vispector_s synctex_vispector_proxy_box = {
 };
 
 static _synctex_class_s _synctex_class_proxy_hbox = {
-    NULL,                           /*  No scanner yet */
-    synctex_node_type_proxy_hbox,   /*  Node type */
-    &_synctex_new_proxy_hbox,       /*  creator */
-    &_synctex_free_node,            /*  destructor */
-    &_synctex_log_proxy,            /*  log */
-    &_synctex_display_proxy_hbox,   /*  display */
-    &_synctex_abstract_proxy_hbox,  /*  abstract */
+    NULL, /*  No scanner yet */
+    synctex_node_type_proxy_hbox, /*  Node type */
+    &_synctex_new_proxy_hbox, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_proxy, /*  log */
+    &_synctex_display_proxy_hbox, /*  display */
+    &_synctex_abstract_proxy_hbox, /*  abstract */
     &synctex_tree_model_proxy_hbox, /*  tree model */
-    &synctex_data_model_proxy,      /*  data model */
-    &synctex_tlcpector_proxy,       /*  tlcpector */
-    &synctex_inspector_proxy_box,   /*  inspector */
-    &synctex_vispector_proxy_box,   /*  vispector */
+    &synctex_data_model_proxy, /*  data model */
+    &synctex_tlcpector_proxy, /*  tlcpector */
+    &synctex_inspector_proxy_box, /*  inspector */
+    &synctex_vispector_proxy_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark vbox proxy.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark vbox proxy.
+#endif
 
 /*  A proxy to a vbox. */
 
 static const _synctex_tree_model_s synctex_tree_model_proxy_vbox = {
-    synctex_tree_sibling_idx,       /* sibling */
-    synctex_tree_s_parent_idx,      /* parent */
-    synctex_tree_sp_child_idx,      /* child */
-    synctex_tree_spc_friend_idx,    /* friend */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
+    synctex_tree_sp_child_idx, /* child */
+    synctex_tree_spc_friend_idx, /* friend */
     synctex_tree_spcf_last_idx, /* last */
     -1, /* next_hbox */
     -1, /* arg_sibling */
-    synctex_tree_spcfl_target_idx,    /* target */
+    synctex_tree_spcfl_target_idx, /* target */
     synctex_tree_spcflt_proxy_vbox_max,
 };
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spcflt_proxy_vbox_max+synctex_data_proxy_hv_max];
+    _synctex_data_u data[synctex_tree_spcflt_proxy_vbox_max + synctex_data_proxy_hv_max];
 } _synctex_node_proxy_vbox_s;
 
 /*  box proxy node creator */
 DEFINE_synctex_new_unscanned_NODE(proxy_vbox);
 
 static void _synctex_log_proxy(synctex_node_p node);
-static char * _synctex_abstract_proxy_vbox(synctex_node_p node);
+static char *_synctex_abstract_proxy_vbox(synctex_node_p node);
 static void _synctex_display_proxy_vbox(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_proxy_vbox = {
-    NULL,                           /*  No scanner yet */
-    synctex_node_type_proxy_vbox,   /*  Node type */
-    &_synctex_new_proxy_vbox,       /*  creator */
-    &_synctex_free_node,            /*  destructor */
-    &_synctex_log_proxy,            /*  log */
-    &_synctex_display_proxy_vbox,   /*  display */
-    &_synctex_abstract_proxy_vbox,  /*  abstract */
+    NULL, /*  No scanner yet */
+    synctex_node_type_proxy_vbox, /*  Node type */
+    &_synctex_new_proxy_vbox, /*  creator */
+    &_synctex_free_node, /*  destructor */
+    &_synctex_log_proxy, /*  log */
+    &_synctex_display_proxy_vbox, /*  display */
+    &_synctex_abstract_proxy_vbox, /*  abstract */
     &synctex_tree_model_proxy_vbox, /*  tree model */
-    &synctex_data_model_proxy,      /*  data model */
-    &synctex_tlcpector_proxy,       /*  tlcpector */
-    &synctex_inspector_proxy_box,   /*  inspector */
-    &synctex_vispector_proxy_box,   /*  vispector */
+    &synctex_data_model_proxy, /*  data model */
+    &synctex_tlcpector_proxy, /*  tlcpector */
+    &synctex_inspector_proxy_box, /*  inspector */
+    &synctex_vispector_proxy_box, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark proxy.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark proxy.
+#endif
 
 /**
  *  A proxy to a node but a box.
  */
 
 static const _synctex_tree_model_s synctex_tree_model_proxy = {
-    synctex_tree_sibling_idx,   /* sibling */
-    synctex_tree_s_parent_idx,  /* parent */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
     -1, /* child */
     synctex_tree_sp_friend_idx, /* friend */
     -1, /* last */
     -1, /* next_hbox */
     -1, /* arg_sibling */
-    synctex_tree_spf_target_idx,/* target */
+    synctex_tree_spf_target_idx, /* target */
     synctex_tree_spft_proxy_max,
 };
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spft_proxy_max+synctex_data_proxy_hv_max];
+    _synctex_data_u data[synctex_tree_spft_proxy_max + synctex_data_proxy_hv_max];
 } _synctex_node_proxy_s;
 
 /*  proxy node creator */
 DEFINE_synctex_new_unscanned_NODE(proxy);
 
 static void _synctex_log_proxy(synctex_node_p node);
-static char * _synctex_abstract_proxy(synctex_node_p node);
+static char *_synctex_abstract_proxy(synctex_node_p node);
 static void _synctex_display_proxy(synctex_node_p node);
 
 static _synctex_vispector_s synctex_vispector_proxy = {
@@ -2901,71 +2933,71 @@ static _synctex_vispector_s synctex_vispector_proxy = {
 };
 
 static _synctex_class_s _synctex_class_proxy = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_proxy,    /*  Node type */
-    &_synctex_new_proxy,        /*  creator */
-    &_synctex_free_leaf,        /*  destructor */
-    &_synctex_log_proxy,        /*  log */
-    &_synctex_display_proxy,    /*  display */
-    &_synctex_abstract_proxy,   /*  abstract */
-    &synctex_tree_model_proxy,  /*  tree model */
-    &synctex_data_model_proxy,  /*  data model */
-    &synctex_tlcpector_proxy,   /*  tlcpector */
-    &synctex_inspector_proxy_box,   /*  inspector */
-    &synctex_vispector_proxy,   /*  vispector */
+    NULL, /*  No scanner yet */
+    synctex_node_type_proxy, /*  Node type */
+    &_synctex_new_proxy, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_proxy, /*  log */
+    &_synctex_display_proxy, /*  display */
+    &_synctex_abstract_proxy, /*  abstract */
+    &synctex_tree_model_proxy, /*  tree model */
+    &synctex_data_model_proxy, /*  data model */
+    &synctex_tlcpector_proxy, /*  tlcpector */
+    &synctex_inspector_proxy_box, /*  inspector */
+    &synctex_vispector_proxy, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark last proxy.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark last proxy.
+#endif
 
 /**
  *  A proxy to the last proxy/box boundary.
  */
 
 static const _synctex_tree_model_s synctex_tree_model_proxy_last = {
-    synctex_tree_sibling_idx,   /* sibling */
-    synctex_tree_s_parent_idx,  /* parent */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
     -1, /* child */
     synctex_tree_sp_friend_idx, /* friend */
     -1, /* last */
     -1, /* next_hbox */
     synctex_tree_spf_arg_sibling_idx, /* arg_sibling */
-    synctex_tree_spfa_target_idx,     /* target */
+    synctex_tree_spfa_target_idx, /* target */
     synctex_tree_spfat_proxy_last_max,
 };
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spfat_proxy_last_max+synctex_data_proxy_hv_max];
+    _synctex_data_u data[synctex_tree_spfat_proxy_last_max + synctex_data_proxy_hv_max];
 } _synctex_node_proxy_last_s;
 
 /*  proxy node creator */
 DEFINE_synctex_new_unscanned_NODE(proxy_last);
 
 static void _synctex_log_proxy(synctex_node_p node);
-static char * _synctex_abstract_proxy(synctex_node_p node);
+static char *_synctex_abstract_proxy(synctex_node_p node);
 static void _synctex_display_proxy(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_proxy_last = {
-    NULL,                           /*  No scanner yet */
-    synctex_node_type_proxy_last,   /*  Node type */
-    &_synctex_new_proxy,            /*  creator */
-    &_synctex_free_leaf,            /*  destructor */
-    &_synctex_log_proxy,            /*  log */
-    &_synctex_display_proxy,        /*  display */
-    &_synctex_abstract_proxy,       /*  abstract */
+    NULL, /*  No scanner yet */
+    synctex_node_type_proxy_last, /*  Node type */
+    &_synctex_new_proxy, /*  creator */
+    &_synctex_free_leaf, /*  destructor */
+    &_synctex_log_proxy, /*  log */
+    &_synctex_display_proxy, /*  display */
+    &_synctex_abstract_proxy, /*  abstract */
     &synctex_tree_model_proxy_last, /*  tree model */
-    &synctex_data_model_proxy,      /*  data model */
-    &synctex_tlcpector_proxy,       /*  tlcpector */
-    &synctex_inspector_proxy_box,   /*  inspector */
-    &synctex_vispector_proxy,       /*  vispector */
+    &synctex_data_model_proxy, /*  data model */
+    &synctex_tlcpector_proxy, /*  tlcpector */
+    &synctex_inspector_proxy_box, /*  inspector */
+    &synctex_vispector_proxy, /*  vispector */
 };
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark handle.
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark handle.
+#endif
 
 /**
  *  A handle node.
@@ -2977,14 +3009,14 @@ static _synctex_class_s _synctex_class_proxy_last = {
  */
 
 static const _synctex_tree_model_s synctex_tree_model_handle = {
-    synctex_tree_sibling_idx,   /* sibling */
-    synctex_tree_s_parent_idx,  /* parent */
-    synctex_tree_sp_child_idx,  /* child */
+    synctex_tree_sibling_idx, /* sibling */
+    synctex_tree_s_parent_idx, /* parent */
+    synctex_tree_sp_child_idx, /* child */
     -1, /* friend */
     -1, /* last */
     -1, /* next_hbox */
     -1, /* arg_sibling */
-    synctex_tree_spc_target_idx,/* target */
+    synctex_tree_spc_target_idx, /* target */
     synctex_tree_spct_handle_max,
 };
 
@@ -3012,63 +3044,65 @@ static const _synctex_data_model_s synctex_data_model_handle = {
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
     synctex_class_p class_;
-    _synctex_data_u data[synctex_tree_spct_handle_max+synctex_data_handle_w_max];
+    _synctex_data_u data[synctex_tree_spct_handle_max + synctex_data_handle_w_max];
 } _synctex_node_handle_s;
 
 /*  handle node creator */
 DEFINE_synctex_new_unscanned_NODE(handle);
 
 static void _synctex_log_handle(synctex_node_p node);
-static char * _synctex_abstract_handle(synctex_node_p node);
+static char *_synctex_abstract_handle(synctex_node_p node);
 static void _synctex_display_handle(synctex_node_p node);
 
 static _synctex_class_s _synctex_class_handle = {
-    NULL,                       /*  No scanner yet */
-    synctex_node_type_handle,   /*  Node type */
-    &_synctex_new_handle,       /*  creator */
-    &_synctex_free_handle,      /*  destructor */
-    &_synctex_log_handle,       /*  log */
-    &_synctex_display_handle,   /*  display */
-    &_synctex_abstract_handle,  /*  abstract */
+    NULL, /*  No scanner yet */
+    synctex_node_type_handle, /*  Node type */
+    &_synctex_new_handle, /*  creator */
+    &_synctex_free_handle, /*  destructor */
+    &_synctex_log_handle, /*  log */
+    &_synctex_display_handle, /*  display */
+    &_synctex_abstract_handle, /*  abstract */
     &synctex_tree_model_handle, /*  tree model */
     &synctex_data_model_handle, /*  data model */
-    &synctex_tlcpector_proxy,   /*  tlcpector */
-    &synctex_inspector_proxy_box,   /*  inspector */
-    &synctex_vispector_proxy_box,   /*  vispector */
+    &synctex_tlcpector_proxy, /*  tlcpector */
+    &synctex_inspector_proxy_box, /*  inspector */
+    &synctex_vispector_proxy_box, /*  vispector */
 };
 
-SYNCTEX_INLINE static synctex_node_p _synctex_new_handle_with_target(synctex_node_p target) {
+SYNCTEX_INLINE static synctex_node_p _synctex_new_handle_with_target(synctex_node_p target)
+{
     if (target) {
         synctex_node_p result = _synctex_new_handle(target->class_->scanner);
         if (result) {
-            _synctex_tree_set_target(result,target);
+            _synctex_tree_set_target(result, target);
             return result;
         }
     }
     return NULL;
 }
-SYNCTEX_INLINE static synctex_node_p _synctex_new_handle_with_child(synctex_node_p child) {
+SYNCTEX_INLINE static synctex_node_p _synctex_new_handle_with_child(synctex_node_p child)
+{
     if (child) {
         synctex_node_p result = _synctex_new_handle(child->class_->scanner);
         if (result) {
-            _synctex_tree_set_child(result,child);
+            _synctex_tree_set_child(result, child);
             return result;
         }
     }
     return NULL;
 }
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Navigation
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Navigation
+#endif
 synctex_node_p synctex_node_parent(synctex_node_p node)
 {
     return _synctex_tree_parent(node);
 }
 synctex_node_p synctex_node_parent_sheet(synctex_node_p node)
 {
-    while(node && synctex_node_type(node) != synctex_node_type_sheet) {
+    while (node && synctex_node_type(node) != synctex_node_type_sheet) {
         node = _synctex_tree_parent(node);
     }
     /*  exit the while loop either when node is NULL or node is a sheet */
@@ -3076,7 +3110,7 @@ synctex_node_p synctex_node_parent_sheet(synctex_node_p node)
 }
 synctex_node_p synctex_node_parent_form(synctex_node_p node)
 {
-    while(node && synctex_node_type(node) != synctex_node_type_form) {
+    while (node && synctex_node_type(node) != synctex_node_type_form) {
         node = _synctex_tree_parent(node);
     }
     /*  exit the while loop either when node is NULL or node is a form */
@@ -3089,33 +3123,34 @@ synctex_node_p synctex_node_parent_form(synctex_node_p node)
  *  Used only by __synctex_replace_ref.
  *  argument to_node: a box, not a proxy nor anything else.
  */
-SYNCTEX_INLINE static synctex_node_p __synctex_new_proxy_from_ref_to(synctex_node_p ref, synctex_node_p to_node) {
+SYNCTEX_INLINE static synctex_node_p __synctex_new_proxy_from_ref_to(synctex_node_p ref, synctex_node_p to_node)
+{
     synctex_node_p proxy = NULL;
     if (!ref || !to_node) {
         return NULL;
     }
-    switch(synctex_node_type(to_node)) {
-        case synctex_node_type_vbox:
-            proxy = _synctex_new_proxy_vbox(ref->class_->scanner);
-            break;
-        case synctex_node_type_hbox:
-            proxy = _synctex_new_proxy_hbox(ref->class_->scanner);
-            break;
-        default:
-            _synctex_error("!  __synctex_new_proxy_from_ref_to. Unexpected form child (%s). Please report.", synctex_node_isa(to_node));
-            return NULL;
+    switch (synctex_node_type(to_node)) {
+    case synctex_node_type_vbox:
+        proxy = _synctex_new_proxy_vbox(ref->class_->scanner);
+        break;
+    case synctex_node_type_hbox:
+        proxy = _synctex_new_proxy_hbox(ref->class_->scanner);
+        break;
+    default:
+        _synctex_error("!  __synctex_new_proxy_from_ref_to. Unexpected form child (%s). Please report.", synctex_node_isa(to_node));
+        return NULL;
     }
     if (!proxy) {
         _synctex_error("!  __synctex_new_proxy_from_ref_to. Internal error. Please report.");
         return NULL;
     }
     _synctex_data_set_h(proxy, _synctex_data_h(ref));
-    _synctex_data_set_v(proxy, _synctex_data_v(ref)-_synctex_data_height(to_node));
-    _synctex_tree_set_target(proxy,to_node);
-#   if defined(SYNCTEX_USE_CHARINDEX)
-    proxy->line_index=to_node?to_node->line_index:0;
-    proxy->char_index=to_node?to_node->char_index:0;
-#   endif
+    _synctex_data_set_v(proxy, _synctex_data_v(ref) - _synctex_data_height(to_node));
+    _synctex_tree_set_target(proxy, to_node);
+#if defined(SYNCTEX_USE_CHARINDEX)
+    proxy->line_index = to_node ? to_node->line_index : 0;
+    proxy->char_index = to_node ? to_node->char_index : 0;
+#endif
     return proxy;
 }
 /**
@@ -3127,61 +3162,63 @@ SYNCTEX_INLINE static synctex_node_p __synctex_new_proxy_from_ref_to(synctex_nod
  *  then the returned proxy has itself a sibling
  *  pointing to that already computed sibling.
  */
-SYNCTEX_INLINE static synctex_node_p __synctex_new_child_proxy_to(synctex_node_p owner, synctex_node_p to_node) {
+SYNCTEX_INLINE static synctex_node_p __synctex_new_child_proxy_to(synctex_node_p owner, synctex_node_p to_node)
+{
     synctex_node_p proxy = NULL;
     synctex_node_p target = to_node;
     if (!owner) {
         return NULL;
     }
-    switch(synctex_node_type(target)) {
-        case synctex_node_type_vbox:
-            if ((proxy = _synctex_new_proxy_vbox(owner->class_->scanner))) {
-            exit_standard:
-                _synctex_data_set_h(proxy, _synctex_data_h(owner));
-                _synctex_data_set_v(proxy, _synctex_data_v(owner));
-            exit0:
-                _synctex_tree_set_target(proxy,target);
-#   if defined(SYNCTEX_USE_CHARINDEX)
-                proxy->line_index=to_node?to_node->line_index:0;
-                proxy->char_index=to_node?to_node->char_index:0;
-#   endif
-                return proxy;
-            };
-            break;
-        case synctex_node_type_proxy_vbox:
-            if ((proxy = _synctex_new_proxy_vbox(owner->class_->scanner))) {
-            exit_proxy:
-                target = _synctex_tree_target(to_node);
-                _synctex_data_set_h(proxy, _synctex_data_h(owner)+_synctex_data_h(to_node));
-                _synctex_data_set_v(proxy, _synctex_data_v(owner)+_synctex_data_v(to_node));
-                goto exit0;
-            };
-            break;
-        case synctex_node_type_hbox:
-            if ((proxy = _synctex_new_proxy_hbox(owner->class_->scanner))) {
-                goto exit_standard;
-            };
-            break;
-        case synctex_node_type_proxy_hbox:
-            if ((proxy = _synctex_new_proxy_hbox(owner->class_->scanner))) {
-                goto exit_proxy;
-            };
-            break;
-        case synctex_node_type_proxy:
-        case synctex_node_type_proxy_last:
-            if ((proxy = _synctex_new_proxy(owner->class_->scanner))) {
-                goto exit_proxy;
-            };
-            break;
-        default:
-            if ((proxy = _synctex_new_proxy(owner->class_->scanner))) {
-                goto exit_standard;
-            };
-            break;
+    switch (synctex_node_type(target)) {
+    case synctex_node_type_vbox:
+        if ((proxy = _synctex_new_proxy_vbox(owner->class_->scanner))) {
+        exit_standard:
+            _synctex_data_set_h(proxy, _synctex_data_h(owner));
+            _synctex_data_set_v(proxy, _synctex_data_v(owner));
+        exit0:
+            _synctex_tree_set_target(proxy, target);
+#if defined(SYNCTEX_USE_CHARINDEX)
+            proxy->line_index = to_node ? to_node->line_index : 0;
+            proxy->char_index = to_node ? to_node->char_index : 0;
+#endif
+            return proxy;
+        };
+        break;
+    case synctex_node_type_proxy_vbox:
+        if ((proxy = _synctex_new_proxy_vbox(owner->class_->scanner))) {
+        exit_proxy:
+            target = _synctex_tree_target(to_node);
+            _synctex_data_set_h(proxy, _synctex_data_h(owner) + _synctex_data_h(to_node));
+            _synctex_data_set_v(proxy, _synctex_data_v(owner) + _synctex_data_v(to_node));
+            goto exit0;
+        };
+        break;
+    case synctex_node_type_hbox:
+        if ((proxy = _synctex_new_proxy_hbox(owner->class_->scanner))) {
+            goto exit_standard;
+        };
+        break;
+    case synctex_node_type_proxy_hbox:
+        if ((proxy = _synctex_new_proxy_hbox(owner->class_->scanner))) {
+            goto exit_proxy;
+        };
+        break;
+    case synctex_node_type_proxy:
+    case synctex_node_type_proxy_last:
+        if ((proxy = _synctex_new_proxy(owner->class_->scanner))) {
+            goto exit_proxy;
+        };
+        break;
+    default:
+        if ((proxy = _synctex_new_proxy(owner->class_->scanner))) {
+            goto exit_standard;
+        };
+        break;
     }
-    _synctex_error("!  __synctex_new_child_proxy_to. "
-                   "Internal error. "
-                   "Please report.");
+    _synctex_error(
+        "!  __synctex_new_child_proxy_to. "
+        "Internal error. "
+        "Please report.");
     return NULL;
 }
 SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_sibling(synctex_node_p node, synctex_node_p new_sibling);
@@ -3197,39 +3234,42 @@ typedef struct _synctex_nns_t {
  *  Returns the first created proxy, the last one and
  *  an error status.
  */
-SYNCTEX_INLINE static _synctex_nns_s _synctex_new_child_proxies_to(synctex_node_p owner, synctex_node_p to_node) {
-    _synctex_nns_s nns = {NULL,NULL,SYNCTEX_STATUS_OK};
-    if ((nns.first = nns.last = __synctex_new_child_proxy_to(owner,to_node))) {
+SYNCTEX_INLINE static _synctex_nns_s _synctex_new_child_proxies_to(synctex_node_p owner, synctex_node_p to_node)
+{
+    _synctex_nns_s nns = {NULL, NULL, SYNCTEX_STATUS_OK};
+    if ((nns.first = nns.last = __synctex_new_child_proxy_to(owner, to_node))) {
         synctex_node_p to_next_sibling = __synctex_tree_sibling(to_node);
         synctex_node_p to_sibling;
         while ((to_sibling = to_next_sibling)) {
             synctex_node_p sibling;
             if ((to_next_sibling = __synctex_tree_sibling(to_sibling))) {
                 /*  This is not the last sibling */
-                if((sibling = __synctex_new_child_proxy_to(owner,to_sibling))) {
-                    _synctex_tree_set_sibling(nns.last,sibling);
+                if ((sibling = __synctex_new_child_proxy_to(owner, to_sibling))) {
+                    _synctex_tree_set_sibling(nns.last, sibling);
                     nns.last = sibling;
                     continue;
                 } else {
-                    _synctex_error("!  _synctex_new_child_proxy_to. "
-                                   "Internal error (1). "
-                                   "Please report.");
+                    _synctex_error(
+                        "!  _synctex_new_child_proxy_to. "
+                        "Internal error (1). "
+                        "Please report.");
                     nns.status = SYNCTEX_STATUS_ERROR;
                 }
-            } else if((sibling = _synctex_new_proxy_last(owner->class_->scanner))) {
-                _synctex_tree_set_sibling(nns.last,sibling);
+            } else if ((sibling = _synctex_new_proxy_last(owner->class_->scanner))) {
+                _synctex_tree_set_sibling(nns.last, sibling);
                 nns.last = sibling;
                 _synctex_data_set_h(nns.last, _synctex_data_h(nns.first));
                 _synctex_data_set_v(nns.last, _synctex_data_v(nns.first));
-                _synctex_tree_set_target(nns.last,to_sibling);
-#   if defined(SYNCTEX_USE_CHARINDEX)
-                nns.last->line_index=to_sibling->line_index;
-                nns.last->char_index=to_sibling->char_index;
-#   endif
+                _synctex_tree_set_target(nns.last, to_sibling);
+#if defined(SYNCTEX_USE_CHARINDEX)
+                nns.last->line_index = to_sibling->line_index;
+                nns.last->char_index = to_sibling->char_index;
+#endif
             } else {
-                _synctex_error("!  _synctex_new_child_proxy_to. "
-                               "Internal error (2). "
-                               "Please report.");
+                _synctex_error(
+                    "!  _synctex_new_child_proxy_to. "
+                    "Internal error (2). "
+                    "Please report.");
                 nns.status = SYNCTEX_STATUS_ERROR;
             }
             break;
@@ -3237,8 +3277,9 @@ SYNCTEX_INLINE static _synctex_nns_s _synctex_new_child_proxies_to(synctex_node_
     }
     return nns;
 }
-static char * _synctex_node_abstract(synctex_node_p node);
-SYNCTEX_INLINE static synctex_node_p synctex_tree_set_friend(synctex_node_p node,synctex_node_p new_friend) {
+static char *_synctex_node_abstract(synctex_node_p node);
+SYNCTEX_INLINE static synctex_node_p synctex_tree_set_friend(synctex_node_p node, synctex_node_p new_friend)
+{
 #if SYNCTEX_DEBUG
     synctex_node_p F = new_friend;
     while (F) {
@@ -3246,7 +3287,7 @@ SYNCTEX_INLINE static synctex_node_p synctex_tree_set_friend(synctex_node_p node
             printf("THIS IS AN ERROR\n");
             F = new_friend;
             while (F) {
-                printf("%s\n",_synctex_node_abstract(F));
+                printf("%s\n", _synctex_node_abstract(F));
                 if (node == F) {
                     return NULL;
                 }
@@ -3257,19 +3298,20 @@ SYNCTEX_INLINE static synctex_node_p synctex_tree_set_friend(synctex_node_p node
         F = _synctex_tree_friend(F);
     }
 #endif
-    return new_friend?_synctex_tree_set_friend(node,new_friend):_synctex_tree_reset_friend(node);
+    return new_friend ? _synctex_tree_set_friend(node, new_friend) : _synctex_tree_reset_friend(node);
 }
 /**
  *
  */
-SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend(synctex_node_p node, int i) {
+SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend(synctex_node_p node, int i)
+{
     synctex_node_p old = NULL;
-    if (i>=0) {
-        i = i%(node->class_->scanner->number_of_lists);
-        old = synctex_tree_set_friend(node,(node->class_->scanner->lists_of_friends)[i]);
+    if (i >= 0) {
+        i = i % (node->class_->scanner->number_of_lists);
+        old = synctex_tree_set_friend(node, (node->class_->scanner->lists_of_friends)[i]);
         (node->class_->scanner->lists_of_friends)[i] = node;
 #if SYNCTEX_DEBUG > 500
-        printf("tl(%i)=>",i);
+        printf("tl(%i)=>", i);
         synctex_node_log(node);
         if (synctex_node_parent_form(node)) {
             printf("!  ERROR. No registration expected!\n");
@@ -3283,20 +3325,21 @@ SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend(synctex_node_p n
  *  The purpose is to register all af them.
  *  - argument node: is the proxy, must not be NULL
  */
-SYNCTEX_INLINE static synctex_node_p __synctex_proxy_make_friend_and_next_hbox(synctex_node_p node) {
+SYNCTEX_INLINE static synctex_node_p __synctex_proxy_make_friend_and_next_hbox(synctex_node_p node)
+{
     synctex_node_p old = NULL;
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
-        int i = _synctex_data_tag(target)+_synctex_data_line(target);
-        old = __synctex_node_make_friend(node,i);
+        int i = _synctex_data_tag(target) + _synctex_data_line(target);
+        old = __synctex_node_make_friend(node, i);
     } else {
         old = __synctex_tree_reset_friend(node);
     }
     if (synctex_node_type(node) == synctex_node_type_proxy_hbox) {
         synctex_node_p sheet = synctex_node_parent_sheet(node);
         if (sheet) {
-            _synctex_tree_set_next_hbox(node,_synctex_tree_next_hbox(sheet));
-            _synctex_tree_set_next_hbox(sheet,node);
+            _synctex_tree_set_next_hbox(node, _synctex_tree_next_hbox(sheet));
+            _synctex_tree_set_next_hbox(sheet, node);
         }
     }
     return old;
@@ -3305,9 +3348,10 @@ SYNCTEX_INLINE static synctex_node_p __synctex_proxy_make_friend_and_next_hbox(s
  *  Register a node which have tag, line and column.
  *  - argument node: the node
  */
-SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend_tlc(synctex_node_p node) {
-    int i = synctex_node_tag(node)+synctex_node_line(node);
-    return __synctex_node_make_friend(node,i);
+SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend_tlc(synctex_node_p node)
+{
+    int i = synctex_node_tag(node) + synctex_node_line(node);
+    return __synctex_node_make_friend(node, i);
 }
 /**
  *  Register a node which have tag, line and column.
@@ -3315,7 +3359,8 @@ SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend_tlc(synctex_node
  *  Calls __synctex_node_make_friend_tlc.
  *  - argument node: the node
  */
-SYNCTEX_INLINE static void _synctex_node_make_friend_tlc(synctex_node_p node) {
+SYNCTEX_INLINE static void _synctex_node_make_friend_tlc(synctex_node_p node)
+{
     if (node) {
         __synctex_node_make_friend_tlc(node);
     }
@@ -3335,7 +3380,8 @@ static synctex_node_p _synctex_node_set_child(synctex_node_p node, synctex_node_
  *  node that belongs to a form.
  *  This is the only place where child proxies are created.
  */
-synctex_node_p synctex_node_child(synctex_node_p node) {
+synctex_node_p synctex_node_child(synctex_node_p node)
+{
     synctex_node_p child = NULL;
     synctex_node_p target = NULL;
     if ((child = _synctex_tree_child(node))) {
@@ -3346,7 +3392,7 @@ synctex_node_p synctex_node_child(synctex_node_p node) {
              *  which target does have a child. */
             _synctex_nns_s nns = _synctex_new_child_proxies_to(node, child);
             if (nns.first) {
-                _synctex_node_set_child(node,nns.first);
+                _synctex_node_set_child(node, nns.first);
                 return nns.first;
             } else {
                 _synctex_error("!  synctex_node_child. Internal inconsistency. Please report.");
@@ -3360,9 +3406,10 @@ synctex_node_p synctex_node_child(synctex_node_p node) {
  *  Things get complicated when new_child has siblings.
  *  The caller is responsible for releasing the returned value.
  */
-static synctex_node_p _synctex_node_set_child(synctex_node_p parent, synctex_node_p new_child) {
+static synctex_node_p _synctex_node_set_child(synctex_node_p parent, synctex_node_p new_child)
+{
     if (parent) {
-        synctex_node_p old = _synctex_tree_set_child(parent,new_child);
+        synctex_node_p old = _synctex_tree_set_child(parent, new_child);
         synctex_node_p last_child = NULL;
         synctex_node_p child;
         if ((child = old)) {
@@ -3372,11 +3419,11 @@ static synctex_node_p _synctex_node_set_child(synctex_node_p parent, synctex_nod
         }
         if ((child = new_child)) {
             do {
-                _synctex_tree_set_parent(child,parent);
+                _synctex_tree_set_parent(child, parent);
                 last_child = child;
             } while ((child = __synctex_tree_sibling(child)));
         }
-        _synctex_tree_set_last(parent,last_child);
+        _synctex_tree_set_last(parent, last_child);
         return old;
     }
     return NULL;
@@ -3384,15 +3431,17 @@ static synctex_node_p _synctex_node_set_child(synctex_node_p parent, synctex_nod
 
 /*  The last child of the given node, or NULL.
  */
-synctex_node_p synctex_node_last_child(synctex_node_p node) {
+synctex_node_p synctex_node_last_child(synctex_node_p node)
+{
     return _synctex_tree_last(node);
 }
 /**
  *  All nodes siblings are properly set up at parse time
  *  except for non root proxies.
  */
-synctex_node_p synctex_node_sibling(synctex_node_p node) {
-    return node? __synctex_tree_sibling(node): NULL;
+synctex_node_p synctex_node_sibling(synctex_node_p node)
+{
+    return node ? __synctex_tree_sibling(node) : NULL;
 }
 /**
  *  All the _synctex_tree_... methods refer to the tree model.
@@ -3405,12 +3454,13 @@ synctex_node_p synctex_node_sibling(synctex_node_p node) {
  *  The caller is responsible for releasing the old sibling.
  *  The bound to the parent is managed below.
  */
-SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_sibling(synctex_node_p node, synctex_node_p new_sibling) {
+SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_sibling(synctex_node_p node, synctex_node_p new_sibling)
+{
     if (node == new_sibling) {
         printf("BOF\n");
     }
-    synctex_node_p old = node? __synctex_tree_set_sibling(node,new_sibling): NULL;
-    _synctex_tree_set_arg_sibling(new_sibling,node);
+    synctex_node_p old = node ? __synctex_tree_set_sibling(node, new_sibling) : NULL;
+    _synctex_tree_set_arg_sibling(new_sibling, node);
     return old;
 }
 /**
@@ -3422,23 +3472,25 @@ SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_sibling(synctex_node_p no
  *  - returns the old sibling.
  *  The caller is responsible for releasing the old sibling.
  */
-static synctex_node_p _synctex_node_set_sibling(synctex_node_p node, synctex_node_p new_sibling) {
+static synctex_node_p _synctex_node_set_sibling(synctex_node_p node, synctex_node_p new_sibling)
+{
     if (node && new_sibling) {
-        synctex_node_p old = _synctex_tree_set_sibling(node,new_sibling);
+        synctex_node_p old = _synctex_tree_set_sibling(node, new_sibling);
         if (_synctex_tree_has_parent(node)) {
             synctex_node_p parent = __synctex_tree_parent(node);
             if (parent) {
                 synctex_node_p N = new_sibling;
                 while (synctex_YES) {
                     if (_synctex_tree_has_parent(N)) {
-                        __synctex_tree_set_parent(N,parent);
-                        _synctex_tree_set_last(parent,N);
+                        __synctex_tree_set_parent(N, parent);
+                        _synctex_tree_set_last(parent, N);
                         N = __synctex_tree_sibling(N);
                         continue;
                     } else if (N) {
-                        _synctex_error("!  synctex_node_sibling. "
-                                       "Internal inconsistency. "
-                                       "Please report.");
+                        _synctex_error(
+                            "!  synctex_node_sibling. "
+                            "Internal inconsistency. "
+                            "Please report.");
                     }
                     break;
                 }
@@ -3451,11 +3503,12 @@ static synctex_node_p _synctex_node_set_sibling(synctex_node_p node, synctex_nod
 /**
  *  The last sibling of the given node, or NULL with node.
  */
-synctex_node_p synctex_node_last_sibling(synctex_node_p node) {
+synctex_node_p synctex_node_last_sibling(synctex_node_p node)
+{
     synctex_node_p sibling;
     do {
         sibling = node;
-    } while((node = synctex_node_sibling(node)));
+    } while ((node = synctex_node_sibling(node)));
     return sibling;
 }
 /**
@@ -3465,13 +3518,14 @@ synctex_node_p synctex_node_last_sibling(synctex_node_p node) {
  *  May loop infinitely many times if the tree
  *  is not properly built (contains loops).
  */
-SYNCTEX_INLINE static synctex_node_p _synctex_node_sibling_or_parents(synctex_node_p node) {
+SYNCTEX_INLINE static synctex_node_p _synctex_node_sibling_or_parents(synctex_node_p node)
+{
     while (node) {
         synctex_node_p N;
         if ((N = __synctex_tree_sibling(node))) {
             return N;
         } else if ((node = _synctex_tree_parent(node))) {
-            if (synctex_node_type(node) == synctex_node_type_sheet) {/*  EXC_BAD_ACCESS? */
+            if (synctex_node_type(node) == synctex_node_type_sheet) { /*  EXC_BAD_ACCESS? */
                 return NULL;
             } else if (synctex_node_type(node) == synctex_node_type_form) {
                 return NULL;
@@ -3488,7 +3542,8 @@ SYNCTEX_INLINE static synctex_node_p _synctex_node_sibling_or_parents(synctex_no
  *  May loop infinitely many times if the tree
  *  is not properly built (contains loops).
  */
-synctex_node_p synctex_node_next(synctex_node_p node) {
+synctex_node_p synctex_node_next(synctex_node_p node)
+{
     synctex_node_p N = synctex_node_child(node);
     if (N) {
         return N;
@@ -3501,7 +3556,8 @@ synctex_node_p synctex_node_next(synctex_node_p node) {
  *      is the first child of its parent.
  *  - Input nodes have no arg siblings
  */
-synctex_node_p synctex_node_arg_sibling(synctex_node_p node) {
+synctex_node_p synctex_node_arg_sibling(synctex_node_p node)
+{
 #if 1
     return _synctex_tree_arg_sibling(node);
 #else
@@ -3518,18 +3574,20 @@ synctex_node_p synctex_node_arg_sibling(synctex_node_p node) {
     return N;
 #endif
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark CLASS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark CLASS
+#endif
 
 /*  Public node accessor: the type  */
-synctex_node_type_t synctex_node_type(synctex_node_p node) {
-    return node? node->class_->type: synctex_node_type_none;
+synctex_node_type_t synctex_node_type(synctex_node_p node)
+{
+    return node ? node->class_->type : synctex_node_type_none;
 }
 
 /*  Public node accessor: the type  */
-synctex_node_type_t synctex_node_target_type(synctex_node_p node) {
+synctex_node_type_t synctex_node_target_type(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         return (((target)->class_))->type;
@@ -3540,93 +3598,74 @@ synctex_node_type_t synctex_node_target_type(synctex_node_p node) {
 }
 
 /*  Public node accessor: the human readable type  */
-const char * synctex_node_isa(synctex_node_p node) {
-    static const char * isa[synctex_node_number_of_types] =
-    {"Not a node",
-        "input",
-        "sheet",
-        "form",
-        "ref",
-        "vbox",
-        "void vbox",
-        "hbox",
-        "void hbox",
-        "kern",
-        "glue",
-        "rule",
-        "math",
-        "boundary",
-        "box_bdry",
-        "proxy",
-        "last proxy",
-        "vbox proxy",
-        "hbox proxy",
-        "handle"};
+const char *synctex_node_isa(synctex_node_p node)
+{
+    static const char *isa[synctex_node_number_of_types] = {"Not a node", "input",     "sheet",      "form",       "ref",        "vbox",  "void vbox",
+                                                            "hbox",       "void hbox", "kern",       "glue",       "rule",       "math",  "boundary",
+                                                            "box_bdry",   "proxy",     "last proxy", "vbox proxy", "hbox proxy", "handle"};
     return isa[synctex_node_type(node)];
 }
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark LOG
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark LOG
+#endif
 
 /*  Public node logger  */
-void synctex_node_log(synctex_node_p node) {
-    SYNCTEX_MSG_SEND(node,log);
+void synctex_node_log(synctex_node_p node)
+{
+    SYNCTEX_MSG_SEND(node, log);
 }
 
-static void _synctex_log_input(synctex_node_p node) {
+static void _synctex_log_input(synctex_node_p node)
+{
     if (node) {
-        printf("%s:%i,%s(%i)\n",synctex_node_isa(node),
-               _synctex_data_tag(node),
-               _synctex_data_name(node),
-               _synctex_data_line(node));
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",
-               (void *)__synctex_tree_sibling(node));
+        printf("%s:%i,%s(%i)\n", synctex_node_isa(node), _synctex_data_tag(node), _synctex_data_name(node), _synctex_data_line(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
     }
 }
 
-static void _synctex_log_sheet(synctex_node_p node) {
+static void _synctex_log_sheet(synctex_node_p node)
+{
     if (node) {
-        printf("%s:%i",synctex_node_isa(node),_synctex_data_page(node));
+        printf("%s:%i", synctex_node_isa(node), _synctex_data_page(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
-        printf("    NEXT_hbox:%p\n",(void *)_synctex_tree_next_hbox(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
+        printf("    NEXT_hbox:%p\n", (void *)_synctex_tree_next_hbox(node));
     }
 }
 
-static void _synctex_log_form(synctex_node_p node) {
+static void _synctex_log_form(synctex_node_p node)
+{
     if (node) {
-        printf("%s:%i",synctex_node_isa(node),_synctex_data_tag(node));
+        printf("%s:%i", synctex_node_isa(node), _synctex_data_tag(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
     }
 }
 
-static void _synctex_log_ref(synctex_node_p node) {
+static void _synctex_log_ref(synctex_node_p node)
+{
     if (node) {
-        printf("%s:%i:%i,%i",
-               synctex_node_isa(node),
-               _synctex_data_tag(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node));
+        printf("%s:%i:%i,%i", synctex_node_isa(node), _synctex_data_tag(node), _synctex_data_h(node), _synctex_data_v(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
     }
 }
 
-static void _synctex_log_tlchv_node(synctex_node_p node) {
+static void _synctex_log_tlchv_node(synctex_node_p node)
+{
     if (node) {
         printf("%s:%i,%i,%i:%i,%i",
                synctex_node_isa(node),
@@ -3636,15 +3675,16 @@ static void _synctex_log_tlchv_node(synctex_node_p node) {
                _synctex_data_h(node),
                _synctex_data_v(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
     }
 }
 
-static void _synctex_log_kern_node(synctex_node_p node) {
+static void _synctex_log_kern_node(synctex_node_p node)
+{
     if (node) {
         printf("%s:%i,%i,%i:%i,%i:%i",
                synctex_node_isa(node),
@@ -3655,15 +3695,16 @@ static void _synctex_log_kern_node(synctex_node_p node) {
                _synctex_data_v(node),
                _synctex_data_width(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
     }
 }
 
-static void _synctex_log_rule(synctex_node_p node) {
+static void _synctex_log_rule(synctex_node_p node)
+{
     if (node) {
         printf("%s:%i,%i,%i:%i,%i",
                synctex_node_isa(node),
@@ -3672,155 +3713,167 @@ static void _synctex_log_rule(synctex_node_p node) {
                _synctex_data_column(node),
                _synctex_data_h(node),
                _synctex_data_v(node));
-        printf(":%i",_synctex_data_width(node));
-        printf(",%i",_synctex_data_height(node));
-        printf(",%i",_synctex_data_depth(node));
+        printf(":%i", _synctex_data_width(node));
+        printf(",%i", _synctex_data_height(node));
+        printf(",%i", _synctex_data_depth(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
     }
 }
 
-static void _synctex_log_void_box(synctex_node_p node) {
+static void _synctex_log_void_box(synctex_node_p node)
+{
     if (node) {
-        printf("%s",synctex_node_isa(node));
-        printf(":%i",_synctex_data_tag(node));
-        printf(",%i",_synctex_data_line(node));
-        printf(",%i",_synctex_data_column(node));
-        printf(":%i",_synctex_data_h(node));
-        printf(",%i",_synctex_data_v(node));
-        printf(":%i",_synctex_data_width(node));
-        printf(",%i",_synctex_data_height(node));
-        printf(",%i",_synctex_data_depth(node));
+        printf("%s", synctex_node_isa(node));
+        printf(":%i", _synctex_data_tag(node));
+        printf(",%i", _synctex_data_line(node));
+        printf(",%i", _synctex_data_column(node));
+        printf(":%i", _synctex_data_h(node));
+        printf(",%i", _synctex_data_v(node));
+        printf(":%i", _synctex_data_width(node));
+        printf(",%i", _synctex_data_height(node));
+        printf(",%i", _synctex_data_depth(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
     }
 }
 
-static void _synctex_log_vbox(synctex_node_p node) {
+static void _synctex_log_vbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s",synctex_node_isa(node));
-        printf(":%i",_synctex_data_tag(node));
-        printf(",%i",_synctex_data_line(node));
-        printf(",%i",_synctex_data_column(node));
-        printf(":%i",_synctex_data_h(node));
-        printf(",%i",_synctex_data_v(node));
-        printf(":%i",_synctex_data_width(node));
-        printf(",%i",_synctex_data_height(node));
-        printf(",%i",_synctex_data_depth(node));
+        printf("%s", synctex_node_isa(node));
+        printf(":%i", _synctex_data_tag(node));
+        printf(",%i", _synctex_data_line(node));
+        printf(",%i", _synctex_data_column(node));
+        printf(":%i", _synctex_data_h(node));
+        printf(",%i", _synctex_data_v(node));
+        printf(":%i", _synctex_data_width(node));
+        printf(",%i", _synctex_data_height(node));
+        printf(",%i", _synctex_data_depth(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
-        printf("    NEXT_hbox:%p\n",(void *)_synctex_tree_next_hbox(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
+        printf("    NEXT_hbox:%p\n", (void *)_synctex_tree_next_hbox(node));
     }
 }
 
-static void _synctex_log_hbox(synctex_node_p node) {
+static void _synctex_log_hbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s",synctex_node_isa(node));
-        printf(":%i",_synctex_data_tag(node));
-        printf(",%i~%i*%i",_synctex_data_line(node),_synctex_data_mean_line(node),_synctex_data_weight(node));
-        printf(",%i",_synctex_data_column(node));
-        printf(":%i",_synctex_data_h(node));
-        printf(",%i",_synctex_data_v(node));
-        printf(":%i",_synctex_data_width(node));
-        printf(",%i",_synctex_data_height(node));
-        printf(",%i",_synctex_data_depth(node));
-        printf("/%i",_synctex_data_h_V(node));
-        printf(",%i",_synctex_data_v_V(node));
-        printf(":%i",_synctex_data_width_V(node));
-        printf(",%i",_synctex_data_height_V(node));
-        printf(",%i",_synctex_data_depth_V(node));
+        printf("%s", synctex_node_isa(node));
+        printf(":%i", _synctex_data_tag(node));
+        printf(",%i~%i*%i", _synctex_data_line(node), _synctex_data_mean_line(node), _synctex_data_weight(node));
+        printf(",%i", _synctex_data_column(node));
+        printf(":%i", _synctex_data_h(node));
+        printf(",%i", _synctex_data_v(node));
+        printf(":%i", _synctex_data_width(node));
+        printf(",%i", _synctex_data_height(node));
+        printf(",%i", _synctex_data_depth(node));
+        printf("/%i", _synctex_data_h_V(node));
+        printf(",%i", _synctex_data_v_V(node));
+        printf(":%i", _synctex_data_width_V(node));
+        printf(",%i", _synctex_data_height_V(node));
+        printf(",%i", _synctex_data_depth_V(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    PARENT:%p\n",(void *)_synctex_tree_parent(node));
-        printf("    CHILD:%p\n",(void *)_synctex_tree_child(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
-        printf("    NEXT_hbox:%p\n",(void *)_synctex_tree_next_hbox(node));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    PARENT:%p\n", (void *)_synctex_tree_parent(node));
+        printf("    CHILD:%p\n", (void *)_synctex_tree_child(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
+        printf("    NEXT_hbox:%p\n", (void *)_synctex_tree_next_hbox(node));
     }
 }
-static void _synctex_log_proxy(synctex_node_p node) {
-    if (node) {
-        synctex_node_p N = _synctex_tree_target(node);
-        printf("%s",synctex_node_isa(node));
-        printf(":%i",_synctex_data_h(node));
-        printf(",%i",_synctex_data_v(node));
-        SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    LEFT:%p\n",(void *)_synctex_tree_friend(node));
-        printf("    ->%s\n",_synctex_node_abstract(N));
-    }
-}
-static void _synctex_log_handle(synctex_node_p node) {
+static void _synctex_log_proxy(synctex_node_p node)
+{
     if (node) {
         synctex_node_p N = _synctex_tree_target(node);
-        printf("%s",synctex_node_isa(node));
+        printf("%s", synctex_node_isa(node));
+        printf(":%i", _synctex_data_h(node));
+        printf(",%i", _synctex_data_v(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
-        printf("SELF:%p\n",(void *)node);
-        printf("    SIBLING:%p\n",(void *)__synctex_tree_sibling(node));
-        printf("    ->%s\n",_synctex_node_abstract(N));
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    LEFT:%p\n", (void *)_synctex_tree_friend(node));
+        printf("    ->%s\n", _synctex_node_abstract(N));
+    }
+}
+static void _synctex_log_handle(synctex_node_p node)
+{
+    if (node) {
+        synctex_node_p N = _synctex_tree_target(node);
+        printf("%s", synctex_node_isa(node));
+        SYNCTEX_PRINT_CHARINDEX_NL;
+        printf("SELF:%p\n", (void *)node);
+        printf("    SIBLING:%p\n", (void *)__synctex_tree_sibling(node));
+        printf("    ->%s\n", _synctex_node_abstract(N));
     }
 }
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark SYNCTEX_DISPLAY
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark SYNCTEX_DISPLAY
+#endif
 
-int synctex_scanner_display_switcher(synctex_scanner_p scanR) {
+int synctex_scanner_display_switcher(synctex_scanner_p scanR)
+{
     return scanR->display_switcher;
 }
-void synctex_scanner_set_display_switcher(synctex_scanner_p scanR, int switcher) {
+void synctex_scanner_set_display_switcher(synctex_scanner_p scanR, int switcher)
+{
     scanR->display_switcher = switcher;
 }
-static const char * const _synctex_display_prompt = "................................";
+static const char *const _synctex_display_prompt = "................................";
 
-static char * _synctex_scanner_display_prompt_down(synctex_scanner_p scanR) {
-    if (scanR->display_prompt>_synctex_display_prompt) {
+static char *_synctex_scanner_display_prompt_down(synctex_scanner_p scanR)
+{
+    if (scanR->display_prompt > _synctex_display_prompt) {
         --scanR->display_prompt;
     }
     return scanR->display_prompt;
 }
-static char * _synctex_scanner_display_prompt_up(synctex_scanner_p scanR) {
-    if (scanR->display_prompt+1<_synctex_display_prompt+strlen(_synctex_display_prompt)) {
+static char *_synctex_scanner_display_prompt_up(synctex_scanner_p scanR)
+{
+    if (scanR->display_prompt + 1 < _synctex_display_prompt + strlen(_synctex_display_prompt)) {
         ++scanR->display_prompt;
     }
     return scanR->display_prompt;
 }
 
-void synctex_node_display(synctex_node_p node) {
+void synctex_node_display(synctex_node_p node)
+{
     if (node) {
         synctex_scanner_p scanR = node->class_->scanner;
         if (scanR) {
-            if (scanR->display_switcher<0) {
+            if (scanR->display_switcher < 0) {
                 SYNCTEX_MSG_SEND(node, display);
-            } else if (scanR->display_switcher>0 && --scanR->display_switcher>0) {
+            } else if (scanR->display_switcher > 0 && --scanR->display_switcher > 0) {
                 SYNCTEX_MSG_SEND(node, display);
-            } else if (scanR->display_switcher-->=0) {
-                printf("%s Next display skipped. Reset display switcher.\n",node->class_->scanner->display_prompt);
+            } else if (scanR->display_switcher-- >= 0) {
+                printf("%s Next display skipped. Reset display switcher.\n", node->class_->scanner->display_prompt);
             }
         } else {
             SYNCTEX_MSG_SEND(node, display);
         }
     }
 }
-static char * _synctex_node_abstract(synctex_node_p node) {
+static char *_synctex_node_abstract(synctex_node_p node)
+{
     SYNCTEX_PARAMETER_ASSERT(node || node->class_);
-    return (node && node->class_->abstract)? node->class_->abstract(node):"none";
+    return (node && node->class_->abstract) ? node->class_->abstract(node) : "none";
 }
 
-SYNCTEX_INLINE static void _synctex_display_child(synctex_node_p node) {
+SYNCTEX_INLINE static void _synctex_display_child(synctex_node_p node)
+{
     synctex_node_p N = _synctex_tree_child(node);
     if (N) {
         _synctex_scanner_display_prompt_down(N->class_->scanner);
@@ -3829,106 +3882,97 @@ SYNCTEX_INLINE static void _synctex_display_child(synctex_node_p node) {
     }
 }
 
-SYNCTEX_INLINE static void _synctex_display_sibling(synctex_node_p node) {
+SYNCTEX_INLINE static void _synctex_display_sibling(synctex_node_p node)
+{
     synctex_node_display(__synctex_tree_sibling(node));
 }
 #define SYNCTEX_ABSTRACT_MAX 128
-static char * _synctex_abstract_input(synctex_node_p node) {
+static char *_synctex_abstract_input(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"Input:%i:%s(%i)" SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_name(node),
-               _synctex_data_line(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "Input:%i:%s(%i)" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_name(node),
+                 _synctex_data_line(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_input(synctex_node_p node) {
+static void _synctex_display_input(synctex_node_p node)
+{
     if (node) {
-        printf("Input:%i:%s(%i)"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("Input:%i:%s(%i)" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                _synctex_data_tag(node),
                _synctex_data_name(node),
-               _synctex_data_line(node)
-                SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_line(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         synctex_node_display(__synctex_tree_sibling(node));
     }
 }
 
-static char * _synctex_abstract_sheet(synctex_node_p node) {
+static char *_synctex_abstract_sheet(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"{%i...}" SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_page(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract, SYNCTEX_ABSTRACT_MAX, "{%i...}" SYNCTEX_PRINT_CHARINDEX_FMT, _synctex_data_page(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_sheet(synctex_node_p node) {
+static void _synctex_display_sheet(synctex_node_p node)
+{
     if (node) {
-        printf("%s{%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
-               node->class_->scanner->display_prompt,
-               _synctex_data_page(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        printf("%s{%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n", node->class_->scanner->display_prompt, _synctex_data_page(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
-        printf("%s}\n",node->class_->scanner->display_prompt);
+        printf("%s}\n", node->class_->scanner->display_prompt);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_form(synctex_node_p node) {
+static char *_synctex_abstract_form(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"<%i...>" SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract, SYNCTEX_ABSTRACT_MAX, "<%i...>" SYNCTEX_PRINT_CHARINDEX_FMT, _synctex_data_tag(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         SYNCTEX_PRINT_CHARINDEX;
     }
     return abstract;
 }
 
-static void _synctex_display_form(synctex_node_p node) {
+static void _synctex_display_form(synctex_node_p node)
+{
     if (node) {
-        printf("%s<%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
-               node->class_->scanner->display_prompt,
-               _synctex_data_tag(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        printf("%s<%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n", node->class_->scanner->display_prompt, _synctex_data_tag(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
-        printf("%s>\n",node->class_->scanner->display_prompt);
+        printf("%s>\n", node->class_->scanner->display_prompt);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_vbox(synctex_node_p node) {
+static char *_synctex_abstract_vbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"[%i,%i:%i,%i:%i,%i,%i...]"
-               SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node),
-               _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "[%i,%i:%i,%i:%i,%i,%i...]" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node),
+                 _synctex_data_height(node),
+                 _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_vbox(synctex_node_p node) {
+static void _synctex_display_vbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s[%i,%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%s[%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
@@ -3936,8 +3980,7 @@ static void _synctex_display_vbox(synctex_node_p node) {
                _synctex_data_v(node),
                _synctex_data_width(node),
                _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
         printf("%s]\n%slast:%s\n",
                node->class_->scanner->display_prompt,
@@ -3947,30 +3990,30 @@ static void _synctex_display_vbox(synctex_node_p node) {
     }
 }
 
-static char * _synctex_abstract_hbox(synctex_node_p node) {
+static char *_synctex_abstract_hbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"(%i,%i~%i*%i:%i,%i:%i,%i,%i...)"
-               SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_mean_line(node),
-               _synctex_data_weight(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node),
-               _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "(%i,%i~%i*%i:%i,%i:%i,%i,%i...)" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_mean_line(node),
+                 _synctex_data_weight(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node),
+                 _synctex_data_height(node),
+                 _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_hbox(synctex_node_p node) {
+static void _synctex_display_hbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s(%i,%i~%i*%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%s(%i,%i~%i*%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
@@ -3980,8 +4023,7 @@ static void _synctex_display_hbox(synctex_node_p node) {
                _synctex_data_v(node),
                _synctex_data_width(node),
                _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
         printf("%s)\n%slast:%s\n",
                node->class_->scanner->display_prompt,
@@ -3991,29 +4033,28 @@ static void _synctex_display_hbox(synctex_node_p node) {
     }
 }
 
-static char * _synctex_abstract_void_vbox(synctex_node_p node) {
+static char *_synctex_abstract_void_vbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"v%i,%i;%i,%i:%i,%i,%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT
-                       "\n",
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node),
-               _synctex_data_height(node),
-               _synctex_data_depth(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "v%i,%i;%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node),
+                 _synctex_data_height(node),
+                 _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_void_vbox(synctex_node_p node) {
+static void _synctex_display_void_vbox(synctex_node_p node)
+{
     if (node) {
-        printf("%sv%i,%i;%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%sv%i,%i;%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
@@ -4021,34 +4062,33 @@ static void _synctex_display_void_vbox(synctex_node_p node) {
                _synctex_data_v(node),
                _synctex_data_width(node),
                _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_void_hbox(synctex_node_p node) {
+static char *_synctex_abstract_void_hbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"h%i,%i:%i,%i:%i,%i,%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node),
-               _synctex_data_height(node),
-               _synctex_data_depth(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "h%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node),
+                 _synctex_data_height(node),
+                 _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_void_hbox(synctex_node_p node) {
+static void _synctex_display_void_hbox(synctex_node_p node)
+{
     if (node) {
-        printf("%sh%i,%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%sh%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
@@ -4056,179 +4096,176 @@ static void _synctex_display_void_hbox(synctex_node_p node) {
                _synctex_data_v(node),
                _synctex_data_width(node),
                _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_glue(synctex_node_p node) {
+static char *_synctex_abstract_glue(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"glue:%i,%i:%i,%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "glue:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_glue(synctex_node_p node) {
+static void _synctex_display_glue(synctex_node_p node)
+{
     if (node) {
-        printf("%sglue:%i,%i:%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%sglue:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
                _synctex_data_h(node),
-               _synctex_data_v(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_rule(synctex_node_p node) {
+static char *_synctex_abstract_rule(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"rule:%i,%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT,
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "rule:%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node),
+                 _synctex_data_height(node),
+                 _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
+    }
+    return abstract;
+}
+
+static void _synctex_display_rule(synctex_node_p node)
+{
+    if (node) {
+        printf("%srule:%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
+               node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
                _synctex_data_h(node),
                _synctex_data_v(node),
                _synctex_data_width(node),
                _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
+        _synctex_display_sibling(node);
+    }
+}
+
+static char *_synctex_abstract_math(synctex_node_p node)
+{
+    static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
+    if (node) {
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "math:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_rule(synctex_node_p node) {
+static void _synctex_display_math(synctex_node_p node)
+{
     if (node) {
-        printf("%srule:%i,%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%smath:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
+               node->class_->scanner->display_prompt,
+               _synctex_data_tag(node),
+               _synctex_data_line(node),
+               _synctex_data_h(node),
+               _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
+        _synctex_display_sibling(node);
+    }
+}
+
+static char *_synctex_abstract_kern(synctex_node_p node)
+{
+    static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
+    if (node) {
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "kern:%i,%i:%i,%i:%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 _synctex_data_width(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
+    }
+    return abstract;
+}
+
+static void _synctex_display_kern(synctex_node_p node)
+{
+    if (node) {
+        printf("%skern:%i,%i:%i,%i:%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
                _synctex_data_h(node),
                _synctex_data_v(node),
-               _synctex_data_width(node),
-               _synctex_data_height(node),
-               _synctex_data_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_width(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_math(synctex_node_p node) {
+static char *_synctex_abstract_boundary(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"math:%i,%i:%i,%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "boundary:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_math(synctex_node_p node) {
+static void _synctex_display_boundary(synctex_node_p node)
+{
     if (node) {
-        printf("%smath:%i,%i:%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%sboundary:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                _synctex_data_tag(node),
                _synctex_data_line(node),
                _synctex_data_h(node),
-               _synctex_data_v(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_sibling(node);
     }
 }
 
-static char * _synctex_abstract_kern(synctex_node_p node) {
+static char *_synctex_abstract_box_bdry(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"kern:%i,%i:%i,%i:%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "box bdry:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_kern(synctex_node_p node) {
-    if (node) {
-        printf("%skern:%i,%i:%i,%i:%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
-               node->class_->scanner->display_prompt,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               _synctex_data_width(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
-        _synctex_display_sibling(node);
-    }
-}
-
-static char * _synctex_abstract_boundary(synctex_node_p node) {
-    static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
-    if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"boundary:%i,%i:%i,%i"
-                       SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
-    }
-    return abstract;
-}
-
-static void _synctex_display_boundary(synctex_node_p node) {
-    if (node) {
-        printf("%sboundary:%i,%i:%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
-               node->class_->scanner->display_prompt,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
-        _synctex_display_sibling(node);
-    }
-}
-
-static char * _synctex_abstract_box_bdry(synctex_node_p node) {
-    static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
-    if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"box bdry:%i,%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
-    }
-    return abstract;
-}
-
-static void _synctex_display_box_bdry(synctex_node_p node) {
+static void _synctex_display_box_bdry(synctex_node_p node)
+{
     if (node) {
         printf("%sbox bdry:%i,%i:%i,%i",
                node->class_->scanner->display_prompt,
@@ -4241,45 +4278,48 @@ static void _synctex_display_box_bdry(synctex_node_p node) {
     }
 }
 
-static char * _synctex_abstract_ref(synctex_node_p node) {
+static char *_synctex_abstract_ref(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"form ref:%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
-               _synctex_data_tag(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node)
-                       SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "form ref:%i:%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 _synctex_data_tag(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_ref(synctex_node_p node) {
+static void _synctex_display_ref(synctex_node_p node)
+{
     if (node) {
-        printf("%sform ref:%i:%i,%i",
-               node->class_->scanner->display_prompt,
-               _synctex_data_tag(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node));
+        printf("%sform ref:%i:%i,%i", node->class_->scanner->display_prompt, _synctex_data_tag(node), _synctex_data_h(node), _synctex_data_v(node));
         SYNCTEX_PRINT_CHARINDEX_NL;
         _synctex_display_sibling(node);
     }
 }
-static char * _synctex_abstract_proxy(synctex_node_p node) {
+static char *_synctex_abstract_proxy(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
         synctex_node_p N = _synctex_tree_target(node);
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"%s:%i,%i:%i,%i/%p%s",
-               synctex_node_isa(node),
-               synctex_node_tag(node),
-               synctex_node_line(node),
-               _synctex_data_h(node),
-               _synctex_data_v(node),
-               (void*)node, // Fix GCC warning: %p expects a void* according to POSIX
-               _synctex_node_abstract(N));
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "%s:%i,%i:%i,%i/%p%s",
+                 synctex_node_isa(node),
+                 synctex_node_tag(node),
+                 synctex_node_line(node),
+                 _synctex_data_h(node),
+                 _synctex_data_v(node),
+                 (void *)node, // Fix GCC warning: %p expects a void* according to POSIX
+                 _synctex_node_abstract(N));
     }
     return abstract;
 }
-static void _synctex_display_proxy(synctex_node_p node) {
+static void _synctex_display_proxy(synctex_node_p node)
+{
     if (node) {
         synctex_node_p N = _synctex_tree_target(node);
         printf("%s%s:%i,%i:%i,%i",
@@ -4303,29 +4343,28 @@ static void _synctex_display_proxy(synctex_node_p node) {
         _synctex_display_sibling(node);
     }
 }
-static char * _synctex_abstract_proxy_vbox(synctex_node_p node) {
+static char *_synctex_abstract_proxy_vbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,
-                 "[*%i,%i:%i,%i:%i,%i,%i...*]"
-               SYNCTEX_PRINT_CHARINDEX_FMT,
-               synctex_node_tag(node),
-               synctex_node_line(node),
-               synctex_node_h(node),
-               synctex_node_v(node),
-               synctex_node_width(node),
-               synctex_node_height(node),
-               synctex_node_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "[*%i,%i:%i,%i:%i,%i,%i...*]" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 synctex_node_tag(node),
+                 synctex_node_line(node),
+                 synctex_node_h(node),
+                 synctex_node_v(node),
+                 synctex_node_width(node),
+                 synctex_node_height(node),
+                 synctex_node_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_proxy_vbox(synctex_node_p node) {
+static void _synctex_display_proxy_vbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s[*%i,%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%s[*%i,%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                synctex_node_tag(node),
                synctex_node_line(node),
@@ -4333,8 +4372,7 @@ static void _synctex_display_proxy_vbox(synctex_node_p node) {
                synctex_node_v(node),
                synctex_node_width(node),
                synctex_node_height(node),
-               synctex_node_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               synctex_node_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
         printf("%s*]\n%slast:%s\n",
                node->class_->scanner->display_prompt,
@@ -4344,31 +4382,32 @@ static void _synctex_display_proxy_vbox(synctex_node_p node) {
     }
 }
 
-static char * _synctex_abstract_proxy_hbox(synctex_node_p node) {
+static char *_synctex_abstract_proxy_hbox(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"(*%i,%i~%i*%i:%i,%i:%i,%i,%i...*)/%p"
-               SYNCTEX_PRINT_CHARINDEX_FMT,
-               synctex_node_tag(node),
-               synctex_node_line(node),
-               synctex_node_mean_line(node),
-               synctex_node_weight(node),
-               synctex_node_h(node),
-               synctex_node_v(node),
-               synctex_node_width(node),
-               synctex_node_height(node),
-               synctex_node_depth(node),
-               (void*)node // Fix GCC warning: %p expects a void* according to POSIX
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+        snprintf(abstract,
+                 SYNCTEX_ABSTRACT_MAX,
+                 "(*%i,%i~%i*%i:%i,%i:%i,%i,%i...*)/%p" SYNCTEX_PRINT_CHARINDEX_FMT,
+                 synctex_node_tag(node),
+                 synctex_node_line(node),
+                 synctex_node_mean_line(node),
+                 synctex_node_weight(node),
+                 synctex_node_h(node),
+                 synctex_node_v(node),
+                 synctex_node_width(node),
+                 synctex_node_height(node),
+                 synctex_node_depth(node),
+                 (void *)node // Fix GCC warning: %p expects a void* according to POSIX
+                     SYNCTEX_PRINT_CHARINDEX_WHAT);
     }
     return abstract;
 }
 
-static void _synctex_display_proxy_hbox(synctex_node_p node) {
+static void _synctex_display_proxy_hbox(synctex_node_p node)
+{
     if (node) {
-        printf("%s(*%i,%i~%i*%i:%i,%i:%i,%i,%i"
-               SYNCTEX_PRINT_CHARINDEX_FMT
-               "\n",
+        printf("%s(*%i,%i~%i*%i:%i,%i:%i,%i,%i" SYNCTEX_PRINT_CHARINDEX_FMT "\n",
                node->class_->scanner->display_prompt,
                synctex_node_tag(node),
                synctex_node_line(node),
@@ -4378,8 +4417,7 @@ static void _synctex_display_proxy_hbox(synctex_node_p node) {
                synctex_node_v(node),
                synctex_node_width(node),
                synctex_node_height(node),
-               synctex_node_depth(node)
-               SYNCTEX_PRINT_CHARINDEX_WHAT);
+               synctex_node_depth(node) SYNCTEX_PRINT_CHARINDEX_WHAT);
         _synctex_display_child(node);
         printf("%s*)\n%slast:%s\n",
                node->class_->scanner->display_prompt,
@@ -4389,40 +4427,36 @@ static void _synctex_display_proxy_hbox(synctex_node_p node) {
     }
 }
 
-static char * _synctex_abstract_handle(synctex_node_p node) {
+static char *_synctex_abstract_handle(synctex_node_p node)
+{
     static char abstract[SYNCTEX_ABSTRACT_MAX] = "none";
     if (node) {
         synctex_node_p N = _synctex_tree_target(node);
         if (N && !N->class_) {
             exit(1);
         }
-        snprintf(abstract,SYNCTEX_ABSTRACT_MAX,"%s:%s",
-               synctex_node_isa(node),
-               (N?_synctex_node_abstract(N):""));
+        snprintf(abstract, SYNCTEX_ABSTRACT_MAX, "%s:%s", synctex_node_isa(node), (N ? _synctex_node_abstract(N) : ""));
     }
     return abstract;
 }
-static void _synctex_display_handle(synctex_node_p node) {
+static void _synctex_display_handle(synctex_node_p node)
+{
     if (node) {
         synctex_node_p N = _synctex_tree_target(node);
-        printf("%s%s(%i):->%s\n",
-               node->class_->scanner->display_prompt,
-               synctex_node_isa(node),
-               _synctex_data_weight(N),
-               _synctex_node_abstract(N));
+        printf("%s%s(%i):->%s\n", node->class_->scanner->display_prompt, synctex_node_isa(node), _synctex_data_weight(N), _synctex_node_abstract(N));
         _synctex_display_child(node);
         _synctex_display_sibling(node);
     }
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark STATUS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark STATUS
+#endif
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Prototypes
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Prototypes
+#endif
 /**
  * @brief size+status structure
  *
@@ -4436,7 +4470,7 @@ typedef struct {
 } _synctex_zs_s;
 static _synctex_zs_s _synctex_buffer_get_available_size(synctex_scanner_p scanner, size_t size);
 static synctex_status_t _synctex_next_line(synctex_scanner_p scanner);
-static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const char * the_string);
+static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const char *the_string);
 
 /**
  * @brief node+status structure
@@ -4470,12 +4504,12 @@ static synctex_status_t _synctex_scan_content(synctex_scanner_p scanner);
 int _synctex_scanner_pre_x_offset(synctex_scanner_p scanner);
 int _synctex_scanner_pre_y_offset(synctex_scanner_p scanner);
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark SCANNER UTILITIES
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark SCANNER UTILITIES
+#endif
 
-#   define SYNCTEX_FILE (scanner->reader->file)
+#define SYNCTEX_FILE (scanner->reader->file)
 
 /**
  *  Try to ensure that the buffer contains at least size bytes.
@@ -4490,54 +4524,55 @@ int _synctex_scanner_pre_y_offset(synctex_scanner_p scanner);
  *  - parameter expected: expected number of bytes.
  *  - returns: a size and a status.
  */
-static _synctex_zs_s _synctex_buffer_get_available_size(synctex_scanner_p scanner, size_t expected) {
+static _synctex_zs_s _synctex_buffer_get_available_size(synctex_scanner_p scanner, size_t expected)
+{
     size_t size = 0;
     if (NULL == scanner) {
-        return (_synctex_zs_s){0,SYNCTEX_STATUS_BAD_ARGUMENT};
+        return (_synctex_zs_s){0, SYNCTEX_STATUS_BAD_ARGUMENT};
     }
-    if (expected>scanner->reader->size){
+    if (expected > scanner->reader->size) {
         expected = scanner->reader->size;
     }
     size = SYNCTEX_END - SYNCTEX_CUR; /*  available is the number of unparsed chars in the buffer */
-    if (expected<=size) {
+    if (expected <= size) {
         /*  There are already sufficiently many characters in the buffer */
-        return (_synctex_zs_s){size,SYNCTEX_STATUS_OK};
+        return (_synctex_zs_s){size, SYNCTEX_STATUS_OK};
     }
     if (SYNCTEX_FILE) {
         /*  Copy the remaining part of the buffer to the beginning,
          *  then read the next part of the file */
         int already_read = 0;
-#   if defined(SYNCTEX_USE_CHARINDEX)
+#if defined(SYNCTEX_USE_CHARINDEX)
         scanner->reader->charindex_offset += SYNCTEX_CUR - SYNCTEX_START;
-#   endif
+#endif
         if (size) {
             memmove(SYNCTEX_START, SYNCTEX_CUR, size);
         }
         SYNCTEX_CUR = SYNCTEX_START + size; /*  the next character after the move, will change. */
         /*  Fill the buffer up to its end */
-        already_read = gzread(SYNCTEX_FILE,(void *)SYNCTEX_CUR,(int)(SYNCTEX_BUFFER_SIZE - size));
-        if (already_read>0) {
+        already_read = gzread(SYNCTEX_FILE, (void *)SYNCTEX_CUR, (int)(SYNCTEX_BUFFER_SIZE - size));
+        if (already_read > 0) {
             /*  We assume that 0<already_read<=SYNCTEX_BUFFER_SIZE - size, such that
              *  SYNCTEX_CUR + already_read = SYNCTEX_START + size  + already_read <= SYNCTEX_START + SYNCTEX_BUFFER_SIZE */
             SYNCTEX_END = SYNCTEX_CUR + already_read;
             /*  If the end of the file was reached, all the required SYNCTEX_BUFFER_SIZE - available
              *  may not be filled with values from the file.
              *  In that case, the buffer should stop properly after already_read characters. */
-            * SYNCTEX_END = '\0'; /* there is enough room */
+            *SYNCTEX_END = '\0'; /* there is enough room */
             SYNCTEX_CUR = SYNCTEX_START;
             /*  May be available is less than size, the caller will have to test. */
-            return (_synctex_zs_s){SYNCTEX_END - SYNCTEX_CUR,SYNCTEX_STATUS_OK};
-        } else if (0>already_read) {
+            return (_synctex_zs_s){SYNCTEX_END - SYNCTEX_CUR, SYNCTEX_STATUS_OK};
+        } else if (0 > already_read) {
             /*  There is a possible error in reading the file */
             int errnum = 0;
-            const char * error_string = gzerror(SYNCTEX_FILE, &errnum);
+            const char *error_string = gzerror(SYNCTEX_FILE, &errnum);
             if (Z_ERRNO == errnum) {
                 /*  There is an error in zlib caused by the file system */
-                _synctex_error("gzread error from the file system (%i)",errno);
-                return (_synctex_zs_s){0,SYNCTEX_STATUS_ERROR};
+                _synctex_error("gzread error from the file system (%i)", errno);
+                return (_synctex_zs_s){0, SYNCTEX_STATUS_ERROR};
             } else if (errnum) {
-                _synctex_error("gzread error (%i:%i,%s)",already_read,errnum,error_string);
-                return (_synctex_zs_s){0,SYNCTEX_STATUS_ERROR};
+                _synctex_error("gzread error (%i:%i,%s)", already_read, errnum, error_string);
+                return (_synctex_zs_s){0, SYNCTEX_STATUS_ERROR};
             }
         }
         /*  Nothing was read, we are at the end of the file. */
@@ -4545,12 +4580,12 @@ static _synctex_zs_s _synctex_buffer_get_available_size(synctex_scanner_p scanne
         SYNCTEX_FILE = NULL;
         SYNCTEX_END = SYNCTEX_CUR;
         SYNCTEX_CUR = SYNCTEX_START;
-        * SYNCTEX_END = '\0';/*  Terminate the string properly.*/
+        *SYNCTEX_END = '\0'; /*  Terminate the string properly.*/
         /*  there might be a bit of text left */
-        return (_synctex_zs_s){SYNCTEX_END - SYNCTEX_CUR,SYNCTEX_STATUS_EOF};
+        return (_synctex_zs_s){SYNCTEX_END - SYNCTEX_CUR, SYNCTEX_STATUS_EOF};
     }
     /*  We cannot enlarge the buffer because the end of the file was reached. */
-    return (_synctex_zs_s){size,SYNCTEX_STATUS_EOF};
+    return (_synctex_zs_s){size, SYNCTEX_STATUS_EOF};
 }
 
 /*  Used when parsing the synctex file.
@@ -4562,13 +4597,14 @@ static _synctex_zs_s _synctex_buffer_get_available_size(synctex_scanner_p scanne
  *  When the function returns with no error, SYNCTEX_CUR points to the first character of the next line, if any.
  *  J. Laurens: Sat May 10 07:52:31 UTC 2008
  */
-static synctex_status_t _synctex_next_line(synctex_scanner_p scanner) {
+static synctex_status_t _synctex_next_line(synctex_scanner_p scanner)
+{
     synctex_status_t status = SYNCTEX_STATUS_OK;
     if (NULL == scanner) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
 infinite_loop:
-    while(SYNCTEX_CUR<SYNCTEX_END) {
+    while (SYNCTEX_CUR < SYNCTEX_END) {
         if (*SYNCTEX_CUR == '\n') {
             ++SYNCTEX_CUR;
             ++scanner->reader->line_number;
@@ -4579,7 +4615,7 @@ infinite_loop:
     /*  Here, we have SYNCTEX_CUR == SYNCTEX_END, such that the next call to _synctex_buffer_get_available_size
      *  will read another bunch of synctex file. Little by little, we advance to the end of the file. */
     status = _synctex_buffer_get_available_size(scanner, 1).status;
-    if (status<=SYNCTEX_STATUS_EOF) {
+    if (status <= SYNCTEX_STATUS_EOF) {
         return status;
     }
     goto infinite_loop;
@@ -4595,11 +4631,12 @@ infinite_loop:
  *  The given string might be as long as the maximum size_t value.
  *  As side effect, the buffer state may have changed if the given argument string can't fit into the buffer.
  */
-static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const char * the_string) {
+static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const char *the_string)
+{
     /* size_t tested_len = 0; */ /*  the number of characters at the beginning of the_string that match */
     size_t remaining_len = 0; /*  the number of remaining characters of the_string that should match */
     size_t available = 0;
-    _synctex_zs_s zs = {0,0};
+    _synctex_zs_s zs = {0, 0};
     if (NULL == scanner || NULL == the_string) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
@@ -4608,21 +4645,21 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
     /*  How many characters available in the buffer? */
-    zs = _synctex_buffer_get_available_size(scanner,remaining_len);
-    if (zs.status<SYNCTEX_STATUS_EOF) {
+    zs = _synctex_buffer_get_available_size(scanner, remaining_len);
+    if (zs.status < SYNCTEX_STATUS_EOF) {
         return zs.status;
     }
     /*  Maybe we have less characters than expected because the buffer is too small. */
-    if (zs.size>=remaining_len) {
+    if (zs.size >= remaining_len) {
         /*  The buffer is sufficiently big to hold the expected number of characters. */
-        if (strncmp((char *)SYNCTEX_CUR,the_string,remaining_len)) {
+        if (strncmp((char *)SYNCTEX_CUR, the_string, remaining_len)) {
             return SYNCTEX_STATUS_NOT_OK;
         }
     return_OK:
         /*  Advance SYNCTEX_CUR to the next character after the_string. */
         SYNCTEX_CUR += remaining_len;
         return SYNCTEX_STATUS_OK;
-    } else if (strncmp((char *)SYNCTEX_CUR,the_string,zs.size)) {
+    } else if (strncmp((char *)SYNCTEX_CUR, the_string, zs.size)) {
         /*  No need to go further, this is not the expected string in the buffer. */
         return SYNCTEX_STATUS_NOT_OK;
     } else if (SYNCTEX_FILE) {
@@ -4657,14 +4694,14 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
          *  This is the second call to _synctex_buffer_get_available_size,
          *  which means that the actual contents of the buffer will be discarded.
          *  We will definitely have to recover the previous state in case we do not find the expected string. */
-        zs = _synctex_buffer_get_available_size(scanner,remaining_len);
-        if (zs.status<SYNCTEX_STATUS_EOF) {
+        zs = _synctex_buffer_get_available_size(scanner, remaining_len);
+        if (zs.status < SYNCTEX_STATUS_EOF) {
             return zs.status; /*  This is an error, no need to go further. */
         }
-        if (zs.size==0) {
+        if (zs.size == 0) {
             /*  Missing characters: recover the initial state of the file and return. */
         return_NOT_OK:
-            if (offset != gzseek(SYNCTEX_FILE,offset,SEEK_SET)) {
+            if (offset != gzseek(SYNCTEX_FILE, offset, SEEK_SET)) {
                 /*  This is a critical error, we could not recover the previous state. */
                 _synctex_error("Can't seek file");
                 return SYNCTEX_STATUS_ERROR;
@@ -4674,9 +4711,9 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
             SYNCTEX_CUR = SYNCTEX_END;
             return SYNCTEX_STATUS_NOT_OK;
         }
-        if (zs.size<remaining_len) {
+        if (zs.size < remaining_len) {
             /*  We'll have to loop one more time. */
-            if (strncmp((char *)SYNCTEX_CUR,the_string,zs.size)) {
+            if (strncmp((char *)SYNCTEX_CUR, the_string, zs.size)) {
                 /*  This is not the expected string, recover the previous state and return. */
                 goto return_NOT_OK;
             }
@@ -4689,7 +4726,7 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
             goto more_characters;
         }
         /*  This is the last step. */
-        if (strncmp((char *)SYNCTEX_CUR,the_string,remaining_len)) {
+        if (strncmp((char *)SYNCTEX_CUR, the_string, remaining_len)) {
             /*  This is not the expected string, recover the previous state and return. */
             goto return_NOT_OK;
         }
@@ -4710,68 +4747,70 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
  *  It is SYNCTEX_STATUS_OK if an int has been successfully parsed.
  *  The given scanner argument must not be NULL, on the contrary, value_ref may be NULL.
  */
-static _synctex_is_s _synctex_decode_int(synctex_scanner_p scanner) {
-    char * ptr = NULL;
-    char * end = NULL;
-    _synctex_zs_s zs = {0,0};
+static _synctex_is_s _synctex_decode_int(synctex_scanner_p scanner)
+{
+    char *ptr = NULL;
+    char *end = NULL;
+    _synctex_zs_s zs = {0, 0};
     int result;
     if (NULL == scanner) {
         return (_synctex_is_s){0, SYNCTEX_STATUS_BAD_ARGUMENT};
     }
     zs = _synctex_buffer_get_available_size(scanner, SYNCTEX_BUFFER_MIN_SIZE);
-    if (zs.status<SYNCTEX_STATUS_EOF) {
-        return (_synctex_is_s){0,zs.status};
+    if (zs.status < SYNCTEX_STATUS_EOF) {
+        return (_synctex_is_s){0, zs.status};
     }
-    if (zs.size==0) {
-        return (_synctex_is_s){0,SYNCTEX_STATUS_NOT_OK};
+    if (zs.size == 0) {
+        return (_synctex_is_s){0, SYNCTEX_STATUS_NOT_OK};
     }
     ptr = SYNCTEX_CUR;
     /*  Optionally parse the separator */
-    if (*ptr==':' || *ptr==',') {
+    if (*ptr == ':' || *ptr == ',') {
         ++ptr;
         --zs.size;
-        if (zs.size==0) {
-            return (_synctex_is_s){0,SYNCTEX_STATUS_NOT_OK};
+        if (zs.size == 0) {
+            return (_synctex_is_s){0, SYNCTEX_STATUS_NOT_OK};
         }
     }
     result = synctex_parse_int(ptr, &end);
-    if (end>ptr) {
+    if (end > ptr) {
         SYNCTEX_CUR = end;
-        return (_synctex_is_s){result,SYNCTEX_STATUS_OK};
+        return (_synctex_is_s){result, SYNCTEX_STATUS_OK};
     }
-    return (_synctex_is_s){result,SYNCTEX_STATUS_NOT_OK};
+    return (_synctex_is_s){result, SYNCTEX_STATUS_NOT_OK};
 }
-static _synctex_is_s _synctex_decode_int_opt(synctex_scanner_p scanner, int default_value) {
-    char * ptr = NULL;
-    char * end = NULL;
+static _synctex_is_s _synctex_decode_int_opt(synctex_scanner_p scanner, int default_value)
+{
+    char *ptr = NULL;
+    char *end = NULL;
     _synctex_zs_s zs = {0, 0};
     if (NULL == scanner) {
         return (_synctex_is_s){default_value, SYNCTEX_STATUS_BAD_ARGUMENT};
     }
     zs = _synctex_buffer_get_available_size(scanner, SYNCTEX_BUFFER_MIN_SIZE);
-    if (zs.status<SYNCTEX_STATUS_EOF) {
-        return (_synctex_is_s){default_value,zs.status};
+    if (zs.status < SYNCTEX_STATUS_EOF) {
+        return (_synctex_is_s){default_value, zs.status};
     }
-    if (zs.size==0) {
-        return (_synctex_is_s){default_value,SYNCTEX_STATUS_OK};
+    if (zs.size == 0) {
+        return (_synctex_is_s){default_value, SYNCTEX_STATUS_OK};
     }
     ptr = SYNCTEX_CUR;
     /*  Comma separator required */
-    if (*ptr==',') {
+    if (*ptr == ',') {
         int result;
         ++ptr;
         --zs.size;
-        if (zs.size==0) {
-            return (_synctex_is_s){default_value,SYNCTEX_STATUS_NOT_OK};
+        if (zs.size == 0) {
+            return (_synctex_is_s){default_value, SYNCTEX_STATUS_NOT_OK};
         }
         result = synctex_parse_int(ptr, &end);
-        if (end>ptr) {
+        if (end > ptr) {
             SYNCTEX_CUR = end;
-            return (_synctex_is_s){result,SYNCTEX_STATUS_OK};
+            return (_synctex_is_s){result, SYNCTEX_STATUS_OK};
         }
-        return (_synctex_is_s){default_value,SYNCTEX_STATUS_NOT_OK};
+        return (_synctex_is_s){default_value, SYNCTEX_STATUS_NOT_OK};
     }
-    return (_synctex_is_s){default_value,SYNCTEX_STATUS_OK};
+    return (_synctex_is_s){default_value, SYNCTEX_STATUS_OK};
 }
 /*  Used when parsing the synctex file.
  *  Decode an integer for a v field.
@@ -4779,15 +4818,16 @@ static _synctex_is_s _synctex_decode_int_opt(synctex_scanner_p scanner, int defa
  *  If it does not succeed, tries to match an '=' sign,
  *  which is a shortcut for the last v field scanned.
  */
-#   define SYNCTEX_INPUT_COMEQUALS ",="
-static _synctex_is_s _synctex_decode_int_v(synctex_scanner_p scanner) {
+#define SYNCTEX_INPUT_COMEQUALS ",="
+static _synctex_is_s _synctex_decode_int_v(synctex_scanner_p scanner)
+{
     _synctex_is_s is = _synctex_decode_int(scanner);
     if (SYNCTEX_STATUS_OK == is.status) {
         scanner->reader->lastv = is.integer;
         return is;
     }
-    is.status = _synctex_match_string(scanner,SYNCTEX_INPUT_COMEQUALS);
-    if (is.status<SYNCTEX_STATUS_OK) {
+    is.status = _synctex_match_string(scanner, SYNCTEX_INPUT_COMEQUALS);
+    if (is.status < SYNCTEX_STATUS_OK) {
         return is;
     }
     is.integer = scanner->reader->lastv;
@@ -4812,26 +4852,27 @@ static _synctex_is_s _synctex_decode_int_v(synctex_scanner_p scanner) {
  *  If either scanner or value_ref is NULL, it is considered as an error and
  *  SYNCTEX_STATUS_BAD_ARGUMENT is returned.
  */
-static _synctex_ss_s _synctex_decode_string(synctex_scanner_p scanner) {
-    char * end = NULL;
-    size_t len = 0;/*  The number of bytes to copy */
+static _synctex_ss_s _synctex_decode_string(synctex_scanner_p scanner)
+{
+    char *end = NULL;
+    size_t len = 0; /*  The number of bytes to copy */
     size_t already_len = 0;
-    _synctex_zs_s zs = {0,0};
-    char * string = NULL;
-    char * new_string = NULL;
+    _synctex_zs_s zs = {0, 0};
+    char *string = NULL;
+    char *new_string = NULL;
     if (NULL == scanner) {
-        return (_synctex_ss_s){NULL,SYNCTEX_STATUS_BAD_ARGUMENT};
+        return (_synctex_ss_s){NULL, SYNCTEX_STATUS_BAD_ARGUMENT};
     }
     /*  The buffer must at least contain one character: the '\n' end of line marker */
-    if (SYNCTEX_CUR>=SYNCTEX_END) {
-more_characters:
-        zs = _synctex_buffer_get_available_size(scanner,1);
+    if (SYNCTEX_CUR >= SYNCTEX_END) {
+    more_characters:
+        zs = _synctex_buffer_get_available_size(scanner, 1);
         if (zs.status < SYNCTEX_STATUS_EOF) {
             free(string);
-            return (_synctex_ss_s){NULL,zs.status};
+            return (_synctex_ss_s){NULL, zs.status};
         } else if (0 == zs.size) {
             free(string);
-            return (_synctex_ss_s){NULL,SYNCTEX_STATUS_EOF};
+            return (_synctex_ss_s){NULL, SYNCTEX_STATUS_EOF};
         }
     }
     /*  Now we are sure that there is at least one available character, either because
@@ -4839,44 +4880,44 @@ more_characters:
     /*  end will point to the next unparsed '\n' character in the file, when mapped to the buffer. */
     end = SYNCTEX_CUR;
     /*  We scan all the characters up to the next '\n' */
-    while (end<SYNCTEX_END && *end != '\n') {
+    while (end < SYNCTEX_END && *end != '\n') {
         ++end;
     }
     /*  OK, we found where to stop:
      *      either end == SYNCTEX_END
      *      or *end == '\n' */
     len = end - SYNCTEX_CUR;
-    if (len<UINT_MAX-already_len) {
-        if ((new_string = realloc(string,len+already_len+1)) != NULL) {
+    if (len < UINT_MAX - already_len) {
+        if ((new_string = realloc(string, len + already_len + 1)) != NULL) {
             string = new_string;
             new_string = NULL;
-            if (memcpy(string+already_len,SYNCTEX_CUR,len)) {
+            if (memcpy(string + already_len, SYNCTEX_CUR, len)) {
                 already_len += len;
-                string[already_len]='\0'; /*  Terminate the string */
-                SYNCTEX_CUR += len;/*  Eventually advance to the terminating '\n' */
-                if (SYNCTEX_CUR==SYNCTEX_END) {
+                string[already_len] = '\0'; /*  Terminate the string */
+                SYNCTEX_CUR += len; /*  Eventually advance to the terminating '\n' */
+                if (SYNCTEX_CUR == SYNCTEX_END) {
                     /* No \n found*/
                     goto more_characters;
                 }
                 /* trim the trailing whites */
                 len = already_len;
-                while (len>0) {
+                while (len > 0) {
                     already_len = len--;
-                    if (string[len]!=' ') {
+                    if (string[len] != ' ') {
                         break;
                     }
                 }
                 string[already_len] = '\0';
-                return (_synctex_ss_s){string,SYNCTEX_STATUS_OK};
+                return (_synctex_ss_s){string, SYNCTEX_STATUS_OK};
             }
             free(string);
             _synctex_error("could not copy memory (1).");
-            return (_synctex_ss_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ss_s){NULL, SYNCTEX_STATUS_ERROR};
         }
     }
     free(string);
     _synctex_error("could not (re)allocate memory (1).");
-    return (_synctex_ss_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ss_s){NULL, SYNCTEX_STATUS_ERROR};
 }
 
 /*  Used when parsing the synctex file.
@@ -4884,51 +4925,52 @@ more_characters:
  *  - parameter scanner: non NULL scanner
  *  - returns SYNCTEX_STATUS_OK on successful completions, others values otherwise.
  */
-static _synctex_ns_s __synctex_parse_new_input(synctex_scanner_p scanner) {
+static _synctex_ns_s __synctex_parse_new_input(synctex_scanner_p scanner)
+{
     synctex_node_p input = NULL;
     synctex_status_t status = SYNCTEX_STATUS_BAD_ARGUMENT;
-    _synctex_zs_s zs = {0,0};
+    _synctex_zs_s zs = {0, 0};
     if (NULL == scanner) {
-        return (_synctex_ns_s){NULL,status};
+        return (_synctex_ns_s){NULL, status};
     }
-    if ((status=_synctex_match_string(scanner,SYNCTEX_INPUT_MARK))<SYNCTEX_STATUS_OK) {
-        return (_synctex_ns_s){NULL,status};
+    if ((status = _synctex_match_string(scanner, SYNCTEX_INPUT_MARK)) < SYNCTEX_STATUS_OK) {
+        return (_synctex_ns_s){NULL, status};
     }
     /*  Create a node */
     if (NULL == (input = _synctex_new_input(scanner))) {
         _synctex_error("Could not create an input node.");
-        return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+        return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
     }
     /*  Decode the tag  */
-    if ((status=_synctex_data_decode_tag(input))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_data_decode_tag(input)) < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad format of input node.");
         _synctex_node_free(input);
-        return (_synctex_ns_s){NULL,status};
+        return (_synctex_ns_s){NULL, status};
     }
     /*  The next character is a field separator, we expect one character in the buffer. */
     zs = _synctex_buffer_get_available_size(scanner, 1);
-    if (zs.status<=SYNCTEX_STATUS_ERROR) {
-        return (_synctex_ns_s){NULL,status};
+    if (zs.status <= SYNCTEX_STATUS_ERROR) {
+        return (_synctex_ns_s){NULL, status};
     }
     if (0 == zs.size) {
-        return (_synctex_ns_s){NULL,SYNCTEX_STATUS_EOF};
+        return (_synctex_ns_s){NULL, SYNCTEX_STATUS_EOF};
     }
     /*  We can now safely advance to the next character, stepping over the field separator. */
     ++SYNCTEX_CUR;
     --zs.size;
     /*  Then we scan the file name */
-    if ((status=_synctex_data_decode_name(input))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_data_decode_name(input)) < SYNCTEX_STATUS_OK) {
         _synctex_node_free(input);
-        _synctex_next_line(scanner);/* Ignore this whole line */
-        return (_synctex_ns_s){NULL,status};
+        _synctex_next_line(scanner); /* Ignore this whole line */
+        return (_synctex_ns_s){NULL, status};
     }
     /*  Prepend this input node to the input linked list of the scanner */
-    __synctex_tree_set_sibling(input,scanner->input);/* input has no parent */
+    __synctex_tree_set_sibling(input, scanner->input); /* input has no parent */
     scanner->input = input;
-#   if SYNCTEX_VERBOSE
+#if SYNCTEX_VERBOSE
     synctex_node_log(input);
-#   endif
-    return (_synctex_ns_s){input,_synctex_next_line(scanner)};/*  read the line termination character, if any */
+#endif
+    return (_synctex_ns_s){input, _synctex_next_line(scanner)}; /*  read the line termination character, if any */
 }
 
 /*  Used when parsing the synctex file.
@@ -4939,18 +4981,19 @@ static _synctex_ns_s __synctex_parse_new_input(synctex_scanner_p scanner) {
  *  On return, the scanner points to the next character after the decoded object whatever it is.
  *  It is the responsibility of the caller to prepare the scanner for the next line.
  */
-static synctex_status_t _synctex_scan_named(synctex_scanner_p scanner,const char * name) {
+static synctex_status_t _synctex_scan_named(synctex_scanner_p scanner, const char *name)
+{
     synctex_status_t status = 0;
     if (NULL == scanner || NULL == name) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
 not_found:
-    status = _synctex_match_string(scanner,name);
-    if (status<SYNCTEX_STATUS_NOT_OK) {
+    status = _synctex_match_string(scanner, name);
+    if (status < SYNCTEX_STATUS_NOT_OK) {
         return status;
     } else if (status == SYNCTEX_STATUS_NOT_OK) {
         status = _synctex_next_line(scanner);
-        if (status<SYNCTEX_STATUS_OK) {
+        if (status < SYNCTEX_STATUS_OK) {
             return status;
         }
         goto not_found;
@@ -4961,82 +5004,83 @@ not_found:
 /*  Used when parsing the synctex file.
  *  Read the preamble.
  */
-static synctex_status_t _synctex_scan_preamble(synctex_scanner_p scanner) {
+static synctex_status_t _synctex_scan_preamble(synctex_scanner_p scanner)
+{
     synctex_status_t status = 0;
-    _synctex_is_s is = {0,0};
-    _synctex_ss_s ss = {NULL,0};
+    _synctex_is_s is = {0, 0};
+    _synctex_ss_s ss = {NULL, 0};
     if (NULL == scanner) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
-    status = _synctex_scan_named(scanner,"SyncTeX Version:");
-    if (status<SYNCTEX_STATUS_OK) {
+    status = _synctex_scan_named(scanner, "SyncTeX Version:");
+    if (status < SYNCTEX_STATUS_OK) {
         return status;
     }
     is = _synctex_decode_int(scanner);
-    if (is.status<SYNCTEX_STATUS_OK) {
+    if (is.status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
     status = _synctex_next_line(scanner);
-    if (status<SYNCTEX_STATUS_OK) {
+    if (status < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->version = is.integer;
     /*  Read all the input records */
     do {
         status = __synctex_parse_new_input(scanner).status;
-        if (status<SYNCTEX_STATUS_NOT_OK) {
+        if (status < SYNCTEX_STATUS_NOT_OK) {
             return status;
         }
-    } while(status == SYNCTEX_STATUS_OK);
+    } while (status == SYNCTEX_STATUS_OK);
     /*  the loop exits when status == SYNCTEX_STATUS_NOT_OK */
     /*  Now read all the required settings. */
-    if ((status=_synctex_scan_named(scanner,"Output:"))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_scan_named(scanner, "Output:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
-    if ((ss=_synctex_decode_string(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((ss = _synctex_decode_string(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->output_fmt = ss.string;
-    if ((status=_synctex_scan_named(scanner,"Magnification:"))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_scan_named(scanner, "Magnification:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
-    if ((is=_synctex_decode_int(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((is = _synctex_decode_int(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->pre_magnification = is.integer;
-    if ((status=_synctex_scan_named(scanner,"Unit:"))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_scan_named(scanner, "Unit:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
-    if ((is=_synctex_decode_int(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((is = _synctex_decode_int(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->pre_unit = is.integer;
-    if ((status=_synctex_scan_named(scanner,"X Offset:"))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_scan_named(scanner, "X Offset:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
-    if ((is=_synctex_decode_int(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((is = _synctex_decode_int(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->pre_x_offset = is.integer;
-    if ((status=_synctex_scan_named(scanner,"Y Offset:"))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_scan_named(scanner, "Y Offset:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
-    if ((is=_synctex_decode_int(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((is = _synctex_decode_int(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return status;
     }
     scanner->pre_y_offset = is.integer;
@@ -5044,78 +5088,79 @@ static synctex_status_t _synctex_scan_preamble(synctex_scanner_p scanner) {
 }
 
 /*  parse a float with a dimension */
-static _synctex_fs_s _synctex_scan_float_and_dimension(synctex_scanner_p scanner) {
-    _synctex_fs_s fs = {0,0};
-    _synctex_zs_s zs = {0,0};
-    char * endptr = NULL;
+static _synctex_fs_s _synctex_scan_float_and_dimension(synctex_scanner_p scanner)
+{
+    _synctex_fs_s fs = {0, 0};
+    _synctex_zs_s zs = {0, 0};
+    char *endptr = NULL;
 #ifdef HAVE_SETLOCALE
-    char * loc = setlocale(LC_NUMERIC, NULL);
+    char *loc = setlocale(LC_NUMERIC, NULL);
 #endif
     if (NULL == scanner) {
-        return (_synctex_fs_s){0,SYNCTEX_STATUS_BAD_ARGUMENT};
+        return (_synctex_fs_s){0, SYNCTEX_STATUS_BAD_ARGUMENT};
     }
     zs = _synctex_buffer_get_available_size(scanner, SYNCTEX_BUFFER_MIN_SIZE);
-    if (zs.status<SYNCTEX_STATUS_EOF) {
+    if (zs.status < SYNCTEX_STATUS_EOF) {
         _synctex_error("Problem with float.");
-        return (_synctex_fs_s){0,zs.status};
+        return (_synctex_fs_s){0, zs.status};
     }
 #ifdef HAVE_SETLOCALE
     setlocale(LC_NUMERIC, "C");
 #endif
-    fs.value = strtod(SYNCTEX_CUR,&endptr);
+    fs.value = strtod(SYNCTEX_CUR, &endptr);
 #ifdef HAVE_SETLOCALE
     setlocale(LC_NUMERIC, loc);
 #endif
     if (endptr == SYNCTEX_CUR) {
         _synctex_error("A float was expected.");
-        return (_synctex_fs_s){0,SYNCTEX_STATUS_ERROR};
+        return (_synctex_fs_s){0, SYNCTEX_STATUS_ERROR};
     }
     SYNCTEX_CUR = endptr;
-    if ((fs.status = _synctex_match_string(scanner,"in")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 72.27f*65536;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    if ((fs.status = _synctex_match_string(scanner, "in")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 72.27f * 65536;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
     report_unit_error:
         _synctex_error("problem with unit.");
         return fs;
-    } else if ((fs.status = _synctex_match_string(scanner,"cm")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 72.27f*65536/2.54f;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "cm")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 72.27f * 65536 / 2.54f;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"mm")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 72.27f*65536/25.4f;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "mm")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 72.27f * 65536 / 25.4f;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"pt")) >= SYNCTEX_STATUS_OK) {
+    } else if ((fs.status = _synctex_match_string(scanner, "pt")) >= SYNCTEX_STATUS_OK) {
         fs.value *= 65536.0f;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"bp")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 72.27f/72*65536.0f;
-    }  else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "bp")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 72.27f / 72 * 65536.0f;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"pc")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 12.0*65536.0f;
-    }  else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "pc")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 12.0 * 65536.0f;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"sp")) >= SYNCTEX_STATUS_OK) {
+    } else if ((fs.status = _synctex_match_string(scanner, "sp")) >= SYNCTEX_STATUS_OK) {
         fs.value *= 1.0f;
-    }  else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"dd")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 1238.0f/1157*65536.0f;
-    }  else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "dd")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 1238.0f / 1157 * 65536.0f;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"cc")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 14856.0f/1157*65536;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "cc")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 14856.0f / 1157 * 65536;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"nd")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 685.0f/642*65536;
-    }  else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "nd")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 685.0f / 642 * 65536;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
-    } else if ((fs.status = _synctex_match_string(scanner,"nc")) >= SYNCTEX_STATUS_OK) {
-        fs.value *= 1370.0f/107*65536;
-    } else if (fs.status<SYNCTEX_STATUS_EOF) {
+    } else if ((fs.status = _synctex_match_string(scanner, "nc")) >= SYNCTEX_STATUS_OK) {
+        fs.value *= 1370.0f / 107 * 65536;
+    } else if (fs.status < SYNCTEX_STATUS_EOF) {
         goto report_unit_error;
     }
     return fs;
@@ -5124,46 +5169,47 @@ static _synctex_fs_s _synctex_scan_float_and_dimension(synctex_scanner_p scanner
 /*  parse the post scriptum
  *  SYNCTEX_STATUS_OK is returned on completion
  *  a negative error is returned otherwise */
-static synctex_status_t _synctex_scan_post_scriptum(synctex_scanner_p scanner) {
+static synctex_status_t _synctex_scan_post_scriptum(synctex_scanner_p scanner)
+{
     synctex_status_t status = 0;
-    _synctex_fs_s fs = {0,0};
-    char * endptr = NULL;
+    _synctex_fs_s fs = {0, 0};
+    char *endptr = NULL;
 #ifdef HAVE_SETLOCALE
-    char * loc = setlocale(LC_NUMERIC, NULL);
+    char *loc = setlocale(LC_NUMERIC, NULL);
 #endif
     if (NULL == scanner) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
     /*  Scan the file until a post scriptum line is found */
 post_scriptum_not_found:
-    status = _synctex_match_string(scanner,"Post scriptum:");
-    if (status<SYNCTEX_STATUS_NOT_OK) {
+    status = _synctex_match_string(scanner, "Post scriptum:");
+    if (status < SYNCTEX_STATUS_NOT_OK) {
         return status;
     }
     if (status == SYNCTEX_STATUS_NOT_OK) {
         status = _synctex_next_line(scanner);
-        if (status<SYNCTEX_STATUS_EOF) {
+        if (status < SYNCTEX_STATUS_EOF) {
             return status;
-        } else if (status<SYNCTEX_STATUS_OK) {
-            return SYNCTEX_STATUS_OK;/*  The EOF is found, we have properly scanned the file */
+        } else if (status < SYNCTEX_STATUS_OK) {
+            return SYNCTEX_STATUS_OK; /*  The EOF is found, we have properly scanned the file */
         }
         goto post_scriptum_not_found;
     }
     /*  We found the name, advance to the next line. */
 next_line:
     status = _synctex_next_line(scanner);
-    if (status<SYNCTEX_STATUS_EOF) {
+    if (status < SYNCTEX_STATUS_EOF) {
         return status;
-    } else if (status<SYNCTEX_STATUS_OK) {
-        return SYNCTEX_STATUS_OK;/*  The EOF is found, we have properly scanned the file */
+    } else if (status < SYNCTEX_STATUS_OK) {
+        return SYNCTEX_STATUS_OK; /*  The EOF is found, we have properly scanned the file */
     }
     /*  Scanning the information */
-    status = _synctex_match_string(scanner,"Magnification:");
-    if (status == SYNCTEX_STATUS_OK ) {
+    status = _synctex_match_string(scanner, "Magnification:");
+    if (status == SYNCTEX_STATUS_OK) {
 #ifdef HAVE_SETLOCALE
         setlocale(LC_NUMERIC, "C");
 #endif
-        scanner->unit = strtod(SYNCTEX_CUR,&endptr);
+        scanner->unit = strtod(SYNCTEX_CUR, &endptr);
 #ifdef HAVE_SETLOCALE
         setlocale(LC_NUMERIC, loc);
 #endif
@@ -5171,40 +5217,40 @@ next_line:
             _synctex_error("bad magnification in the post scriptum, a float was expected.");
             return SYNCTEX_STATUS_ERROR;
         }
-        if (scanner->unit<=0) {
+        if (scanner->unit <= 0) {
             _synctex_error("bad magnification in the post scriptum, a positive float was expected.");
             return SYNCTEX_STATUS_ERROR;
         }
         SYNCTEX_CUR = endptr;
         goto next_line;
     }
-    if (status<SYNCTEX_STATUS_EOF){
+    if (status < SYNCTEX_STATUS_EOF) {
     report_record_problem:
         _synctex_error("Problem reading the Post Scriptum records");
         return status; /*  echo the error. */
     }
-    status = _synctex_match_string(scanner,"X Offset:");
+    status = _synctex_match_string(scanner, "X Offset:");
     if (status == SYNCTEX_STATUS_OK) {
         fs = _synctex_scan_float_and_dimension(scanner);
-        if (fs.status<SYNCTEX_STATUS_OK) {
+        if (fs.status < SYNCTEX_STATUS_OK) {
             _synctex_error("Problem with X offset in the Post Scriptum.");
             return fs.status;
         }
         scanner->x_offset = fs.value;
         goto next_line;
-    } else if (status<SYNCTEX_STATUS_EOF){
+    } else if (status < SYNCTEX_STATUS_EOF) {
         goto report_record_problem;
     }
-    status = _synctex_match_string(scanner,"Y Offset:");
-    if (status==SYNCTEX_STATUS_OK) {
+    status = _synctex_match_string(scanner, "Y Offset:");
+    if (status == SYNCTEX_STATUS_OK) {
         fs = _synctex_scan_float_and_dimension(scanner);
-        if (fs.status<SYNCTEX_STATUS_OK) {
+        if (fs.status < SYNCTEX_STATUS_OK) {
             _synctex_error("Problem with Y offset in the Post Scriptum.");
             return fs.status;
         }
         scanner->y_offset = fs.value;
         goto next_line;
-    } else if (status<SYNCTEX_STATUS_EOF){
+    } else if (status < SYNCTEX_STATUS_EOF) {
         goto report_record_problem;
     }
     goto next_line;
@@ -5215,28 +5261,29 @@ next_line:
  *  a negative error otherwise
  *  The postamble comprises the post scriptum section.
  */
-static synctex_status_t _synctex_scan_postamble(synctex_scanner_p scanner) {
+static synctex_status_t _synctex_scan_postamble(synctex_scanner_p scanner)
+{
     synctex_status_t status = 0;
-    _synctex_is_s is = {0,0};
+    _synctex_is_s is = {0, 0};
     if (NULL == scanner) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
-    if (!scanner->flags.postamble && (status=_synctex_match_string(scanner,"Postamble:"))<SYNCTEX_STATUS_OK) {
+    if (!scanner->flags.postamble && (status = _synctex_match_string(scanner, "Postamble:")) < SYNCTEX_STATUS_OK) {
         return status;
     }
 count_again:
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return SYNCTEX_STATUS_OK;
     }
-    if ((status=_synctex_scan_named(scanner,"Count:"))< SYNCTEX_STATUS_EOF) {
+    if ((status = _synctex_scan_named(scanner, "Count:")) < SYNCTEX_STATUS_EOF) {
         return status; /*  forward the error */
     } else if (status < SYNCTEX_STATUS_OK) { /*  No Count record found */
         goto count_again;
     }
-    if ((is=_synctex_decode_int(scanner)).status<SYNCTEX_STATUS_OK) {
+    if ((is = _synctex_decode_int(scanner)).status < SYNCTEX_STATUS_OK) {
         return is.status;
     }
-    if ((status=_synctex_next_line(scanner))<SYNCTEX_STATUS_OK) {
+    if ((status = _synctex_next_line(scanner)) < SYNCTEX_STATUS_OK) {
         return SYNCTEX_STATUS_OK;
     }
     scanner->count = is.integer;
@@ -5249,18 +5296,19 @@ count_again:
  *  For example 0 width boxes may contain text.
  *  At creation time, the visible size is set to the values of the real size.
  */
-static synctex_status_t _synctex_setup_visible_hbox(synctex_node_p box) {
+static synctex_status_t _synctex_setup_visible_hbox(synctex_node_p box)
+{
     if (box) {
-        switch(synctex_node_type(box)) {
-            case synctex_node_type_hbox:
-                _synctex_data_set_h_V(box,_synctex_data_h(box));
-                _synctex_data_set_v_V(box,_synctex_data_v(box));
-                _synctex_data_set_width_V(box,_synctex_data_width(box));
-                _synctex_data_set_height_V(box,_synctex_data_height(box));
-                _synctex_data_set_depth_V(box,_synctex_data_depth(box));
-                return SYNCTEX_STATUS_OK;
-            default:
-                break;
+        switch (synctex_node_type(box)) {
+        case synctex_node_type_hbox:
+            _synctex_data_set_h_V(box, _synctex_data_h(box));
+            _synctex_data_set_v_V(box, _synctex_data_v(box));
+            _synctex_data_set_width_V(box, _synctex_data_width(box));
+            _synctex_data_set_height_V(box, _synctex_data_height(box));
+            _synctex_data_set_depth_V(box, _synctex_data_depth(box));
+            return SYNCTEX_STATUS_OK;
+        default:
+            break;
         }
     }
     return SYNCTEX_STATUS_BAD_ARGUMENT;
@@ -5270,98 +5318,101 @@ static synctex_status_t _synctex_setup_visible_hbox(synctex_node_p box) {
  *  Some box have 0 width but do contain text material.
  *  With this method, one can enlarge the box to contain the given point (h,v).
  */
-static synctex_status_t _synctex_make_hbox_contain_point(synctex_node_p node,synctex_point_s point) {
+static synctex_status_t _synctex_make_hbox_contain_point(synctex_node_p node, synctex_point_s point)
+{
     int min, max, n;
     if (NULL == node || synctex_node_type(node) != synctex_node_type_hbox) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
-    if ((n = _synctex_data_width_V(node))<0) {
+    if ((n = _synctex_data_width_V(node)) < 0) {
         max = _synctex_data_h_V(node);
-        min = max+n;
-        if (point.h<min) {
-            _synctex_data_set_width_V(node,point.h-max);
-        } else if (point.h>max) {
-            _synctex_data_set_h_V(node,point.h);
-            _synctex_data_set_width_V(node,min-point.h);
+        min = max + n;
+        if (point.h < min) {
+            _synctex_data_set_width_V(node, point.h - max);
+        } else if (point.h > max) {
+            _synctex_data_set_h_V(node, point.h);
+            _synctex_data_set_width_V(node, min - point.h);
         }
     } else {
         min = _synctex_data_h_V(node);
-        max = min+n;
-        if (point.h<min) {
-            _synctex_data_set_h_V(node,point.h);
-            _synctex_data_set_width_V(node,max - point.h);
-        } else if (point.h>max) {
-            _synctex_data_set_width_V(node,point.h - min);
+        max = min + n;
+        if (point.h < min) {
+            _synctex_data_set_h_V(node, point.h);
+            _synctex_data_set_width_V(node, max - point.h);
+        } else if (point.h > max) {
+            _synctex_data_set_width_V(node, point.h - min);
         }
     }
     n = _synctex_data_v_V(node);
     min = n - _synctex_data_height_V(node);
     max = n + _synctex_data_depth_V(node);
-    if (point.v<min) {
-        _synctex_data_set_height_V(node,n-point.v);
-    } else if (point.v>max) {
-        _synctex_data_set_depth_V(node,point.v-n);
+    if (point.v < min) {
+        _synctex_data_set_height_V(node, n - point.v);
+    } else if (point.v > max) {
+        _synctex_data_set_depth_V(node, point.v - n);
     }
     return SYNCTEX_STATUS_OK;
 }
-static synctex_status_t _synctex_make_hbox_contain_box(synctex_node_p node,synctex_box_s box) {
+static synctex_status_t _synctex_make_hbox_contain_box(synctex_node_p node, synctex_box_s box)
+{
     int min, max, n;
     if (NULL == node || synctex_node_type(node) != synctex_node_type_hbox) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
-    if ((n = _synctex_data_width_V(node))<0) {
+    if ((n = _synctex_data_width_V(node)) < 0) {
         max = _synctex_data_h_V(node);
-        min = max+n;
-        if (box.min.h <min) {
-            _synctex_data_set_width_V(node,box.min.h-max);
-        } else if (box.max.h>max) {
-            _synctex_data_set_h_V(node,box.max.h);
-            _synctex_data_set_width_V(node,min-box.max.h);
+        min = max + n;
+        if (box.min.h < min) {
+            _synctex_data_set_width_V(node, box.min.h - max);
+        } else if (box.max.h > max) {
+            _synctex_data_set_h_V(node, box.max.h);
+            _synctex_data_set_width_V(node, min - box.max.h);
         }
     } else {
         min = _synctex_data_h_V(node);
-        max = min+n;
-        if (box.min.h<min) {
-            _synctex_data_set_h_V(node,box.min.h);
-            _synctex_data_set_width_V(node,max - box.min.h);
-        } else if (box.max.h>max) {
-            _synctex_data_set_width_V(node,box.max.h - min);
+        max = min + n;
+        if (box.min.h < min) {
+            _synctex_data_set_h_V(node, box.min.h);
+            _synctex_data_set_width_V(node, max - box.min.h);
+        } else if (box.max.h > max) {
+            _synctex_data_set_width_V(node, box.max.h - min);
         }
     }
     n = _synctex_data_v_V(node);
     min = n - _synctex_data_height_V(node);
     max = n + _synctex_data_depth_V(node);
-    if (box.min.v<min) {
-        _synctex_data_set_height_V(node,n-box.min.v);
-    } else if (box.max.v>max) {
-        _synctex_data_set_depth_V(node,box.max.v-n);
+    if (box.min.v < min) {
+        _synctex_data_set_height_V(node, n - box.min.v);
+    } else if (box.max.v > max) {
+        _synctex_data_set_depth_V(node, box.max.v - n);
     }
     return SYNCTEX_STATUS_OK;
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark SPECIAL CHARACTERS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark SPECIAL CHARACTERS
+#endif
 
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark SCANNERS & PARSERS
+#endif
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark SCANNERS & PARSERS
-#   endif
+#define SYNCTEX_DECODE_FAILED(NODE, WHAT) (_synctex_data_decode_##WHAT(NODE) < SYNCTEX_STATUS_OK)
+#define SYNCTEX_DECODE_FAILED_V(NODE, WHAT) (_synctex_data_decode_##WHAT##_v(NODE) < SYNCTEX_STATUS_OK)
 
-#   define SYNCTEX_DECODE_FAILED(NODE,WHAT) \
-(_synctex_data_decode_##WHAT(NODE)<SYNCTEX_STATUS_OK)
-#   define SYNCTEX_DECODE_FAILED_V(NODE,WHAT) \
-(_synctex_data_decode_##WHAT##_v(NODE)<SYNCTEX_STATUS_OK)
-
-#define SYNCTEX_NS_NULL (_synctex_ns_s){NULL,SYNCTEX_STATUS_NOT_OK}
-static _synctex_ns_s _synctex_parse_new_sheet(synctex_scanner_p scanner) {
+#define SYNCTEX_NS_NULL                                                                                                                                        \
+    (_synctex_ns_s)                                                                                                                                            \
+    {                                                                                                                                                          \
+        NULL, SYNCTEX_STATUS_NOT_OK                                                                                                                            \
+    }
+static _synctex_ns_s _synctex_parse_new_sheet(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_sheet(scanner))) {
-        if (
-            SYNCTEX_DECODE_FAILED(node,page)) {
+        if (SYNCTEX_DECODE_FAILED(node, page)) {
             _synctex_error("Bad sheet record.");
-        } else if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        } else if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of sheet.");
         } else {
             /* Now set the owner */
@@ -5372,30 +5423,31 @@ static _synctex_ns_s _synctex_parse_new_sheet(synctex_scanner_p scanner) {
                     last_sheet = next_sheet;
                 }
                 /* sheets have no parent */
-                __synctex_tree_set_sibling(last_sheet,node);
+                __synctex_tree_set_sibling(last_sheet, node);
             } else {
                 scanner->sheet = node;
             }
-            return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+            return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
         }
         _synctex_free_node(node);
     }
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
 /**
  *  - requirement: scanner != NULL
  */
-static _synctex_ns_s _synctex_parse_new_form(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_form(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_form(scanner))) {
-        if ((_synctex_data_decode_tag(node)<SYNCTEX_STATUS_OK)) {
-//        if (SYNCTEX_DECODE_FAILED(node,tag)) {
+        if ((_synctex_data_decode_tag(node) < SYNCTEX_STATUS_OK)) {
+            //        if (SYNCTEX_DECODE_FAILED(node,tag)) {
             _synctex_error("Bad form record.");
-        } else if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        } else if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of form.");
         } else {
-printf("FORM TAG: %i\n", synctex_node_tag(node));
-printf("FORM TAG: %i\n", _synctex_data_tag(node));
+            printf("FORM TAG: %i\n", synctex_node_tag(node));
+            printf("FORM TAG: %i\n", _synctex_data_tag(node));
             /* Now set the owner */
             if (scanner->form) {
                 synctex_node_p last_form = scanner->form;
@@ -5403,32 +5455,27 @@ printf("FORM TAG: %i\n", _synctex_data_tag(node));
                 while ((next_form = __synctex_tree_sibling(last_form))) {
                     last_form = next_form;
                 }
-                __synctex_tree_set_sibling(last_form,node);
+                __synctex_tree_set_sibling(last_form, node);
             } else {
                 scanner->form = node;
             }
-            return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+            return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
         }
         _synctex_free_node(node);
     }
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-#   define SYNCTEX_SHOULD_DECODE_FAILED(NODE,WHAT) \
-(_synctex_data_has_##WHAT(NODE) &&(_synctex_data_decode_##WHAT(NODE)<SYNCTEX_STATUS_OK))
-#   define SYNCTEX_SHOULD_DECODE_FAILED_V(NODE,WHAT) \
-(_synctex_data_has_##WHAT(NODE) &&(_synctex_data_decode_##WHAT##_v(NODE)<SYNCTEX_STATUS_OK))
+#define SYNCTEX_SHOULD_DECODE_FAILED(NODE, WHAT) (_synctex_data_has_##WHAT(NODE) && (_synctex_data_decode_##WHAT(NODE) < SYNCTEX_STATUS_OK))
+#define SYNCTEX_SHOULD_DECODE_FAILED_V(NODE, WHAT) (_synctex_data_has_##WHAT(NODE) && (_synctex_data_decode_##WHAT##_v(NODE) < SYNCTEX_STATUS_OK))
 
-static synctex_status_t _synctex_data_decode_tlchvwhd(synctex_node_p node) {
-    return SYNCTEX_SHOULD_DECODE_FAILED(node,tag)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,line)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,column)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,h)
-    || SYNCTEX_SHOULD_DECODE_FAILED_V(node,v)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,width)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,height)
-    || SYNCTEX_SHOULD_DECODE_FAILED(node,depth);
+static synctex_status_t _synctex_data_decode_tlchvwhd(synctex_node_p node)
+{
+    return SYNCTEX_SHOULD_DECODE_FAILED(node, tag) || SYNCTEX_SHOULD_DECODE_FAILED(node, line) || SYNCTEX_SHOULD_DECODE_FAILED(node, column)
+        || SYNCTEX_SHOULD_DECODE_FAILED(node, h) || SYNCTEX_SHOULD_DECODE_FAILED_V(node, v) || SYNCTEX_SHOULD_DECODE_FAILED(node, width)
+        || SYNCTEX_SHOULD_DECODE_FAILED(node, height) || SYNCTEX_SHOULD_DECODE_FAILED(node, depth);
 }
-static _synctex_ns_s _synctex_parse_new_vbox(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_vbox(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_vbox(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5436,19 +5483,20 @@ static _synctex_ns_s _synctex_parse_new_vbox(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of vbox.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
 SYNCTEX_INLINE static synctex_node_p __synctex_node_make_friend_tlc(synctex_node_p node);
-static _synctex_ns_s _synctex_parse_new_hbox(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_hbox(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_hbox(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5456,22 +5504,23 @@ static _synctex_ns_s _synctex_parse_new_hbox(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of hbox.");
             goto out;
         }
-        if (_synctex_setup_visible_hbox(node)<SYNCTEX_STATUS_OK) {
+        if (_synctex_setup_visible_hbox(node) < SYNCTEX_STATUS_OK) {
             _synctex_error("Unexpected error (_synctex_parse_new_hbox).");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_void_vbox(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_void_vbox(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_void_vbox(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5479,18 +5528,19 @@ static _synctex_ns_s _synctex_parse_new_void_vbox(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_void_hbox(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_void_hbox(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_void_hbox(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5498,18 +5548,19 @@ static _synctex_ns_s _synctex_parse_new_void_hbox(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_kern(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_kern(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_kern(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5517,18 +5568,19 @@ static _synctex_ns_s _synctex_parse_new_kern(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_glue(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_glue(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_glue(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5536,18 +5588,19 @@ static _synctex_ns_s _synctex_parse_new_glue(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_rule(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_rule(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_rule(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5555,18 +5608,19 @@ static _synctex_ns_s _synctex_parse_new_rule(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_math(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_math(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_math(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5574,18 +5628,19 @@ static _synctex_ns_s _synctex_parse_new_math(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-static _synctex_ns_s _synctex_parse_new_boundary(synctex_scanner_p scanner) {
+static _synctex_ns_s _synctex_parse_new_boundary(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_boundary(scanner))) {
         if (_synctex_data_decode_tlchvwhd(node)) {
@@ -5593,40 +5648,39 @@ static _synctex_ns_s _synctex_parse_new_boundary(synctex_scanner_p scanner) {
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-SYNCTEX_INLINE static _synctex_ns_s _synctex_parse_new_ref(synctex_scanner_p scanner) {
+SYNCTEX_INLINE static _synctex_ns_s _synctex_parse_new_ref(synctex_scanner_p scanner)
+{
     synctex_node_p node;
     if ((node = _synctex_new_ref(scanner))) {
-        if (SYNCTEX_DECODE_FAILED(node,tag)
-            || SYNCTEX_DECODE_FAILED(node,h)
-            || SYNCTEX_DECODE_FAILED_V(node,v)) {
+        if (SYNCTEX_DECODE_FAILED(node, tag) || SYNCTEX_DECODE_FAILED(node, h) || SYNCTEX_DECODE_FAILED_V(node, v)) {
             _synctex_error("Bad form ref record.");
             _synctex_next_line(scanner);
         out:
             _synctex_free_node(node);
-            return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+            return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of container.");
             goto out;
         }
-        return (_synctex_ns_s){node,SYNCTEX_STATUS_OK};
+        return (_synctex_ns_s){node, SYNCTEX_STATUS_OK};
     }
     _synctex_next_line(scanner);
-    return (_synctex_ns_s){NULL,SYNCTEX_STATUS_ERROR};
+    return (_synctex_ns_s){NULL, SYNCTEX_STATUS_ERROR};
 }
-#   undef SYNCTEX_DECODE_FAILED
-#   undef SYNCTEX_DECODE_FAILED_V
+#undef SYNCTEX_DECODE_FAILED
+#undef SYNCTEX_DECODE_FAILED_V
 
 SYNCTEX_INLINE static synctex_point_s _synctex_data_point(synctex_node_p node);
 SYNCTEX_INLINE static synctex_point_s _synctex_data_point_V(synctex_node_p node);
@@ -5635,19 +5689,21 @@ SYNCTEX_INLINE static synctex_box_s _synctex_data_box(synctex_node_p node);
 SYNCTEX_INLINE static synctex_box_s _synctex_data_xob(synctex_node_p node);
 SYNCTEX_INLINE static synctex_box_s _synctex_data_box_V(synctex_node_p node);
 
-SYNCTEX_INLINE static synctex_node_p _synctex_input_register_line(synctex_node_p input,synctex_node_p node) {
+SYNCTEX_INLINE static synctex_node_p _synctex_input_register_line(synctex_node_p input, synctex_node_p node)
+{
     if (node && _synctex_data_tag(input) != _synctex_data_tag(node)) {
-        input = synctex_scanner_input_with_tag(node->class_->scanner,_synctex_data_tag(node));
+        input = synctex_scanner_input_with_tag(node->class_->scanner, _synctex_data_tag(node));
     }
-    if (_synctex_data_line(node)>_synctex_data_line(input)) {
-        _synctex_data_set_line(input,_synctex_data_line(node));
+    if (_synctex_data_line(node) > _synctex_data_line(input)) {
+        _synctex_data_set_line(input, _synctex_data_line(node));
     }
     return input;
 }
 /**
  *  Free node and its siblings and return its detached child.
  */
-SYNCTEX_INLINE static synctex_node_p _synctex_handle_pop_child(synctex_node_p handle) {
+SYNCTEX_INLINE static synctex_node_p _synctex_handle_pop_child(synctex_node_p handle)
+{
     synctex_node_p child = _synctex_tree_reset_child(handle);
     _synctex_node_free(handle);
     return child;
@@ -5658,13 +5714,14 @@ SYNCTEX_INLINE static synctex_node_p _synctex_handle_pop_child(synctex_node_p ha
  *  Reset the target of x_handle and deletes its siblings.
  *  child is a node that has just been parsed and is not a boundary node.
  */
-SYNCTEX_INLINE static void _synctex_handle_set_tlc(synctex_node_p x_handle, synctex_node_p child, synctex_bool_t make_friend) {
+SYNCTEX_INLINE static void _synctex_handle_set_tlc(synctex_node_p x_handle, synctex_node_p child, synctex_bool_t make_friend)
+{
     if (x_handle) {
         synctex_node_p sibling = x_handle;
         if (child) {
             synctex_node_p target;
             while ((target = synctex_node_target(sibling))) {
-                _synctex_data_set_tlc(target,child);
+                _synctex_data_set_tlc(target, child);
                 if (make_friend) {
                     _synctex_node_make_friend_tlc(target);
                 }
@@ -5686,7 +5743,8 @@ SYNCTEX_INLINE static void _synctex_handle_set_tlc(synctex_node_p x_handle, sync
  *  that have not yet been registered.
  *  Those handles will be deleted when poping.
  */
-SYNCTEX_INLINE static void _synctex_handle_make_friend_tlc(synctex_node_p node) {
+SYNCTEX_INLINE static void _synctex_handle_make_friend_tlc(synctex_node_p node)
+{
     while (node) {
         synctex_node_p target = _synctex_tree_reset_target(node);
         _synctex_node_make_friend_tlc(target);
@@ -5698,9 +5756,10 @@ SYNCTEX_INLINE static void _synctex_handle_make_friend_tlc(synctex_node_p node) 
  *  - parameter scanner: owning scanner
  *  - returns: status
  */
-static synctex_status_t __synctex_parse_sfi(synctex_scanner_p scanner) {
+static synctex_status_t __synctex_parse_sfi(synctex_scanner_p scanner)
+{
     synctex_status_t status = SYNCTEX_STATUS_OK;
-    _synctex_zs_s zs = {0,0};
+    _synctex_zs_s zs = {0, 0};
     _synctex_ns_s input = SYNCTEX_NS_NULL;
     synctex_node_p sheet = NULL;
     synctex_node_p form = NULL;
@@ -5715,9 +5774,9 @@ static synctex_status_t __synctex_parse_sfi(synctex_scanner_p scanner) {
      *  We keep track of these leading x nodes in a handle tree.
      */
     synctex_node_p x_handle = NULL;
-#   define SYNCTEX_RETURN(STATUS) \
-        _synctex_node_free(x_handle);\
-        return STATUS
+#define SYNCTEX_RETURN(STATUS)                                                                                                                                 \
+    _synctex_node_free(x_handle);                                                                                                                              \
+    return STATUS
     synctex_node_p last_k = NULL;
     synctex_node_p last_g = NULL;
     _synctex_ns_s ns = SYNCTEX_NS_NULL;
@@ -5727,19 +5786,18 @@ static synctex_status_t __synctex_parse_sfi(synctex_scanner_p scanner) {
     if (!(x_handle = _synctex_new_handle(scanner))) {
         SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
     }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark MAIN LOOP
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark MAIN LOOP
+#endif
 main_loop:
     status = SYNCTEX_STATUS_OK;
     sheet = form = parent = child = NULL;
-#   define SYNCTEX_START_SCAN(WHAT)\
-(*SYNCTEX_CUR == SYNCTEX_CHAR_##WHAT)
-    if (SYNCTEX_CUR<SYNCTEX_END) {
+#define SYNCTEX_START_SCAN(WHAT) (*SYNCTEX_CUR == SYNCTEX_CHAR_##WHAT)
+    if (SYNCTEX_CUR < SYNCTEX_END) {
         if (SYNCTEX_START_SCAN(BEGIN_FORM)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN FORM
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN FORM
+#endif
         scan_form:
             ns = _synctex_parse_new_form(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
@@ -5749,7 +5807,7 @@ main_loop:
                     ++ignored_form_depth;
                     goto ignore_loop;
                 }
-                _synctex_tree_set_parent(ns.node,form);
+                _synctex_tree_set_parent(ns.node, form);
                 form = ns.node;
                 parent = form;
                 child = NULL;
@@ -5763,9 +5821,9 @@ main_loop:
             try_input = synctex_YES;
             goto main_loop;
         } else if (SYNCTEX_START_SCAN(BEGIN_SHEET)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN SHEET
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN SHEET
+#endif
             try_input = synctex_YES;
             ns = _synctex_parse_new_sheet(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
@@ -5776,12 +5834,12 @@ main_loop:
             }
             goto main_loop;
         } else if (SYNCTEX_START_SCAN(ANCHOR)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN ANCHOR
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN ANCHOR
+#endif
         scan_anchor:
             ++SYNCTEX_CUR;
-            if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+            if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
                 _synctex_error("Missing anchor.");
                 SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
             }
@@ -5792,59 +5850,59 @@ main_loop:
             try_input = synctex_YES;
             goto main_loop;
         } else if (SYNCTEX_START_SCAN(ANCHOR)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN COMMENT
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN COMMENT
+#endif
             ++SYNCTEX_CUR;
             _synctex_next_line(scanner);
             try_input = synctex_YES;
             goto main_loop;
         } else if (try_input) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN INPUT
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN INPUT
+#endif
             try_input = synctex_NO;
             do {
                 input = __synctex_parse_new_input(scanner);
             } while (input.status == SYNCTEX_STATUS_OK);
             goto main_loop;
         }
-        status = _synctex_match_string(scanner,"Postamble:");
-        if (status==SYNCTEX_STATUS_OK) {
+        status = _synctex_match_string(scanner, "Postamble:");
+        if (status == SYNCTEX_STATUS_OK) {
             scanner->flags.postamble = 1;
             SYNCTEX_RETURN(status);
         }
         status = _synctex_next_line(scanner);
-        if (status<SYNCTEX_STATUS_OK) {
+        if (status < SYNCTEX_STATUS_OK) {
             SYNCTEX_RETURN(status);
         }
-   }
+    }
     /* At least 1 more character */
-    zs = _synctex_buffer_get_available_size(scanner,1);
-    if (zs.size == 0){
+    zs = _synctex_buffer_get_available_size(scanner, 1);
+    if (zs.size == 0) {
         _synctex_error("Incomplete synctex file, postamble missing.");
         SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
     }
     goto main_loop;
     /*  Unreachable. */
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark IGNORE LOOP
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark IGNORE LOOP
+#endif
 ignore_loop:
     ns = SYNCTEX_NS_NULL;
-    if (SYNCTEX_CUR<SYNCTEX_END) {
+    if (SYNCTEX_CUR < SYNCTEX_END) {
         if (SYNCTEX_START_SCAN(BEGIN_FORM)) {
             ++ignored_form_depth;
         } else if (SYNCTEX_START_SCAN(END_FORM)) {
             --ignored_form_depth;
         }
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Incomplete container.");
             SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
         }
     } else {
-        zs = _synctex_buffer_get_available_size(scanner,1);
-        if (zs.size == 0){
+        zs = _synctex_buffer_get_available_size(scanner, 1);
+        if (zs.size == 0) {
             _synctex_error("Incomplete synctex file, postamble missing.");
             SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
         }
@@ -5856,9 +5914,9 @@ ignore_loop:
         goto content_loop;
     }
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark CONTENT LOOP
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark CONTENT LOOP
+#endif
 content_loop:
     /*  Either in a form, a sheet or a box.
      *  - in a sheet, "{" is not possible, only boxes and "}" at top level.
@@ -5870,41 +5928,41 @@ content_loop:
     /* forms are everywhere */
     ns = SYNCTEX_NS_NULL;
 #if SYNCTEX_VERBOSE
-    synctex_scanner_set_display_switcher(scanner,-1);
+    synctex_scanner_set_display_switcher(scanner, -1);
     printf("NEW CONTENT LOOP\n");
 #if SYNCTEX_DEBUG > 500
     synctex_node_display(sheet);
 #endif
 #endif
-    if (SYNCTEX_CUR<SYNCTEX_END) {
+    if (SYNCTEX_CUR < SYNCTEX_END) {
         if (SYNCTEX_START_SCAN(BEGIN_FORM)) {
             goto scan_form;
         } else if (SYNCTEX_START_SCAN(BEGIN_VBOX)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN VBOX
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN VBOX
+#endif
             ns = _synctex_parse_new_vbox(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 x_handle = _synctex_new_handle_with_child(x_handle);
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 parent = ns.node;
                 child = _synctex_tree_last(parent);
-#   if SYNCTEX_VERBOSE
+#if SYNCTEX_VERBOSE
                 synctex_node_log(parent);
-#   endif
-                input.node = _synctex_input_register_line(input.node,parent);
+#endif
+                input.node = _synctex_input_register_line(input.node, parent);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(END_VBOX)) {
             if (synctex_node_type(parent) == synctex_node_type_vbox) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN XOBV
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN XOBV
+#endif
                 ++SYNCTEX_CUR;
                 if (NULL == _synctex_tree_child(parent) && !form) {
                     /*  only void v boxes are friends */
@@ -5916,11 +5974,11 @@ content_loop:
                     _synctex_handle_make_friend_tlc(x_handle);
                 }
                 x_handle = _synctex_handle_pop_child(x_handle);
-                _synctex_handle_set_tlc(x_handle,child,!form);
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+#endif
+                if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
                     _synctex_error("Incomplete container.");
                     SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
                 }
@@ -5928,55 +5986,55 @@ content_loop:
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(BEGIN_HBOX)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN HBOX
-#   endif
-#   if defined(SYNCTEX_USE_CHARINDEX)
-            synctex_charindex_t char_index = (synctex_charindex_t)(scanner->reader->charindex_offset+SYNCTEX_CUR-SYNCTEX_START);
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN HBOX
+#endif
+#if defined(SYNCTEX_USE_CHARINDEX)
+            synctex_charindex_t char_index = (synctex_charindex_t)(scanner->reader->charindex_offset + SYNCTEX_CUR - SYNCTEX_START);
             synctex_lineindex_t line_index = scanner->reader->line_number;
-#   endif
+#endif
             ns = _synctex_parse_new_hbox(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 x_handle = _synctex_new_handle_with_child(x_handle);
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 parent = ns.node;
                 /*  add a box boundary node at the start */
                 if ((child = _synctex_new_box_bdry(scanner))) {
-#   if defined(SYNCTEX_USE_CHARINDEX)
-                    child->line_index=line_index;
-                    child->char_index=char_index;
-#   endif
-                    _synctex_node_set_child(parent,child);
-                    _synctex_data_set_tlchv(child,parent);
+#if defined(SYNCTEX_USE_CHARINDEX)
+                    child->line_index = line_index;
+                    child->char_index = char_index;
+#endif
+                    _synctex_node_set_child(parent, child);
+                    _synctex_data_set_tlchv(child, parent);
                     if (!form) {
                         __synctex_node_make_friend_tlc(child);
                     }
                 } else {
                     _synctex_error("Can't create box bdry record.");
                 }
-#   if SYNCTEX_VERBOSE
+#if SYNCTEX_VERBOSE
                 synctex_node_log(parent);
-#   endif
-                input.node = _synctex_input_register_line(input.node,parent);
+#endif
+                input.node = _synctex_input_register_line(input.node, parent);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(END_HBOX)) {
             if (synctex_node_type(parent) == synctex_node_type_hbox) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN XOBH
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN XOBH
+#endif
                 ++SYNCTEX_CUR;
                 /*  setting the next horizontal box at the end ensures
                  * that a child is recorded before any of its ancestors.
                  */
-                if (form == NULL /* && sheet != NULL*/ ) {
-                    _synctex_tree_set_next_hbox(parent,_synctex_tree_next_hbox(sheet));
-                    _synctex_tree_set_next_hbox(sheet,parent);
+                if (form == NULL /* && sheet != NULL*/) {
+                    _synctex_tree_set_next_hbox(parent, _synctex_tree_next_hbox(sheet));
+                    _synctex_tree_set_next_hbox(sheet, parent);
                 }
                 {
                     /*  Update the mean line number */
@@ -5989,10 +6047,10 @@ content_loop:
                         _synctex_data_set_line(node, _synctex_data_line(sibling));
                         node = sibling;
                         do {
-                            if (synctex_node_type(node)==synctex_node_type_hbox) {
+                            if (synctex_node_type(node) == synctex_node_type_hbox) {
                                 if (_synctex_data_weight(node)) {
                                     node_weight += _synctex_data_weight(node);
-                                    cumulated_line_numbers += _synctex_data_mean_line(node)*_synctex_data_weight(node);
+                                    cumulated_line_numbers += _synctex_data_mean_line(node) * _synctex_data_weight(node);
                                 } else {
                                     ++node_weight;
                                     cumulated_line_numbers += _synctex_data_mean_line(node);
@@ -6002,40 +6060,40 @@ content_loop:
                                 cumulated_line_numbers += synctex_node_line(node);
                             }
                         } while ((node = __synctex_tree_sibling(node)));
-                        _synctex_data_set_mean_line(parent,(cumulated_line_numbers + node_weight/2)/node_weight);
-                        _synctex_data_set_weight(parent,node_weight);
+                        _synctex_data_set_mean_line(parent, (cumulated_line_numbers + node_weight / 2) / node_weight);
+                        _synctex_data_set_weight(parent, node_weight);
                     } else {
-                        _synctex_data_set_mean_line(parent,_synctex_data_line(parent));
-                        _synctex_data_set_weight(parent,1);
+                        _synctex_data_set_mean_line(parent, _synctex_data_line(parent));
+                        _synctex_data_set_weight(parent, 1);
                     }
                     if ((sibling = _synctex_new_box_bdry(scanner))) {
-#   if defined(SYNCTEX_USE_CHARINDEX)
-                        sibling->line_index=child->line_index;
-                        sibling->char_index=child->char_index;
-#   endif
-                        _synctex_node_set_sibling(child,sibling);
+#if defined(SYNCTEX_USE_CHARINDEX)
+                        sibling->line_index = child->line_index;
+                        sibling->char_index = child->char_index;
+#endif
+                        _synctex_node_set_sibling(child, sibling);
                         {
                             synctex_node_p N = child;
                             while (synctex_node_type(N) == synctex_node_type_ref) {
                                 N = _synctex_tree_arg_sibling(N);
                             }
-                            _synctex_data_set_tlc(sibling,N);
+                            _synctex_data_set_tlc(sibling, N);
                         }
-                        _synctex_data_set_h(sibling,_synctex_data_h_V(parent)+_synctex_data_width_V(parent));
-                        _synctex_data_set_v(sibling,_synctex_data_v_V(parent));
+                        _synctex_data_set_h(sibling, _synctex_data_h_V(parent) + _synctex_data_width_V(parent));
+                        _synctex_data_set_v(sibling, _synctex_data_v_V(parent));
                         child = sibling;
                     } else {
                         _synctex_error("Can't create box bdry record.");
                     }
                     sibling = _synctex_tree_child(parent);
-                    _synctex_data_set_point(sibling,_synctex_data_point_V(parent));
+                    _synctex_data_set_point(sibling, _synctex_data_point_V(parent));
                     if (last_k && last_g && (child = synctex_node_child(parent))) {
                         /* Find the node preceding last_k */
                         synctex_node_p next;
                         while ((next = __synctex_tree_sibling(child))) {
                             if (next == last_k) {
-                                _synctex_data_set_tlc(last_k,child);
-                                _synctex_data_set_tlc(last_g,child);
+                                _synctex_data_set_tlc(last_k, child);
+                                _synctex_data_set_tlc(last_g, child);
                                 break;
                             }
                             child = next;
@@ -6047,13 +6105,13 @@ content_loop:
                         _synctex_handle_make_friend_tlc(x_handle);
                     }
                     x_handle = _synctex_handle_pop_child(x_handle);
-                    _synctex_handle_set_tlc(x_handle,child,!form);
-                    _synctex_make_hbox_contain_box(parent,                                    _synctex_data_box_V(child));
-#   if SYNCTEX_VERBOSE
+                    _synctex_handle_set_tlc(x_handle, child, !form);
+                    _synctex_make_hbox_contain_box(parent, _synctex_data_box_V(child));
+#if SYNCTEX_VERBOSE
                     synctex_node_log(child);
-#   endif
+#endif
                 }
-                if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+                if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
                     _synctex_error("Incomplete container.");
                     SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
                 }
@@ -6061,95 +6119,95 @@ content_loop:
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(VOID_VBOX)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN VOID VBOX
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN VOID VBOX
+#endif
             ns = _synctex_parse_new_void_vbox(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
-                _synctex_handle_set_tlc(x_handle, child,!form);
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(VOID_HBOX)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN VOID HBOX
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN VOID HBOX
+#endif
             ns = _synctex_parse_new_void_hbox(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
-                if (_synctex_data_width(ns.node)<0) {
+                if (_synctex_data_width(ns.node) < 0) {
                     printf("Negative width\n");
                 }
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
-                _synctex_handle_set_tlc(x_handle, child,!form);
-                _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+                _synctex_make_hbox_contain_box(parent, _synctex_data_box(child));
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(KERN)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN KERN
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN KERN
+#endif
             ns = _synctex_parse_new_kern(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
                 if (!form) {
                     __synctex_node_make_friend_tlc(child);
                 }
-                _synctex_handle_set_tlc(x_handle, child,!form);
-                _synctex_make_hbox_contain_box(parent,_synctex_data_xob(child));
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+                _synctex_make_hbox_contain_box(parent, _synctex_data_xob(child));
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = child;
                 last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(GLUE)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN GLUE
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN GLUE
+#endif
             ns = _synctex_parse_new_glue(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
                 if (!form) {
                     __synctex_node_make_friend_tlc(child);
                 }
-                _synctex_handle_set_tlc(x_handle, child,!form);
-                _synctex_make_hbox_contain_point(parent,_synctex_data_point(child));
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+                _synctex_make_hbox_contain_point(parent, _synctex_data_point(child));
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 if (last_k) {
                     last_g = child;
                 } else {
@@ -6158,59 +6216,59 @@ content_loop:
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(RULE)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN RULE
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN RULE
+#endif
             ns = _synctex_parse_new_rule(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
                 if (!form) {
                     __synctex_node_make_friend_tlc(child);
                 }
-                _synctex_handle_set_tlc(x_handle, child,!form);
+                _synctex_handle_set_tlc(x_handle, child, !form);
                 /* Rules are sometimes far too big
 _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
                  */
-#   if SYNCTEX_VERBOSE
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(MATH)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN MATH
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN MATH
+#endif
             ns = _synctex_parse_new_math(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
                 if (!form) {
                     __synctex_node_make_friend_tlc(child);
                 }
-                _synctex_handle_set_tlc(x_handle, child,!form);
-                _synctex_make_hbox_contain_point(parent,_synctex_data_point(child));
-#   if SYNCTEX_VERBOSE
+                _synctex_handle_set_tlc(x_handle, child, !form);
+                _synctex_make_hbox_contain_point(parent, _synctex_data_point(child));
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(FORM_REF)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN FORM REF
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN FORM REF
+#endif
 #if SYNCTEX_DEBUG > 500
             synctex_node_display(parent);
             synctex_node_display(child);
@@ -6218,81 +6276,80 @@ _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
             ns = _synctex_parse_new_ref(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
                 child = ns.node;
                 if (form) {
                     if (scanner->ref_in_form) {
-                        synctex_tree_set_friend(child,scanner->ref_in_form);
+                        synctex_tree_set_friend(child, scanner->ref_in_form);
                     }
                     scanner->ref_in_form = child;
                 } else {
                     if (scanner->ref_in_sheet) {
-                        synctex_tree_set_friend(child,scanner->ref_in_sheet);
+                        synctex_tree_set_friend(child, scanner->ref_in_sheet);
                     }
                     scanner->ref_in_sheet = child;
                 }
-#   if SYNCTEX_VERBOSE
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
+#endif
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(BOUNDARY)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN BOUNDARY
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN BOUNDARY
+#endif
             ns = _synctex_parse_new_boundary(scanner);
             if (ns.status == SYNCTEX_STATUS_OK) {
                 if (child) {
-                    _synctex_node_set_sibling(child,ns.node);
+                    _synctex_node_set_sibling(child, ns.node);
                 } else {
-                    _synctex_node_set_child(parent,ns.node);
+                    _synctex_node_set_child(parent, ns.node);
                 }
-                if (synctex_node_type(child)==synctex_node_type_box_bdry
-                    || _synctex_tree_target(x_handle)) {
+                if (synctex_node_type(child) == synctex_node_type_box_bdry || _synctex_tree_target(x_handle)) {
                     child = _synctex_tree_reset_child(x_handle);
                     child = _synctex_new_handle_with_child(child);
                     __synctex_tree_set_sibling(child, x_handle);
                     x_handle = child;
-                    _synctex_tree_set_target(x_handle,ns.node);
+                    _synctex_tree_set_target(x_handle, ns.node);
                 } else if (!form) {
                     __synctex_node_make_friend_tlc(ns.node);
                 }
                 child = ns.node;
-                _synctex_make_hbox_contain_point(parent,_synctex_data_point(child));
-#   if SYNCTEX_VERBOSE
+                _synctex_make_hbox_contain_point(parent, _synctex_data_point(child));
+#if SYNCTEX_VERBOSE
                 synctex_node_log(child);
-#   endif
-                input.node = _synctex_input_register_line(input.node,child);
+#endif
+                input.node = _synctex_input_register_line(input.node, child);
                 last_k = last_g = NULL;
                 goto content_loop;
             }
         } else if (SYNCTEX_START_SCAN(CHARACTER)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN CHARACTER
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN CHARACTER
+#endif
             ++SYNCTEX_CUR;
-            if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+            if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
                 _synctex_error("Missing end of container.");
                 SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
             }
             last_k = last_g = NULL;
             goto content_loop;
         } else if (SYNCTEX_START_SCAN(ANCHOR)) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN ANCHOR
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN ANCHOR
+#endif
             goto scan_anchor;
         } else if (SYNCTEX_START_SCAN(END_SHEET)) {
             if (sheet && parent == sheet) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN TEEHS
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN TEEHS
+#endif
                 ++SYNCTEX_CUR;
-                if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+                if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
                     _synctex_error("Missing anchor.");
                 }
                 parent = sheet = NULL;
@@ -6300,13 +6357,12 @@ _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
             }
         } else if (SYNCTEX_START_SCAN(END_FORM)) {
             if (parent == form && form_depth > 0) {
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark + SCAN MROF
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark + SCAN MROF
+#endif
                 ++SYNCTEX_CUR;
                 --form_depth;
-                if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK
-                    && (form_depth || sheet)) {
+                if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK && (form_depth || sheet)) {
                     _synctex_error("Missing end of container.");
                     SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
                 }
@@ -6324,16 +6380,16 @@ _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
                 goto main_loop;
             }
         }
-        _synctex_error("Ignored record <%.20s...>(line %i)\n",SYNCTEX_CUR, scanner->reader->line_number+1);
-        if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+        _synctex_error("Ignored record <%.20s...>(line %i)\n", SYNCTEX_CUR, scanner->reader->line_number + 1);
+        if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
             _synctex_error("Missing end of sheet/form.");
             SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
         }
         last_k = last_g = NULL;
         goto content_loop;
     }
-    zs = _synctex_buffer_get_available_size(scanner,1);
-    if (zs.size == 0){
+    zs = _synctex_buffer_get_available_size(scanner, 1);
+    if (zs.size == 0) {
         _synctex_error("Incomplete synctex file, postamble missing.");
         SYNCTEX_RETURN(SYNCTEX_STATUS_ERROR);
     }
@@ -6353,8 +6409,9 @@ _synctex_make_hbox_contain_box(parent,_synctex_data_box(child));
  *  - note: the target of the root proxy is the content
  *      of a form.
  */
-SYNCTEX_INLINE static _synctex_ns_s __synctex_replace_ref(synctex_node_p ref) {
-    _synctex_ns_s ns = {NULL,SYNCTEX_STATUS_OK};
+SYNCTEX_INLINE static _synctex_ns_s __synctex_replace_ref(synctex_node_p ref)
+{
+    _synctex_ns_s ns = {NULL, SYNCTEX_STATUS_OK};
     synctex_node_p parent;
     if ((parent = _synctex_tree_parent(ref))) {
         synctex_node_p sibling = __synctex_tree_reset_sibling(ref);
@@ -6366,10 +6423,10 @@ SYNCTEX_INLINE static _synctex_ns_s __synctex_replace_ref(synctex_node_p ref) {
          *  with children and no siblings. */
         if ((ns.node = __synctex_new_proxy_from_ref_to(ref, target))) {
             /*  Insert this proxy instead of ref. */
-            _synctex_node_set_sibling(arg_sibling,ns.node);
+            _synctex_node_set_sibling(arg_sibling, ns.node);
             /*  Then append the original sibling of ref. */
-            _synctex_node_set_sibling(ns.node,sibling);
-#   if defined(SYNCTEX_USE_CHARINDEX)
+            _synctex_node_set_sibling(ns.node, sibling);
+#if defined(SYNCTEX_USE_CHARINDEX)
             if (synctex_node_type(sibling) == synctex_node_type_box_bdry) {
                 /*  The sibling is the last box boundary
                  *  which may have a less accurate information */
@@ -6383,12 +6440,13 @@ SYNCTEX_INLINE static _synctex_ns_s __synctex_replace_ref(synctex_node_p ref) {
             synctex_node_display(synctex_node_sibling(ref));
 #endif
         } else /*  simply remove ref */ {
-            _synctex_tree_set_sibling(arg_sibling,sibling);
+            _synctex_tree_set_sibling(arg_sibling, sibling);
         }
         __synctex_tree_reset_parent(ref);
     } else {
-        _synctex_error("!  Missing parent in __synctex_replace_ref. "
-                       "Please report.");
+        _synctex_error(
+            "!  Missing parent in __synctex_replace_ref. "
+            "Please report.");
         ns.status = SYNCTEX_STATUS_BAD_ARGUMENT;
     }
     return ns;
@@ -6400,7 +6458,8 @@ SYNCTEX_INLINE static _synctex_ns_s __synctex_replace_ref(synctex_node_p ref) {
  *      created. The link is made through the friend field.
  *  - note: All refs are freed
  */
-SYNCTEX_INLINE static _synctex_ns_s _synctex_post_process_ref(synctex_node_p ref) {
+SYNCTEX_INLINE static _synctex_ns_s _synctex_post_process_ref(synctex_node_p ref)
+{
     _synctex_ns_s ns = {NULL, SYNCTEX_STATUS_OK};
     while (ref) {
         synctex_node_p next_ref = _synctex_tree_reset_friend(ref);
@@ -6411,7 +6470,7 @@ SYNCTEX_INLINE static _synctex_ns_s _synctex_post_process_ref(synctex_node_p ref
             /*  Insert all the created proxies in the list
              *  sub_ns.node is the last friend,
              */
-            synctex_tree_set_friend(sub_ns.node,ns.node);
+            synctex_tree_set_friend(sub_ns.node, ns.node);
             ns.node = sub_ns.node;
         }
         _synctex_node_free(ref);
@@ -6419,14 +6478,15 @@ SYNCTEX_INLINE static _synctex_ns_s _synctex_post_process_ref(synctex_node_p ref
     }
     return ns;
 }
-typedef synctex_node_p (* _synctex_processor_f)(synctex_node_p node);
+typedef synctex_node_p (*_synctex_processor_f)(synctex_node_p node);
 /**
  *  Apply the processor f to the tree hierarchy rooted at proxy.
  *  proxy has replaced a form ref, no children yet.
  *  As a side effect all the hierarchy of nodes will be created.
  */
-SYNCTEX_INLINE static synctex_status_t _synctex_post_process_proxy(synctex_node_p proxy, _synctex_processor_f f) {
-    while(proxy) {
+SYNCTEX_INLINE static synctex_status_t _synctex_post_process_proxy(synctex_node_p proxy, _synctex_processor_f f)
+{
+    while (proxy) {
         synctex_node_p next_proxy = _synctex_tree_friend(proxy);
         synctex_node_p halt = __synctex_tree_sibling(proxy);
         /*  if proxy is the last sibling, halt is NULL.
@@ -6442,38 +6502,38 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process_proxy(synctex_node_
         }
         do {
 #if SYNCTEX_DEBUG > 500
-            printf("POST PROCESSING %s\n",_synctex_node_abstract(proxy));
+            printf("POST PROCESSING %s\n", _synctex_node_abstract(proxy));
             {
-                int i,j = 0;
-                for (i=0;i<proxy->class_->scanner->number_of_lists;++i) {
+                int i, j = 0;
+                for (i = 0; i < proxy->class_->scanner->number_of_lists; ++i) {
                     synctex_node_p N = proxy->class_->scanner->lists_of_friends[i];
                     do {
-                        if (N==proxy) {
+                        if (N == proxy) {
                             ++j;
-                            printf("%s",_synctex_node_abstract(N));
+                            printf("%s", _synctex_node_abstract(N));
                         }
                     } while ((N = _synctex_tree_friend(N)));
                 }
                 if (j) {
-                    printf("\nBeforehand %i match\n",j);
+                    printf("\nBeforehand %i match\n", j);
                 }
             }
 #endif
             f(proxy);
 #if SYNCTEX_DEBUG > 500
             {
-                int i,j = 0;
-                for (i=0;i<proxy->class_->scanner->number_of_lists;++i) {
+                int i, j = 0;
+                for (i = 0; i < proxy->class_->scanner->number_of_lists; ++i) {
                     synctex_node_p N = proxy->class_->scanner->lists_of_friends[i];
                     do {
-                        if (N==proxy) {
+                        if (N == proxy) {
                             ++j;
-                            printf("%s",_synctex_node_abstract(N));
+                            printf("%s", _synctex_node_abstract(N));
                         }
                     } while ((N = _synctex_tree_friend(N)));
                 }
                 if (j) {
-                    printf("\n%i match\n",j);
+                    printf("\n%i match\n", j);
                 }
             }
 #endif
@@ -6481,18 +6541,18 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process_proxy(synctex_node_
             proxy = synctex_node_next(proxy); /*  Change is here */
 #if SYNCTEX_DEBUG > 500
             if (proxy) {
-                int i,j = 0;
-                for (i=0;i<proxy->class_->scanner->number_of_lists;++i) {
+                int i, j = 0;
+                for (i = 0; i < proxy->class_->scanner->number_of_lists; ++i) {
                     synctex_node_p N = proxy->class_->scanner->lists_of_friends[i];
                     do {
-                        if (N==proxy) {
+                        if (N == proxy) {
                             ++j;
-                            printf("%s",_synctex_node_abstract(N));
+                            printf("%s", _synctex_node_abstract(N));
                         }
                     } while ((N = _synctex_tree_friend(N)));
                 }
                 if (j) {
-                    printf("\nnext %i match\n",j);
+                    printf("\nnext %i match\n", j);
                 }
             }
 #endif
@@ -6508,9 +6568,10 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process_proxy(synctex_node_
  *  in either a form or a sheet
  *  - parameter: the owning scanner
  */
-SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p scanner) {
+SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p scanner)
+{
     synctex_status_t status = SYNCTEX_STATUS_OK;
-    _synctex_ns_s ns = {NULL,SYNCTEX_STATUS_NOT_OK};
+    _synctex_ns_s ns = {NULL, SYNCTEX_STATUS_NOT_OK};
 #if SYNCTEX_DEBUG > 500
     printf("!  entering _synctex_post_process.\n");
     synctex_node_display(scanner->sheet);
@@ -6518,8 +6579,8 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p s
 #endif
     /*  replace form refs inside forms by box proxies */
     ns = _synctex_post_process_ref(scanner->ref_in_form);
-    scanner->ref_in_form = NULL;/*  it was just released */
-    if (ns.status<status) {
+    scanner->ref_in_form = NULL; /*  it was just released */
+    if (ns.status < status) {
         status = ns.status;
     }
 #if SYNCTEX_DEBUG > 500
@@ -6534,13 +6595,13 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p s
      *  be organized in the right way.
      *  The inserted form must be defined before
      *  the inserting one. *TeX will take care of that.   */
-    ns.status = _synctex_post_process_proxy(ns.node,&_synctex_tree_reset_friend);
-    if (ns.status<status) {
+    ns.status = _synctex_post_process_proxy(ns.node, &_synctex_tree_reset_friend);
+    if (ns.status < status) {
         status = ns.status;
     }
     /*  replace form refs inside sheets by box proxies */
     ns = _synctex_post_process_ref(scanner->ref_in_sheet);
-    if (ns.status<status) {
+    if (ns.status < status) {
         status = ns.status;
     }
     scanner->ref_in_sheet = NULL;
@@ -6569,7 +6630,7 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p s
 #if SYNCTEX_DEBUG > 10000
     {
         int i;
-        for (i=0;i<scanner->number_of_lists;++i) {
+        for (i = 0; i < scanner->number_of_lists; ++i) {
             synctex_node_p P = scanner->lists_of_friends[i];
             int j = 0;
             while (P) {
@@ -6578,13 +6639,13 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p s
                 P = _synctex_tree_friend(P);
             }
             if (j) {
-                printf("friends %i -> # %i\n",i,j);
+                printf("friends %i -> # %i\n", i, j);
             }
         }
     }
 #endif
-    ns.status = _synctex_post_process_proxy(ns.node,&__synctex_proxy_make_friend_and_next_hbox);
-    if (ns.status<status) {
+    ns.status = _synctex_post_process_proxy(ns.node, &__synctex_proxy_make_friend_and_next_hbox);
+    if (ns.status < status) {
         status = ns.status;
     }
 #if SYNCTEX_DEBUG > 500
@@ -6599,7 +6660,8 @@ SYNCTEX_INLINE static synctex_status_t _synctex_post_process(synctex_scanner_p s
 }
 /*  Used when parsing the synctex file
  */
-static synctex_status_t _synctex_scan_content(synctex_scanner_p scanner) {
+static synctex_status_t _synctex_scan_content(synctex_scanner_p scanner)
+{
     if (NULL == scanner) {
         return SYNCTEX_STATUS_BAD_ARGUMENT;
     }
@@ -6607,11 +6669,11 @@ static synctex_status_t _synctex_scan_content(synctex_scanner_p scanner) {
     synctex_status_t status = 0;
     /*  Find where this section starts */
 content_not_found:
-    status = _synctex_match_string(scanner,"Content:");
-    if (status<SYNCTEX_STATUS_EOF) {
+    status = _synctex_match_string(scanner, "Content:");
+    if (status < SYNCTEX_STATUS_EOF) {
         return status;
     }
-    if (_synctex_next_line(scanner)<SYNCTEX_STATUS_OK) {
+    if (_synctex_next_line(scanner) < SYNCTEX_STATUS_OK) {
         _synctex_error("Incomplete Content.");
         return SYNCTEX_STATUS_ERROR;
     }
@@ -6624,19 +6686,20 @@ content_not_found:
     }
     return status;
 }
-synctex_scanner_p synctex_scanner_new() {
-    synctex_scanner_p scanner =(synctex_scanner_p)_synctex_malloc(sizeof(_synctex_scanner_s));
+synctex_scanner_p synctex_scanner_new()
+{
+    synctex_scanner_p scanner = (synctex_scanner_p)_synctex_malloc(sizeof(_synctex_scanner_s));
     if (scanner) {
         if (!(scanner->reader = _synctex_malloc(sizeof(_synctex_reader_s)))) {
             _synctex_free(scanner);
             return NULL;
         }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#   endif
-#   define DEFINE_synctex_scanner_class(NAME)\
-    scanner->class_[synctex_node_type_##NAME] = _synctex_class_##NAME;\
-(scanner->class_[synctex_node_type_##NAME]).scanner = scanner
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#endif
+#define DEFINE_synctex_scanner_class(NAME)                                                                                                                     \
+    scanner->class_[synctex_node_type_##NAME] = _synctex_class_##NAME;                                                                                         \
+    (scanner->class_[synctex_node_type_##NAME]).scanner = scanner
         DEFINE_synctex_scanner_class(input);
         DEFINE_synctex_scanner_class(sheet);
         DEFINE_synctex_scanner_class(form);
@@ -6658,26 +6721,27 @@ synctex_scanner_p synctex_scanner_new() {
         DEFINE_synctex_scanner_class(handle);
         /*  set up the lists of friends */
         scanner->number_of_lists = 1024;
-        scanner->lists_of_friends = (synctex_node_r)_synctex_malloc(scanner->number_of_lists*sizeof(synctex_node_p));
+        scanner->lists_of_friends = (synctex_node_r)_synctex_malloc(scanner->number_of_lists * sizeof(synctex_node_p));
         if (NULL == scanner->lists_of_friends) {
             synctex_scanner_free(scanner);
             _synctex_error("malloc:2");
             return NULL;
         }
         scanner->display_switcher = 100;
-        scanner->display_prompt = (char *)_synctex_display_prompt+strlen(_synctex_display_prompt)-1;
+        scanner->display_prompt = (char *)_synctex_display_prompt + strlen(_synctex_display_prompt) - 1;
     }
     return scanner;
 }
 /*  Where the synctex scanner is created. */
-synctex_scanner_p synctex_scanner_new_with_output_file(const char * output, const char * build_directory, int parse) {
+synctex_scanner_p synctex_scanner_new_with_output_file(const char *output, const char *build_directory, int parse)
+{
     synctex_scanner_p scanner = synctex_scanner_new();
     if (NULL == scanner) {
         _synctex_error("malloc problem");
         return NULL;
     }
     if (synctex_reader_init_with_output_file(scanner->reader, output, build_directory)) {
-        return parse? synctex_scanner_parse(scanner):scanner;
+        return parse ? synctex_scanner_parse(scanner) : scanner;
     }
     // don't warn to terminal if no file is present, this is a library.
     // _synctex_error("No file?");
@@ -6687,7 +6751,8 @@ synctex_scanner_p synctex_scanner_new_with_output_file(const char * output, cons
 
 /*  The scanner destructor
  */
-int synctex_scanner_free(synctex_scanner_p scanner) {
+int synctex_scanner_free(synctex_scanner_p scanner)
+{
     int node_count = 0;
     if (scanner) {
         _synctex_node_free(scanner->sheet);
@@ -6698,7 +6763,7 @@ int synctex_scanner_free(synctex_scanner_p scanner) {
         synctex_iterator_free(scanner->iterator);
         free(scanner->output_fmt);
         free(scanner->lists_of_friends);
-#if SYNCTEX_USE_NODE_COUNT>0
+#if SYNCTEX_USE_NODE_COUNT > 0
         node_count = scanner->node_count;
 #endif
         free(scanner);
@@ -6707,12 +6772,13 @@ int synctex_scanner_free(synctex_scanner_p scanner) {
 }
 
 /*  Where the synctex scanner parses the contents of the file. */
-synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner) {
+synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner)
+{
     synctex_status_t status = 0;
     if (!scanner || scanner->flags.has_parsed) {
         return scanner;
     }
-    scanner->flags.has_parsed=1;
+    scanner->flags.has_parsed = 1;
     scanner->pre_magnification = 1000;
     scanner->pre_unit = 8192;
     scanner->pre_x_offset = scanner->pre_y_offset = 578;
@@ -6722,33 +6788,33 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner) {
     scanner->reader->line_number = 1;
 
     synctex_scanner_set_display_switcher(scanner, 1000);
-    SYNCTEX_END = SYNCTEX_START+SYNCTEX_BUFFER_SIZE;
+    SYNCTEX_END = SYNCTEX_START + SYNCTEX_BUFFER_SIZE;
     /*  SYNCTEX_END always points to a null terminating character.
      *  Maybe there is another null terminating character between SYNCTEX_CUR and SYNCTEX_END-1.
      *  At least, we are sure that SYNCTEX_CUR points to a string covering a valid part of the memory. */
     *SYNCTEX_END = '\0';
     SYNCTEX_CUR = SYNCTEX_END;
-#   if defined(SYNCTEX_USE_CHARINDEX)
+#if defined(SYNCTEX_USE_CHARINDEX)
     scanner->reader->charindex_offset = -SYNCTEX_BUFFER_SIZE;
-#   endif
+#endif
     status = _synctex_scan_preamble(scanner);
-    if (status<SYNCTEX_STATUS_OK) {
+    if (status < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad preamble\n");
-        bailey:
+    bailey:
 #ifdef SYNCTEX_DEBUG
-            return scanner;
+        return scanner;
 #else
-            synctex_scanner_free(scanner);
-            return NULL;
+        synctex_scanner_free(scanner);
+        return NULL;
 #endif
     }
     status = _synctex_scan_content(scanner);
-    if (status<SYNCTEX_STATUS_OK) {
+    if (status < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad content\n");
         goto bailey;
     }
     status = _synctex_scan_postamble(scanner);
-    if (status<SYNCTEX_STATUS_OK) {
+    if (status < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad postamble. Ignored\n");
     }
 #if SYNCTEX_DEBUG > 500
@@ -6765,15 +6831,15 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner) {
     /*  Final tuning: set the default values for various parameters */
     /*  1 pre_unit = (scanner->pre_unit)/65536 pt = (scanner->pre_unit)/65781.76 bp
      * 1 pt = 65536 sp */
-    if (scanner->pre_unit<=0) {
+    if (scanner->pre_unit <= 0) {
         scanner->pre_unit = 8192;
     }
-    if (scanner->pre_magnification<=0) {
+    if (scanner->pre_magnification <= 0) {
         scanner->pre_magnification = 1000;
     }
     if (scanner->unit <= 0) {
         /*  no post magnification */
-        scanner->unit = scanner->pre_unit / 65781.76;/*  65781.76 or 65536.0*/
+        scanner->unit = scanner->pre_unit / 65781.76; /*  65781.76 or 65536.0*/
     } else {
         /*  post magnification */
         scanner->unit *= scanner->pre_unit / 65781.76;
@@ -6794,47 +6860,48 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner) {
 
 /*  Scanner accessors.
  */
-int _synctex_scanner_pre_x_offset(synctex_scanner_p scanner){
-    return scanner?scanner->pre_x_offset:0;
+int _synctex_scanner_pre_x_offset(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->pre_x_offset : 0;
 }
-int _synctex_scanner_pre_y_offset(synctex_scanner_p scanner){
-    return scanner?scanner->pre_y_offset:0;
+int _synctex_scanner_pre_y_offset(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->pre_y_offset : 0;
 }
-int synctex_scanner_x_offset(synctex_scanner_p scanner){
-    return scanner?scanner->x_offset:0;
+int synctex_scanner_x_offset(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->x_offset : 0;
 }
-int synctex_scanner_y_offset(synctex_scanner_p scanner){
-    return scanner?scanner->y_offset:0;
+int synctex_scanner_y_offset(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->y_offset : 0;
 }
-float synctex_scanner_magnification(synctex_scanner_p scanner){
-    return scanner?scanner->unit:1;
+float synctex_scanner_magnification(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->unit : 1;
 }
-void synctex_scanner_display(synctex_scanner_p scanner) {
+void synctex_scanner_display(synctex_scanner_p scanner)
+{
     if (NULL == scanner) {
         return;
     }
-    printf("The scanner:\noutput:%s\noutput_fmt:%s\nversion:%i\n",scanner->reader->output,scanner->output_fmt,scanner->version);
-    printf("pre_unit:%i\nx_offset:%i\ny_offset:%i\n",scanner->pre_unit,scanner->pre_x_offset,scanner->pre_y_offset);
-    printf("count:%i\npost_magnification:%f\npost_x_offset:%f\npost_y_offset:%f\n",
-           scanner->count,scanner->unit,scanner->x_offset,scanner->y_offset);
+    printf("The scanner:\noutput:%s\noutput_fmt:%s\nversion:%i\n", scanner->reader->output, scanner->output_fmt, scanner->version);
+    printf("pre_unit:%i\nx_offset:%i\ny_offset:%i\n", scanner->pre_unit, scanner->pre_x_offset, scanner->pre_y_offset);
+    printf("count:%i\npost_magnification:%f\npost_x_offset:%f\npost_y_offset:%f\n", scanner->count, scanner->unit, scanner->x_offset, scanner->y_offset);
     printf("The input:\n");
     synctex_node_display(scanner->input);
-    if (scanner->count<1000) {
+    if (scanner->count < 1000) {
         printf("The sheets:\n");
         synctex_node_display(scanner->sheet);
         printf("The friends:\n");
         if (scanner->lists_of_friends) {
             int i = scanner->number_of_lists;
             synctex_node_p node;
-            while(i--) {
-                printf("Friend index:%i\n",i);
+            while (i--) {
+                printf("Friend index:%i\n", i);
                 node = (scanner->lists_of_friends)[i];
-                while(node) {
-                    printf("%s:%i,%i\n",
-                           synctex_node_isa(node),
-                           _synctex_data_tag(node),
-                           _synctex_data_line(node)
-                           );
+                while (node) {
+                    printf("%s:%i,%i\n", synctex_node_isa(node), _synctex_data_tag(node), _synctex_data_line(node));
                     node = _synctex_tree_friend(node);
                 }
             }
@@ -6852,17 +6919,19 @@ void synctex_scanner_display(synctex_scanner_p scanner) {
  * @param tag
  * @return const char*
  */
-const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag) {
+const char *synctex_scanner_get_name(synctex_scanner_p scanner, int tag)
+{
     synctex_node_p input = NULL;
     if (NULL == scanner) {
         return NULL;
     }
-    if ((input = scanner->input)) {;
+    if ((input = scanner->input)) {
+        ;
         do {
             if (tag == _synctex_data_tag(input)) {
                 return (_synctex_data_name(input));
             }
-        } while((input = __synctex_tree_sibling(input)));
+        } while ((input = __synctex_tree_sibling(input)));
     }
     return NULL;
 }
@@ -6874,43 +6943,45 @@ const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag) {
  * @return const char
  * @see synctex_scanner_get_name
  */
-const char * synctex_node_get_name(synctex_node_p node) {
+const char *synctex_node_get_name(synctex_node_p node)
+{
     if (node) {
-        return synctex_scanner_get_name(node->class_->scanner,_synctex_data_tag(node));
+        return synctex_scanner_get_name(node->class_->scanner, _synctex_data_tag(node));
     }
     return NULL;
 }
 
-static int _synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name);
-static int _synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name) {
+static int _synctex_scanner_get_tag(synctex_scanner_p scanner, const char *name);
+static int _synctex_scanner_get_tag(synctex_scanner_p scanner, const char *name)
+{
     synctex_node_p input = NULL;
     if (NULL == scanner) {
         return 0;
     }
     if ((input = scanner->input)) {
         do {
-            if (_synctex_is_equivalent_file_name(name,(_synctex_data_name(input)))) {
+            if (_synctex_is_equivalent_file_name(name, (_synctex_data_name(input)))) {
                 return _synctex_data_tag(input);
             }
-        } while((input = __synctex_tree_sibling(input)));
+        } while ((input = __synctex_tree_sibling(input)));
     }
     //  2011 version
     name = _synctex_base_name(name);
     if ((input = scanner->input)) {
         do {
-            if (_synctex_is_equivalent_file_name(name,_synctex_base_name(_synctex_data_name(input)))) {
+            if (_synctex_is_equivalent_file_name(name, _synctex_base_name(_synctex_data_name(input)))) {
                 synctex_node_p other_input = input;
-                while((other_input = __synctex_tree_sibling(other_input))) {
-                    if (_synctex_is_equivalent_file_name(name,_synctex_base_name(_synctex_data_name(other_input)))
-                        && (strlen(_synctex_data_name(input))!=strlen(_synctex_data_name(other_input))
-                            || strncmp(_synctex_data_name(other_input),_synctex_data_name(input),strlen(_synctex_data_name(input))))) {
-                            // There is a second possible candidate
-                            return 0;
-                        }
+                while ((other_input = __synctex_tree_sibling(other_input))) {
+                    if (_synctex_is_equivalent_file_name(name, _synctex_base_name(_synctex_data_name(other_input)))
+                        && (strlen(_synctex_data_name(input)) != strlen(_synctex_data_name(other_input))
+                            || strncmp(_synctex_data_name(other_input), _synctex_data_name(input), strlen(_synctex_data_name(input))))) {
+                        // There is a second possible candidate
+                        return 0;
+                    }
                 }
                 return _synctex_data_tag(input);
             }
-        } while((input = __synctex_tree_sibling(input)));
+        } while ((input = __synctex_tree_sibling(input)));
     }
     return 0;
 }
@@ -6922,43 +6993,42 @@ static int _synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name)
  * @param name
  * @return int, 0 for an unknown tag.
  */
-int synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name) {
+int synctex_scanner_get_tag(synctex_scanner_p scanner, const char *name)
+{
     size_t char_index = strlen(name);
     if ((scanner = synctex_scanner_parse(scanner)) && (0 < char_index)) {
         /*  the name is not void */
         char_index -= 1;
         if (!SYNCTEX_IS_PATH_SEPARATOR(name[char_index])) {
             /*  the last character of name is not a path separator */
-            int result = _synctex_scanner_get_tag(scanner,name);
+            int result = _synctex_scanner_get_tag(scanner, name);
             if (result) {
                 return result;
             } else {
                 /*  the given name was not the one known by TeX
                  *  try a name relative to the enclosing directory of the scanner->output file */
-                const char * relative = name;
-                const char * ptr = scanner->reader->output;
-                while((strlen(relative) > 0) && (strlen(ptr) > 0) && (*relative == *ptr))
-                {
+                const char *relative = name;
+                const char *ptr = scanner->reader->output;
+                while ((strlen(relative) > 0) && (strlen(ptr) > 0) && (*relative == *ptr)) {
                     relative += 1;
                     ptr += 1;
                 }
                 /*  Find the last path separator before relative */
-                while(relative > name) {
-                    if (SYNCTEX_IS_PATH_SEPARATOR(*(relative-1))) {
+                while (relative > name) {
+                    if (SYNCTEX_IS_PATH_SEPARATOR(*(relative - 1))) {
                         break;
                     }
                     relative -= 1;
                 }
-                if ((relative > name) && (result = _synctex_scanner_get_tag(scanner,relative))) {
+                if ((relative > name) && (result = _synctex_scanner_get_tag(scanner, relative))) {
                     return result;
                 }
                 if (SYNCTEX_IS_PATH_SEPARATOR(name[0])) {
                     /*  No tag found for the given absolute name,
                      *  Try each relative path starting from the shortest one */
-                    while(0<char_index) {
+                    while (0 < char_index) {
                         char_index -= 1;
-                        if (SYNCTEX_IS_PATH_SEPARATOR(name[char_index])
-                            && (result = _synctex_scanner_get_tag(scanner,name+char_index+1))) {
+                        if (SYNCTEX_IS_PATH_SEPARATOR(name[char_index]) && (result = _synctex_scanner_get_tag(scanner, name + char_index + 1))) {
                             return result;
                         }
                     }
@@ -6969,12 +7039,14 @@ int synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name) {
     }
     return 0;
 }
-synctex_node_p synctex_scanner_input(synctex_scanner_p scanner) {
-    return scanner?scanner->input:NULL;
+synctex_node_p synctex_scanner_input(synctex_scanner_p scanner)
+{
+    return scanner ? scanner->input : NULL;
 }
-synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner, int tag) {
-    synctex_node_p input = scanner?scanner->input:NULL;
-    while (_synctex_data_tag(input)!=tag) {
+synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner, int tag)
+{
+    synctex_node_p input = scanner ? scanner->input : NULL;
+    while (_synctex_data_tag(input) != tag) {
         if ((input = __synctex_tree_sibling(input))) {
             continue;
         }
@@ -6982,39 +7054,44 @@ synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner, int tag
     }
     return input;
 }
-const char * synctex_scanner_get_output_fmt(synctex_scanner_p scanner) {
-    return NULL != scanner && scanner->output_fmt?scanner->output_fmt:"";
+const char *synctex_scanner_get_output_fmt(synctex_scanner_p scanner)
+{
+    return NULL != scanner && scanner->output_fmt ? scanner->output_fmt : "";
 }
-const char * synctex_scanner_get_output(synctex_scanner_p scanner) {
-    return NULL != scanner && scanner->reader->output?scanner->reader->output:"";
+const char *synctex_scanner_get_output(synctex_scanner_p scanner)
+{
+    return NULL != scanner && scanner->reader->output ? scanner->reader->output : "";
 }
-const char * synctex_scanner_get_synctex(synctex_scanner_p scanner) {
-    return NULL != scanner && scanner->reader->synctex?scanner->reader->synctex:"";
+const char *synctex_scanner_get_synctex(synctex_scanner_p scanner)
+{
+    return NULL != scanner && scanner->reader->synctex ? scanner->reader->synctex : "";
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Public node attributes
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Public node attributes
+#endif
 
-#   define SYNCTEX_DEFINE_NODE_HVWHD(WHAT) \
-int synctex_node_##WHAT(synctex_node_p node) { \
-    return (node && node->class_->inspector->WHAT)? \
-        node->class_->inspector->WHAT(node): 0; \
-}
-#   define SYNCTEX_DEFINE_PROXY_HV(WHAT) \
-static int _synctex_proxy_##WHAT(_synctex_proxy_p proxy) { \
-    synctex_node_p target = _synctex_tree_target(proxy); \
-    if (target) { \
-        return _synctex_data_##WHAT(proxy)+synctex_node_##WHAT(target); \
-    } else { \
-        return proxy? _synctex_data_##WHAT(proxy): 0; \
-    } \
-}
-#define SYNCTEX_DEFINE_PROXY_TLCWVD(WHAT) \
-static int _synctex_proxy_##WHAT(_synctex_proxy_p proxy) { \
-    synctex_node_p target = _synctex_tree_target(proxy); \
-    return target? synctex_node_##WHAT(target): 0; \
-}
+#define SYNCTEX_DEFINE_NODE_HVWHD(WHAT)                                                                                                                        \
+    int synctex_node_##WHAT(synctex_node_p node)                                                                                                               \
+    {                                                                                                                                                          \
+        return (node && node->class_->inspector->WHAT) ? node->class_->inspector->WHAT(node) : 0;                                                              \
+    }
+#define SYNCTEX_DEFINE_PROXY_HV(WHAT)                                                                                                                          \
+    static int _synctex_proxy_##WHAT(_synctex_proxy_p proxy)                                                                                                   \
+    {                                                                                                                                                          \
+        synctex_node_p target = _synctex_tree_target(proxy);                                                                                                   \
+        if (target) {                                                                                                                                          \
+            return _synctex_data_##WHAT(proxy) + synctex_node_##WHAT(target);                                                                                  \
+        } else {                                                                                                                                               \
+            return proxy ? _synctex_data_##WHAT(proxy) : 0;                                                                                                    \
+        }                                                                                                                                                      \
+    }
+#define SYNCTEX_DEFINE_PROXY_TLCWVD(WHAT)                                                                                                                      \
+    static int _synctex_proxy_##WHAT(_synctex_proxy_p proxy)                                                                                                   \
+    {                                                                                                                                                          \
+        synctex_node_p target = _synctex_tree_target(proxy);                                                                                                   \
+        return target ? synctex_node_##WHAT(target) : 0;                                                                                                       \
+    }
 
 /**
  *  The horizontal location of the node.
@@ -7048,13 +7125,11 @@ SYNCTEX_DEFINE_PROXY_TLCWVD(depth);
  *  - returns: yorn
  */
 
-SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_box(synctex_node_p node) {
-    return node &&
-    (node->class_->type == synctex_node_type_hbox
-     || node->class_->type == synctex_node_type_void_hbox
-     || node->class_->type == synctex_node_type_vbox
-     || node->class_->type == synctex_node_type_void_vbox
-     || _synctex_node_is_box(_synctex_tree_target(node)));
+SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_box(synctex_node_p node)
+{
+    return node
+        && (node->class_->type == synctex_node_type_hbox || node->class_->type == synctex_node_type_void_hbox || node->class_->type == synctex_node_type_vbox
+            || node->class_->type == synctex_node_type_void_vbox || _synctex_node_is_box(_synctex_tree_target(node)));
 }
 
 /**
@@ -7065,9 +7140,9 @@ SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_box(synctex_node_p node) {
  *  - returns: yorn
  */
 
-SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_handle(synctex_node_p node) {
-    return node &&
-    (node->class_->type == synctex_node_type_handle);
+SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_handle(synctex_node_p node)
+{
+    return node && (node->class_->type == synctex_node_type_handle);
 }
 
 /**
@@ -7077,9 +7152,9 @@ SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_handle(synctex_node_p node
  *  its target otherwise.
  */
 
-SYNCTEX_INLINE static synctex_node_p _synctex_node_or_handle_target(synctex_node_p node) {
-    return _synctex_node_is_handle(node)?
-    _synctex_tree_target(node):node;
+SYNCTEX_INLINE static synctex_node_p _synctex_node_or_handle_target(synctex_node_p node)
+{
+    return _synctex_node_is_handle(node) ? _synctex_tree_target(node) : node;
 }
 
 /**
@@ -7088,11 +7163,11 @@ SYNCTEX_INLINE static synctex_node_p _synctex_node_or_handle_target(synctex_node
  *  - returns: yorn
  */
 
-SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_hbox(synctex_node_p node) {
-    return node &&
-    (node->class_->type == synctex_node_type_hbox
-     || node->class_->type == synctex_node_type_void_hbox
-     || _synctex_node_is_hbox(_synctex_tree_target(node)));
+SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_hbox(synctex_node_p node)
+{
+    return node
+        && (node->class_->type == synctex_node_type_hbox || node->class_->type == synctex_node_type_void_hbox
+            || _synctex_node_is_hbox(_synctex_tree_target(node)));
 }
 
 /**
@@ -7102,7 +7177,8 @@ SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_hbox(synctex_node_p node) 
  * @param node a node with geometrical information.
  * @return int in TeX sp coordinates.
  */
-int synctex_node_box_h(synctex_node_p node) {
+int synctex_node_box_h(synctex_node_p node)
+{
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
         return synctex_node_h(node);
     }
@@ -7115,7 +7191,8 @@ int synctex_node_box_h(synctex_node_p node) {
  * @param node a node with geometrical information.
  * @return int in TeX sp coordinates
  */
-int synctex_node_box_v(synctex_node_p node) {
+int synctex_node_box_v(synctex_node_p node)
+{
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
         return synctex_node_v(node);
     }
@@ -7127,7 +7204,8 @@ int synctex_node_box_v(synctex_node_p node) {
  *  - returns: an integer.
  *  - author: JL
  */
-int synctex_node_box_width(synctex_node_p node) {
+int synctex_node_box_width(synctex_node_p node)
+{
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
         return synctex_node_width(node);
     }
@@ -7139,7 +7217,8 @@ int synctex_node_box_width(synctex_node_p node) {
  *  - returns: an integer.
  *  - author: JL
  */
-int synctex_node_box_height(synctex_node_p node) {
+int synctex_node_box_height(synctex_node_p node)
+{
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
         return synctex_node_height(node);
     }
@@ -7151,7 +7230,8 @@ int synctex_node_box_height(synctex_node_p node) {
  *  - returns: an integer.
  *  - author: JL
  */
-int synctex_node_box_depth(synctex_node_p node) {
+int synctex_node_box_depth(synctex_node_p node)
+{
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
         return synctex_node_depth(node);
     }
@@ -7164,14 +7244,15 @@ int synctex_node_box_depth(synctex_node_p node) {
  *  - note: recursive call when node is an hbox proxy.
  *  - author: JL
  */
-int synctex_node_hbox_h(synctex_node_p node) {
-    switch(synctex_node_type(node)) {
-        case synctex_node_type_hbox:
-            return _synctex_data_h_V(node);
-        case synctex_node_type_proxy_hbox:
-            return _synctex_data_h(node)+synctex_node_hbox_h(_synctex_tree_target(node));
-        default:
-            return 0;
+int synctex_node_hbox_h(synctex_node_p node)
+{
+    switch (synctex_node_type(node)) {
+    case synctex_node_type_hbox:
+        return _synctex_data_h_V(node);
+    case synctex_node_type_proxy_hbox:
+        return _synctex_data_h(node) + synctex_node_hbox_h(_synctex_tree_target(node));
+    default:
+        return 0;
     }
 }
 /**
@@ -7181,14 +7262,15 @@ int synctex_node_hbox_h(synctex_node_p node) {
  *  - note: recursive call when node is an hbox proxy.
  *  - author: JL
  */
-int synctex_node_hbox_v(synctex_node_p node) {
-    switch(synctex_node_type(node)) {
-        case synctex_node_type_hbox:
-            return _synctex_data_v_V(node);
-        case synctex_node_type_proxy_hbox:
-            return _synctex_data_v(node)+synctex_node_hbox_v(_synctex_tree_target(node));
-        default:
-            return 0;
+int synctex_node_hbox_v(synctex_node_p node)
+{
+    switch (synctex_node_type(node)) {
+    case synctex_node_type_hbox:
+        return _synctex_data_v_V(node);
+    case synctex_node_type_proxy_hbox:
+        return _synctex_data_v(node) + synctex_node_hbox_v(_synctex_tree_target(node));
+    default:
+        return 0;
     }
 }
 /**
@@ -7197,13 +7279,13 @@ int synctex_node_hbox_v(synctex_node_p node) {
  *  - returns: an integer.
  *  - author: JL
  */
-int synctex_node_hbox_width(synctex_node_p node) {
+int synctex_node_hbox_width(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         node = target;
     }
-    return synctex_node_type(node) == synctex_node_type_hbox?
-    _synctex_data_width_V(node): 0;
+    return synctex_node_type(node) == synctex_node_type_hbox ? _synctex_data_width_V(node) : 0;
 }
 /**
  *  The height of an hbox, corrected with contents.
@@ -7211,13 +7293,13 @@ int synctex_node_hbox_width(synctex_node_p node) {
  *  - returns: an integer, 0 if node is not an hbox or an hbox proxy.
  *  - author: JL
  */
-int synctex_node_hbox_height(synctex_node_p node) {
+int synctex_node_hbox_height(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         node = target;
     }
-    return synctex_node_type(node) == synctex_node_type_hbox?
-    _synctex_data_height_V(node): 0;
+    return synctex_node_type(node) == synctex_node_type_hbox ? _synctex_data_height_V(node) : 0;
 }
 /**
  *  The depth of an hbox, corrected with contents.
@@ -7226,83 +7308,97 @@ int synctex_node_hbox_height(synctex_node_p node) {
  *  - note: recursive call when node is an hbox proxy.
  *  - author: JL
  */
-int synctex_node_hbox_depth(synctex_node_p node) {
+int synctex_node_hbox_depth(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         node = target;
     }
-    return synctex_node_type(node) == synctex_node_type_hbox?
-    _synctex_data_depth_V(node): 0;
+    return synctex_node_type(node) == synctex_node_type_hbox ? _synctex_data_depth_V(node) : 0;
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Public node visible attributes
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Public node visible attributes
+#endif
 
-#define SYNCTEX_VISIBLE_SIZE(node,s) \
-(s)*node->class_->scanner->unit
-#define SYNCTEX_VISIBLE_DISTANCE_h(node,d) \
-((d)*node->class_->scanner->unit+node->class_->scanner->x_offset)
-#define SYNCTEX_VISIBLE_DISTANCE_v(node,d) \
-((d)*node->class_->scanner->unit+node->class_->scanner->y_offset)
-static float __synctex_node_visible_h(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_h(node,synctex_node_h(node));
+#define SYNCTEX_VISIBLE_SIZE(node, s) (s) * node->class_->scanner->unit
+#define SYNCTEX_VISIBLE_DISTANCE_h(node, d) ((d) * node->class_->scanner->unit + node->class_->scanner->x_offset)
+#define SYNCTEX_VISIBLE_DISTANCE_v(node, d) ((d) * node->class_->scanner->unit + node->class_->scanner->y_offset)
+static float __synctex_node_visible_h(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_h(node, synctex_node_h(node));
 }
-static float __synctex_node_visible_v(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_v(node,synctex_node_v(node));
+static float __synctex_node_visible_v(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_v(node, synctex_node_v(node));
 }
-static float __synctex_node_visible_width(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,synctex_node_width(node));
+static float __synctex_node_visible_width(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, synctex_node_width(node));
 }
-static float __synctex_node_visible_height(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,synctex_node_height(node));
+static float __synctex_node_visible_height(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, synctex_node_height(node));
 }
-static float __synctex_node_visible_depth(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,synctex_node_depth(node));
+static float __synctex_node_visible_depth(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, synctex_node_depth(node));
 }
-static float __synctex_proxy_visible_h(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_h(node,synctex_node_h(node));
+static float __synctex_proxy_visible_h(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_h(node, synctex_node_h(node));
 }
-static float __synctex_proxy_visible_v(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_v(node,synctex_node_v(node));
+static float __synctex_proxy_visible_v(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_v(node, synctex_node_v(node));
 }
-static float __synctex_proxy_visible_width(synctex_node_p node) {
+static float __synctex_proxy_visible_width(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     return __synctex_node_visible_width(target);
 }
-static float __synctex_proxy_visible_height(synctex_node_p node) {
+static float __synctex_proxy_visible_height(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     return __synctex_node_visible_height(target);
 }
-static float __synctex_proxy_visible_depth(synctex_node_p node) {
+static float __synctex_proxy_visible_depth(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     return __synctex_node_visible_depth(target);
 }
-static float __synctex_kern_visible_h(_synctex_noxy_p noxy) {
+static float __synctex_kern_visible_h(_synctex_noxy_p noxy)
+{
     int h = _synctex_data_h(noxy);
     int width = _synctex_data_width(noxy);
-    return SYNCTEX_VISIBLE_DISTANCE_h(noxy, width>0?h-width:h);
+    return SYNCTEX_VISIBLE_DISTANCE_h(noxy, width > 0 ? h - width : h);
 }
-static float __synctex_kern_visible_width(_synctex_noxy_p noxy) {
+static float __synctex_kern_visible_width(_synctex_noxy_p noxy)
+{
     int width = _synctex_data_width(noxy);
-    return SYNCTEX_VISIBLE_SIZE(noxy, width>0?width:-width);
+    return SYNCTEX_VISIBLE_SIZE(noxy, width > 0 ? width : -width);
 }
-static float __synctex_rule_visible_h(_synctex_noxy_p noxy) {
+static float __synctex_rule_visible_h(_synctex_noxy_p noxy)
+{
     int h = _synctex_data_h(noxy);
     int width = _synctex_data_width(noxy);
-    return SYNCTEX_VISIBLE_DISTANCE_h(noxy, width>0?h:h-width);
+    return SYNCTEX_VISIBLE_DISTANCE_h(noxy, width > 0 ? h : h - width);
 }
-static float __synctex_rule_visible_width(_synctex_noxy_p noxy) {
+static float __synctex_rule_visible_width(_synctex_noxy_p noxy)
+{
     int width = _synctex_data_width(noxy);
-    return SYNCTEX_VISIBLE_SIZE(noxy, width>0?width:-width);
+    return SYNCTEX_VISIBLE_SIZE(noxy, width > 0 ? width : -width);
 }
-static float __synctex_rule_visible_v(_synctex_noxy_p noxy) {
+static float __synctex_rule_visible_v(_synctex_noxy_p noxy)
+{
     return __synctex_node_visible_v(noxy);
 }
-static float __synctex_rule_visible_height(_synctex_noxy_p noxy) {
+static float __synctex_rule_visible_height(_synctex_noxy_p noxy)
+{
     return __synctex_node_visible_height(noxy);
 }
-static float __synctex_rule_visible_depth(_synctex_noxy_p noxy) {
+static float __synctex_rule_visible_depth(_synctex_noxy_p noxy)
+{
     return __synctex_node_visible_depth(noxy);
 }
 
@@ -7312,8 +7408,9 @@ static float __synctex_rule_visible_depth(_synctex_noxy_p noxy) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_visible_h(synctex_node_p node){
-    return node? node->class_->vispector->h(node): 0;
+float synctex_node_visible_h(synctex_node_p node)
+{
+    return node ? node->class_->vispector->h(node) : 0;
 }
 /**
  *  The vertical location of node, in page coordinates.
@@ -7321,8 +7418,9 @@ float synctex_node_visible_h(synctex_node_p node){
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_visible_v(synctex_node_p node){
-    return node? node->class_->vispector->v(node): 0;
+float synctex_node_visible_v(synctex_node_p node)
+{
+    return node ? node->class_->vispector->v(node) : 0;
 }
 /**
  *  The width of node, in page coordinates.
@@ -7330,8 +7428,9 @@ float synctex_node_visible_v(synctex_node_p node){
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_visible_width(synctex_node_p node){
-    return node? node->class_->vispector->width(node): 0;
+float synctex_node_visible_width(synctex_node_p node)
+{
+    return node ? node->class_->vispector->width(node) : 0;
 }
 /**
  *  The height of node, in page coordinates.
@@ -7339,8 +7438,9 @@ float synctex_node_visible_width(synctex_node_p node){
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_visible_height(synctex_node_p node){
-    return node? node->class_->vispector->height(node): 0;
+float synctex_node_visible_height(synctex_node_p node)
+{
+    return node ? node->class_->vispector->height(node) : 0;
 }
 /**
  *  The depth of node, in page coordinates.
@@ -7348,8 +7448,9 @@ float synctex_node_visible_height(synctex_node_p node){
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_visible_depth(synctex_node_p node){
-    return node? node->class_->vispector->depth(node): 0;
+float synctex_node_visible_depth(synctex_node_p node)
+{
+    return node ? node->class_->vispector->depth(node) : 0;
 }
 
 /**
@@ -7358,17 +7459,18 @@ float synctex_node_visible_depth(synctex_node_p node){
  *  - returns: an integer.
  *  - author: JL
  */
-#define SYNCTEX_DEFINE_V(WHAT)\
-SYNCTEX_INLINE static int _synctex_node_##WHAT##_V(synctex_node_p node) { \
-    synctex_node_p target = _synctex_tree_target(node); \
-    if (target) { \
-        return _synctex_data_##WHAT(node)+_synctex_node_##WHAT##_V(target); \
-    } else if (_synctex_data_has_##WHAT##_V(node)) { \
-        return _synctex_data_##WHAT##_V(node); \
-    } else { \
-        return _synctex_data_##WHAT(node); \
-    } \
-}
+#define SYNCTEX_DEFINE_V(WHAT)                                                                                                                                 \
+    SYNCTEX_INLINE static int _synctex_node_##WHAT##_V(synctex_node_p node)                                                                                    \
+    {                                                                                                                                                          \
+        synctex_node_p target = _synctex_tree_target(node);                                                                                                    \
+        if (target) {                                                                                                                                          \
+            return _synctex_data_##WHAT(node) + _synctex_node_##WHAT##_V(target);                                                                              \
+        } else if (_synctex_data_has_##WHAT##_V(node)) {                                                                                                       \
+            return _synctex_data_##WHAT##_V(node);                                                                                                             \
+        } else {                                                                                                                                               \
+            return _synctex_data_##WHAT(node);                                                                                                                 \
+        }                                                                                                                                                      \
+    }
 /*
 Definitions of
 _synctex_node_h_V
@@ -7383,23 +7485,27 @@ SYNCTEX_DEFINE_V(width);
 SYNCTEX_DEFINE_V(height);
 SYNCTEX_DEFINE_V(depth);
 
-SYNCTEX_INLINE static synctex_point_s _synctex_data_point(synctex_node_p node) {
-    return (synctex_point_s){synctex_node_h(node),synctex_node_v(node)};
+SYNCTEX_INLINE static synctex_point_s _synctex_data_point(synctex_node_p node)
+{
+    return (synctex_point_s){synctex_node_h(node), synctex_node_v(node)};
 }
-SYNCTEX_INLINE static synctex_point_s _synctex_data_point_V(synctex_node_p node) {
-    return (synctex_point_s){_synctex_node_h_V(node),_synctex_node_v_V(node)};
+SYNCTEX_INLINE static synctex_point_s _synctex_data_point_V(synctex_node_p node)
+{
+    return (synctex_point_s){_synctex_node_h_V(node), _synctex_node_v_V(node)};
 }
-SYNCTEX_INLINE static synctex_point_s _synctex_data_set_point(synctex_node_p node, synctex_point_s point) {
+SYNCTEX_INLINE static synctex_point_s _synctex_data_set_point(synctex_node_p node, synctex_point_s point)
+{
     synctex_point_s old = _synctex_data_point(node);
-    _synctex_data_set_h(node,point.h);
-    _synctex_data_set_v(node,point.v);
+    _synctex_data_set_h(node, point.h);
+    _synctex_data_set_v(node, point.v);
     return old;
 }
-SYNCTEX_INLINE static synctex_box_s _synctex_data_box(synctex_node_p node) {
-    synctex_box_s box = {{0,0},{0,0}};
+SYNCTEX_INLINE static synctex_box_s _synctex_data_box(synctex_node_p node)
+{
+    synctex_box_s box = {{0, 0}, {0, 0}};
     int n;
     n = synctex_node_width(node);
-    if (n<0) {
+    if (n < 0) {
         box.max.h = synctex_node_h(node);
         box.min.h = box.max.h + n;
     } else {
@@ -7411,11 +7517,12 @@ SYNCTEX_INLINE static synctex_box_s _synctex_data_box(synctex_node_p node) {
     box.max.v = n + synctex_node_depth(node);
     return box;
 }
-SYNCTEX_INLINE static synctex_box_s _synctex_data_xob(synctex_node_p node) {
-    synctex_box_s box = {{0,0},{0,0}};
+SYNCTEX_INLINE static synctex_box_s _synctex_data_xob(synctex_node_p node)
+{
+    synctex_box_s box = {{0, 0}, {0, 0}};
     int n;
     n = synctex_node_width(node);
-    if (n>0) {
+    if (n > 0) {
         box.max.h = synctex_node_h(node);
         box.min.h = box.max.h - n;
     } else {
@@ -7427,11 +7534,12 @@ SYNCTEX_INLINE static synctex_box_s _synctex_data_xob(synctex_node_p node) {
     box.max.v = n + synctex_node_depth(node);
     return box;
 }
-SYNCTEX_INLINE static synctex_box_s _synctex_data_box_V(synctex_node_p node) {
-    synctex_box_s box = {{0,0},{0,0}};
+SYNCTEX_INLINE static synctex_box_s _synctex_data_box_V(synctex_node_p node)
+{
+    synctex_box_s box = {{0, 0}, {0, 0}};
     int n;
     n = _synctex_node_width_V(node);
-    if (n<0) {
+    if (n < 0) {
         box.max.h = _synctex_node_h_V(node);
         box.min.h = box.max.h + n;
     } else {
@@ -7454,14 +7562,15 @@ SYNCTEX_INLINE static synctex_box_s _synctex_data_box_V(synctex_node_p node) {
  *  2) compute the mean line number
  *  3) scans up the tree for the higher hbox with
  *  the same mean line number, ±1 eventually
-*  - parameter node: a node.
+ *  - parameter node: a node.
  *  - returns: a (proxy to a) box node.
  *  - author: JL
  */
-static synctex_node_p _synctex_node_box_visible(synctex_node_p node) {
+static synctex_node_p _synctex_node_box_visible(synctex_node_p node)
+{
     if ((node = _synctex_node_or_handle_target(node))) {
         int mean = 0;
-        int bound = 1500000/(node->class_->scanner->pre_magnification/1000.0);
+        int bound = 1500000 / (node->class_->scanner->pre_magnification / 1000.0);
         synctex_node_p parent = NULL;
         /*  get the first enclosing parent
          *  then get the highest enclosing parent with the same mean line ±1 */
@@ -7483,11 +7592,11 @@ static synctex_node_p _synctex_node_box_visible(synctex_node_p node) {
         mean = synctex_node_mean_line(node);
         while ((parent = _synctex_tree_parent(parent))) {
             if (_synctex_node_is_hbox(parent)) {
-                if (_synctex_abs(mean-synctex_node_mean_line(parent))>1) {
+                if (_synctex_abs(mean - synctex_node_mean_line(parent)) > 1) {
                     return node;
-                } else if (synctex_node_width(parent)>bound) {
+                } else if (synctex_node_width(parent) > bound) {
                     return parent;
-                } else if (synctex_node_height(parent)+synctex_node_depth(parent)>bound) {
+                } else if (synctex_node_height(parent) + synctex_node_depth(parent) > bound) {
                     return parent;
                 }
                 node = parent;
@@ -7502,8 +7611,9 @@ static synctex_node_p _synctex_node_box_visible(synctex_node_p node) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_box_visible_h(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_h(node,_synctex_node_h_V(_synctex_node_box_visible(node)));
+float synctex_node_box_visible_h(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_h(node, _synctex_node_h_V(_synctex_node_box_visible(node)));
 }
 /**
  *  The vertical location of the first box enclosing node, in page coordinates.
@@ -7511,8 +7621,9 @@ float synctex_node_box_visible_h(synctex_node_p node) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_box_visible_v(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_DISTANCE_v(node,_synctex_node_v_V(_synctex_node_box_visible(node)));
+float synctex_node_box_visible_v(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_DISTANCE_v(node, _synctex_node_v_V(_synctex_node_box_visible(node)));
 }
 /**
  *  The width of the first box enclosing node, in page coordinates.
@@ -7520,8 +7631,9 @@ float synctex_node_box_visible_v(synctex_node_p node) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_box_visible_width(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,_synctex_node_width_V(_synctex_node_box_visible(node)));
+float synctex_node_box_visible_width(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, _synctex_node_width_V(_synctex_node_box_visible(node)));
 }
 /**
  *  The height of the first box enclosing node, in page coordinates.
@@ -7529,8 +7641,9 @@ float synctex_node_box_visible_width(synctex_node_p node) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_box_visible_height(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,_synctex_node_height_V(_synctex_node_box_visible(node)));
+float synctex_node_box_visible_height(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, _synctex_node_height_V(_synctex_node_box_visible(node)));
 }
 /**
  *  The depth of the first box enclosing node, in page coordinates.
@@ -7538,13 +7651,14 @@ float synctex_node_box_visible_height(synctex_node_p node) {
  *  - returns: a float.
  *  - author: JL
  */
-float synctex_node_box_visible_depth(synctex_node_p node) {
-    return SYNCTEX_VISIBLE_SIZE(node,_synctex_node_depth_V(_synctex_node_box_visible(node)));
+float synctex_node_box_visible_depth(synctex_node_p node)
+{
+    return SYNCTEX_VISIBLE_SIZE(node, _synctex_node_depth_V(_synctex_node_box_visible(node)));
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Other public node attributes
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Other public node attributes
+#endif
 
 /**
  *  The page number of the sheet enclosing node.
@@ -7556,9 +7670,10 @@ float synctex_node_box_visible_depth(synctex_node_p node) {
  *      its page number is -1.
  *  - author: JL
  */
-int synctex_node_page(synctex_node_p node){
+int synctex_node_page(synctex_node_p node)
+{
     synctex_node_p parent = NULL;
-    while((parent = _synctex_tree_parent(node))) {
+    while ((parent = _synctex_tree_parent(node))) {
         node = parent;
     }
     if (synctex_node_type(node) == synctex_node_type_sheet) {
@@ -7570,14 +7685,16 @@ int synctex_node_page(synctex_node_p node){
  *  The page number of the target.
  *  - author: JL
  */
-SYNCTEX_INLINE static int _synctex_node_target_page(synctex_node_p node){
+SYNCTEX_INLINE static int _synctex_node_target_page(synctex_node_p node)
+{
     return synctex_node_page(_synctex_tree_target(node));
 }
 
-#if defined (SYNCTEX_USE_CHARINDEX)
-synctex_charindex_t synctex_node_charindex(synctex_node_p node) {
+#if defined(SYNCTEX_USE_CHARINDEX)
+synctex_charindex_t synctex_node_charindex(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
-    return target? SYNCTEX_CHARINDEX(target):(node?SYNCTEX_CHARINDEX(node):0);
+    return target ? SYNCTEX_CHARINDEX(target) : (node ? SYNCTEX_CHARINDEX(node) : 0);
 }
 #endif
 
@@ -7587,8 +7704,9 @@ synctex_charindex_t synctex_node_charindex(synctex_node_p node) {
  *  - returns: the tag or -1 if node is NULL.
  *  - author: JL
  */
-int synctex_node_tag(synctex_node_p node) {
-    return node? node->class_->tlcpector->tag(node): -1;
+int synctex_node_tag(synctex_node_p node)
+{
+    return node ? node->class_->tlcpector->tag(node) : -1;
 }
 /**
  *  The line of the node.
@@ -7596,8 +7714,9 @@ int synctex_node_tag(synctex_node_p node) {
  *  - returns: the line or -1 if node is NULL.
  *  - author: JL
  */
-int synctex_node_line(synctex_node_p node) {
-    return node? node->class_->tlcpector->line(node): -1;
+int synctex_node_line(synctex_node_p node)
+{
+    return node ? node->class_->tlcpector->line(node) : -1;
 }
 /**
  *  The column of the node.
@@ -7605,8 +7724,9 @@ int synctex_node_line(synctex_node_p node) {
  *  - returns: the column or -1 if node is NULL.
  *  - author: JL
  */
-int synctex_node_column(synctex_node_p node) {
-    return node? node->class_->tlcpector->column(node): -1;
+int synctex_node_column(synctex_node_p node)
+{
+    return node ? node->class_->tlcpector->column(node) : -1;
 }
 /**
  *  The mean line number of the node.
@@ -7614,7 +7734,8 @@ int synctex_node_column(synctex_node_p node) {
  *  - returns: the mean line or -1 if node is NULL.
  *  - author: JL
  */
-int synctex_node_mean_line(synctex_node_p node) {
+int synctex_node_mean_line(synctex_node_p node)
+{
     synctex_node_p other = _synctex_tree_target(node);
     if (other) {
         node = other;
@@ -7637,12 +7758,13 @@ int synctex_node_mean_line(synctex_node_p node) {
  * @return int. -1 if node is NULL, 0 if the node is not an hbox.
  * @author Jérôme LAURENS
  */
-int synctex_node_weight(synctex_node_p node) {
+int synctex_node_weight(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         node = target;
     }
-    return node?(synctex_node_type(node)==synctex_node_type_hbox?_synctex_data_weight(node):0):-1;
+    return node ? (synctex_node_type(node) == synctex_node_type_hbox ? _synctex_data_weight(node) : 0) : -1;
 }
 /**
  *  The number of children of the node.
@@ -7650,17 +7772,18 @@ int synctex_node_weight(synctex_node_p node) {
  *  - returns: the count or -1 if node is NULL.
  *  - author: JL
  */
-int synctex_node_child_count(synctex_node_p node) {
+int synctex_node_child_count(synctex_node_p node)
+{
     synctex_node_p target = _synctex_tree_target(node);
     if (target) {
         node = target;
     }
-    return node?(synctex_node_type(node)==synctex_node_type_hbox?_synctex_data_weight(node):0):-1;
+    return node ? (synctex_node_type(node) == synctex_node_type_hbox ? _synctex_data_weight(node) : 0) : -1;
 }
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Sheet & Form
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Sheet & Form
+#endif
 
 /**
  *  The sheet of the scanner with a given page number.
@@ -7670,10 +7793,11 @@ int synctex_node_child_count(synctex_node_p node) {
  *  - returns: a sheet or NULL.
  *  - author: JL
  */
-synctex_node_p synctex_sheet(synctex_scanner_p scanner,int page) {
+synctex_node_p synctex_sheet(synctex_scanner_p scanner, int page)
+{
     if (scanner) {
         synctex_node_p sheet = scanner->sheet;
-        while(sheet) {
+        while (sheet) {
             if (page == _synctex_data_page(sheet)) {
                 return sheet;
             }
@@ -7693,10 +7817,11 @@ synctex_node_p synctex_sheet(synctex_scanner_p scanner,int page) {
  *  - returns: a form.
  *  - author: JL
  */
-synctex_node_p synctex_form(synctex_scanner_p scanner,int tag) {
+synctex_node_p synctex_form(synctex_scanner_p scanner, int tag)
+{
     if (scanner) {
         synctex_node_p form = scanner->form;
-        while(form) {
+        while (form) {
             if (tag == _synctex_data_tag(form)) {
                 return form;
             }
@@ -7716,9 +7841,10 @@ synctex_node_p synctex_form(synctex_scanner_p scanner,int tag) {
  *  - returns: a (vertical) box node.
  *  - author: JL
  */
-synctex_node_p synctex_sheet_content(synctex_scanner_p scanner,int page) {
+synctex_node_p synctex_sheet_content(synctex_scanner_p scanner, int page)
+{
     if (scanner) {
-        return _synctex_tree_child(synctex_sheet(scanner,page));
+        return _synctex_tree_child(synctex_sheet(scanner, page));
     }
     return NULL;
 }
@@ -7730,21 +7856,24 @@ synctex_node_p synctex_sheet_content(synctex_scanner_p scanner,int page) {
  *  - returns: a box node.
  *  - author: JL
  */
-synctex_node_p synctex_form_content(synctex_scanner_p scanner,int tag) {
+synctex_node_p synctex_form_content(synctex_scanner_p scanner, int tag)
+{
     if (scanner) {
-        return _synctex_tree_child(synctex_form(scanner,tag));
+        return _synctex_tree_child(synctex_form(scanner, tag));
     }
     return NULL;
 }
 
-SYNCTEX_INLINE static synctex_node_p _synctex_scanner_friend(synctex_scanner_p scanner,int i) {
-    if (i>=0) {
-        i = _synctex_abs(i)%(scanner->number_of_lists);
+SYNCTEX_INLINE static synctex_node_p _synctex_scanner_friend(synctex_scanner_p scanner, int i)
+{
+    if (i >= 0) {
+        i = _synctex_abs(i) % (scanner->number_of_lists);
         return (scanner->lists_of_friends)[i];
     }
     return NULL;
 }
-SYNCTEX_INLINE static synctex_bool_t _synctex_nodes_are_friend(synctex_node_p left, synctex_node_p right) {
+SYNCTEX_INLINE static synctex_bool_t _synctex_nodes_are_friend(synctex_node_p left, synctex_node_p right)
+{
     return synctex_node_tag(left) == synctex_node_tag(right) && synctex_node_line(left) == synctex_node_line(right);
 }
 /**
@@ -7755,7 +7884,8 @@ typedef struct {
     synctex_node_p node;
 } _synctex_counted_node_s;
 
-SYNCTEX_INLINE static _synctex_counted_node_s _synctex_vertically_sorted_v2(synctex_node_p sibling) {
+SYNCTEX_INLINE static _synctex_counted_node_s _synctex_vertically_sorted_v2(synctex_node_p sibling)
+{
     /* Clean the weights of the parents */
     _synctex_counted_node_s result = {0, NULL};
     synctex_node_p h = NULL;
@@ -7768,47 +7898,47 @@ SYNCTEX_INLINE static _synctex_counted_node_s _synctex_vertically_sorted_v2(sync
         N = _synctex_tree_target(h);
         parent = _synctex_tree_parent(N);
         _synctex_data_set_weight(parent, 0);
-    } while((h = _synctex_tree_child(h)));
+    } while ((h = _synctex_tree_child(h)));
     /* Compute the weights of the nodes */
     h = sibling;
     do {
         N = _synctex_tree_target(h);
         parent = _synctex_tree_parent(N);
         weight = _synctex_data_weight(parent);
-        if (weight==0) {
+        if (weight == 0) {
             N = _synctex_tree_child(parent);
             do {
-                if (_synctex_nodes_are_friend(N,sibling)) {
-                    ++ weight;
+                if (_synctex_nodes_are_friend(N, sibling)) {
+                    ++weight;
                 }
             } while ((N = __synctex_tree_sibling(N)));
-            _synctex_data_set_weight(h,weight);
-            _synctex_data_set_weight(parent,weight);
+            _synctex_data_set_weight(h, weight);
+            _synctex_data_set_weight(parent, weight);
         }
-    } while((h = _synctex_tree_child(h)));
+    } while ((h = _synctex_tree_child(h)));
     /* Order handle nodes according to the weight */
     h = _synctex_tree_reset_child(sibling);
     result.node = sibling;
     weight = 0;
-    while((h)) {
+    while ((h)) {
         N = result.node;
-        if (_synctex_data_weight(h)>_synctex_data_weight(N)) {
-            next_h = _synctex_tree_set_child(h,N);
+        if (_synctex_data_weight(h) > _synctex_data_weight(N)) {
+            next_h = _synctex_tree_set_child(h, N);
             result.node = h;
         } else if (_synctex_data_weight(h) == 0) {
-            ++ weight;
+            ++weight;
             next_h = _synctex_tree_reset_child(h);
             _synctex_node_free(h);
         } else {
             synctex_node_p next_N = NULL;
-            while((next_N = _synctex_tree_child(N))) {
+            while ((next_N = _synctex_tree_child(N))) {
                 N = next_N;
-                if (_synctex_data_weight(h)<_synctex_data_weight(next_N)) {
+                if (_synctex_data_weight(h) < _synctex_data_weight(next_N)) {
                     continue;
                 }
                 break;
             }
-            next_h = _synctex_tree_set_child(h,_synctex_tree_set_child(N,h));
+            next_h = _synctex_tree_set_child(h, _synctex_tree_set_child(N, h));
         }
         h = next_h;
     };
@@ -7816,15 +7946,15 @@ SYNCTEX_INLINE static _synctex_counted_node_s _synctex_vertically_sorted_v2(sync
     weight = 0;
     do {
         ++weight;
-    } while((h = _synctex_tree_child(h)));
+    } while ((h = _synctex_tree_child(h)));
     result.count = 1;
     h = result.node;
-    while((next_h = _synctex_tree_child(h))) {
-        if (_synctex_data_weight(next_h)==0) {
+    while ((next_h = _synctex_tree_child(h))) {
+        if (_synctex_data_weight(next_h) == 0) {
             _synctex_tree_reset_child(h);
             weight = 1;
             h = next_h;
-            while((h = _synctex_tree_child(h))) {
+            while ((h = _synctex_tree_child(h))) {
                 ++weight;
             }
             _synctex_node_free(next_h);
@@ -7847,9 +7977,13 @@ typedef struct {
     int distance;
 } _synctex_nd_s;
 
-#define SYNCTEX_ND_0 (_synctex_nd_s){NULL,INT_MAX}
+#define SYNCTEX_ND_0                                                                                                                                           \
+    (_synctex_nd_s)                                                                                                                                            \
+    {                                                                                                                                                          \
+        NULL, INT_MAX                                                                                                                                          \
+    }
 
-typedef _synctex_nd_s * _synctex_nd_p;
+typedef _synctex_nd_s *_synctex_nd_p;
 
 typedef struct {
     _synctex_nd_s l;
@@ -7882,10 +8016,10 @@ static int _synctex_point_node_distance_v2(synctex_point_p hitP, synctex_node_p 
  *  The "visible" version takes into account the visible dimensions instead of the real ones given by TeX. */
 static _synctex_nd_s _synctex_eq_closest_child_v2(synctex_point_p hitP, synctex_node_p node);
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Queries
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Queries
+#endif
 
 /**
  * @cond
@@ -7901,7 +8035,8 @@ typedef struct synctex_iterator_t {
  * @endcond
  */
 
-SYNCTEX_INLINE static synctex_iterator_p _synctex_iterator_new(synctex_node_p result, int count) {
+SYNCTEX_INLINE static synctex_iterator_p _synctex_iterator_new(synctex_node_p result, int count)
+{
     synctex_iterator_p iterator;
     if ((iterator = _synctex_malloc(sizeof(synctex_iterator_s)))) {
         iterator->seed = iterator->top = iterator->next = result;
@@ -7910,17 +8045,20 @@ SYNCTEX_INLINE static synctex_iterator_p _synctex_iterator_new(synctex_node_p re
     return iterator;
 }
 
-void synctex_iterator_free(synctex_iterator_p iterator) {
+void synctex_iterator_free(synctex_iterator_p iterator)
+{
     if (iterator) {
         _synctex_node_free(iterator->seed);
         _synctex_free(iterator);
     }
 }
-synctex_bool_t synctex_iterator_has_next(synctex_iterator_p iterator) {
-    return iterator?iterator->count>0:0;
+synctex_bool_t synctex_iterator_has_next(synctex_iterator_p iterator)
+{
+    return iterator ? iterator->count > 0 : 0;
 }
-int synctex_iterator_count(synctex_iterator_p iterator) {
-    return iterator? iterator->count: 0;
+int synctex_iterator_count(synctex_iterator_p iterator)
+{
+    return iterator ? iterator->count : 0;
 }
 
 /**
@@ -7929,10 +8067,11 @@ int synctex_iterator_count(synctex_iterator_p iterator) {
  *  Externally, it returns the targets,
  *  such that the caller only sees nodes.
  */
-synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator) {
-    if (iterator && iterator->count>0) {
+synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator)
+{
+    if (iterator && iterator->count > 0) {
         synctex_node_p N = iterator->next;
-        if(!(iterator->next = _synctex_tree_child(N))) {
+        if (!(iterator->next = _synctex_tree_child(N))) {
             iterator->next = iterator->top = __synctex_tree_sibling(iterator->top);
         }
         --iterator->count;
@@ -7940,7 +8079,8 @@ synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator) {
     }
     return NULL;
 }
-int synctex_iterator_reset(synctex_iterator_p iterator) {
+int synctex_iterator_reset(synctex_iterator_p iterator)
+{
     if (iterator) {
         iterator->next = iterator->top = iterator->seed;
         return iterator->count = iterator->count0;
@@ -7948,31 +8088,30 @@ int synctex_iterator_reset(synctex_iterator_p iterator) {
     return 0;
 }
 
-synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,float h,float v){
+synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner, int page, float h, float v)
+{
     if (scanner) {
         synctex_node_p sheet = NULL;
         synctex_point_s hit;
         synctex_node_p node = NULL;
-        _synctex_nd_lr_s nds = {{NULL,0},{NULL,0}};
-        if (NULL == (scanner = synctex_scanner_parse(scanner)) || 0 >= scanner->unit) {/*  scanner->unit must be >0 */
+        _synctex_nd_lr_s nds = {{NULL, 0}, {NULL, 0}};
+        if (NULL == (scanner = synctex_scanner_parse(scanner)) || 0 >= scanner->unit) { /*  scanner->unit must be >0 */
             return NULL;
         }
         /*  Find the proper sheet */
-        sheet = synctex_sheet(scanner,page);
+        sheet = synctex_sheet(scanner, page);
         if (NULL == sheet) {
             return NULL;
         }
         /*  Now sheet points to the sheet node with proper page number. */
         /*  Now that scanner has been initialized, we can convert
          *  the given point to scanner integer coordinates */
-        hit = (synctex_point_s)
-        {(h-scanner->x_offset)/scanner->unit,
-            (v-scanner->y_offset)/scanner->unit};
+        hit = (synctex_point_s){(h - scanner->x_offset) / scanner->unit, (v - scanner->y_offset) / scanner->unit};
         /*  At first, we browse all the horizontal boxes of the sheet
          *  until we find one containing the hit point. */
         if ((node = _synctex_tree_next_hbox(sheet))) {
             do {
-                if (_synctex_point_in_box_v2(&hit,node)) {
+                if (_synctex_point_in_box_v2(&hit, node)) {
                     /*  Maybe the hit point belongs to a contained vertical box.
                      *  This is the most likely situation.
                      */
@@ -7982,8 +8121,8 @@ synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,
 #endif
                     /*  This trick is for catching overlapping boxes */
                     while ((next = _synctex_tree_next_hbox(next))) {
-                        if (_synctex_point_in_box_v2(&hit,next)) {
-                            node = _synctex_smallest_container_v2(next,node);
+                        if (_synctex_point_in_box_v2(&hit, next)) {
+                            node = _synctex_smallest_container_v2(next, node);
                         }
                     }
                     /*  node is the smallest horizontal box that contains hit,
@@ -7993,33 +8132,33 @@ synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,
                     nds = _synctex_eq_get_closest_children_in_box_v2(&hit, node);
                 end:
                     if (nds.r.node && nds.l.node) {
-                        if ((_synctex_data_tag(nds.r.node)!=_synctex_data_tag(nds.l.node))
-                            || (_synctex_data_line(nds.r.node)!=_synctex_data_line(nds.l.node))
-                            || (_synctex_data_column(nds.r.node)!=_synctex_data_column(nds.l.node))) {
-                            if (_synctex_data_line(nds.r.node)<_synctex_data_line(nds.l.node)) {
+                        if ((_synctex_data_tag(nds.r.node) != _synctex_data_tag(nds.l.node))
+                            || (_synctex_data_line(nds.r.node) != _synctex_data_line(nds.l.node))
+                            || (_synctex_data_column(nds.r.node) != _synctex_data_column(nds.l.node))) {
+                            if (_synctex_data_line(nds.r.node) < _synctex_data_line(nds.l.node)) {
                                 node = nds.r.node;
                                 nds.r.node = nds.l.node;
                                 nds.l.node = node;
-                            } else if (_synctex_data_line(nds.r.node)==_synctex_data_line(nds.l.node)) {
-                                if (nds.l.distance>nds.r.distance) {
+                            } else if (_synctex_data_line(nds.r.node) == _synctex_data_line(nds.l.node)) {
+                                if (nds.l.distance > nds.r.distance) {
                                     node = nds.r.node;
                                     nds.r.node = nds.l.node;
                                     nds.l.node = node;
                                 }
                             }
-                            if((node = _synctex_new_handle_with_target(nds.l.node))) {
+                            if ((node = _synctex_new_handle_with_target(nds.l.node))) {
                                 synctex_node_p other_handle;
-                                if((other_handle = _synctex_new_handle_with_target(nds.r.node))) {
-                                    _synctex_tree_set_sibling(node,other_handle);
-                                    return _synctex_iterator_new(node,2);
+                                if ((other_handle = _synctex_new_handle_with_target(nds.r.node))) {
+                                    _synctex_tree_set_sibling(node, other_handle);
+                                    return _synctex_iterator_new(node, 2);
                                 }
-                                return _synctex_iterator_new(node,1);
+                                return _synctex_iterator_new(node, 1);
                             }
                             return NULL;
                         }
                         /*  both nodes have the same input coordinates
                          *  We choose the one closest to the hit point  */
-                        if (nds.l.distance>nds.r.distance) {
+                        if (nds.l.distance > nds.r.distance) {
                             nds.l.node = nds.r.node;
                         }
                         nds.r.node = NULL;
@@ -8028,8 +8167,8 @@ synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,
                     } else if (!nds.l.node) {
                         nds.l.node = node;
                     }
-                    if((node = _synctex_new_handle_with_target(nds.l.node))) {
-                        return _synctex_iterator_new(node,1);
+                    if ((node = _synctex_new_handle_with_target(nds.l.node))) {
+                        return _synctex_iterator_new(node, 1);
                     }
                     return 0;
                 }
@@ -8063,7 +8202,8 @@ synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,
  *  All the results with the same page number are linked by child/parent entry.
  *  - parameter candidate: a friendly list of candidates
  */
-static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, int line, synctex_bool_t exclude_box) {
+static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, int line, synctex_bool_t exclude_box)
+{
     synctex_node_p first_handle = NULL;
     /*  Search the first match */
     if (target == NULL) {
@@ -8071,10 +8211,7 @@ static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, 
     }
     do {
         int page;
-        if ((exclude_box
-             && _synctex_node_is_box(target))
-            || (tag != synctex_node_tag(target))
-            || (line != synctex_node_line(target))) {
+        if ((exclude_box && _synctex_node_is_box(target)) || (tag != synctex_node_tag(target)) || (line != synctex_node_line(target))) {
             continue;
         }
         /*  We found a first match, create
@@ -8091,15 +8228,12 @@ static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, 
         /*  Now create all the other results  */
         while ((target = _synctex_tree_friend(target))) {
             synctex_node_p result = NULL;
-            if ((exclude_box
-                 && _synctex_node_is_box(target))
-                || (tag != synctex_node_tag(target))
-                || (line != synctex_node_line(target))) {
+            if ((exclude_box && _synctex_node_is_box(target)) || (tag != synctex_node_tag(target)) || (line != synctex_node_line(target))) {
                 continue;
             }
             /*  Another match, same page number ? */
             result = _synctex_new_handle_with_target(target);
-            if (NULL == result ) {
+            if (NULL == result) {
                 return first_handle;
             }
             /*  is it the same page number ? */
@@ -8111,10 +8245,7 @@ static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, 
                 __synctex_tree_set_sibling(first_handle, result);
                 while ((target = _synctex_tree_friend(target))) {
                     synctex_node_p same_page_node;
-                    if ((exclude_box
-                         && _synctex_node_is_box(target))
-                        || (tag != synctex_node_tag(target))
-                        || (line != synctex_node_line(target))) {
+                    if ((exclude_box && _synctex_node_is_box(target)) || (tag != synctex_node_tag(target)) || (line != synctex_node_line(target))) {
                         continue;
                     }
                     /*  New match found, which page? */
@@ -8128,12 +8259,12 @@ static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, 
                     do {
                         if (_synctex_node_target_page(same_page_node) == page) {
                             /* Insert result between same_page_node and its child */
-                            _synctex_tree_set_child(result,_synctex_tree_set_child(same_page_node,result));
+                            _synctex_tree_set_child(result, _synctex_tree_set_child(same_page_node, result));
                         } else if ((same_page_node = __synctex_tree_sibling(same_page_node))) {
                             continue;
                         } else {
                             /*  This is a new page number */
-                            __synctex_tree_set_sibling(result,first_handle);
+                            __synctex_tree_set_sibling(result, first_handle);
                             first_handle = result;
                         }
                         break;
@@ -8145,35 +8276,36 @@ static synctex_node_p _synctex_display_query_v2(synctex_node_p target, int tag, 
     } while ((target = _synctex_tree_friend(target)));
     return first_handle;
 }
-synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner,const char * name,int line,int column, int page_hint) {
+synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner, const char *name, int line, int column, int page_hint)
+{
     SYNCTEX_UNUSED(column)
     if (scanner) {
-        int tag = synctex_scanner_get_tag(scanner,name);/* parse if necessary */
+        int tag = synctex_scanner_get_tag(scanner, name); /* parse if necessary */
         int max_line = 0;
         int line_offset = 1;
         int try_count = 100;
         synctex_node_p node = NULL;
         synctex_node_p result = NULL;
         if (tag == 0) {
-            printf("SyncTeX Warning: No tag for %s\n",name);
+            printf("SyncTeX Warning: No tag for %s\n", name);
             return NULL;
         }
         node = synctex_scanner_input_with_tag(scanner, tag);
         max_line = _synctex_data_line(node);
         /*  node = NULL; */
-        if (line>max_line) {
+        if (line > max_line) {
             line = max_line;
         }
-        while(try_count--) {
-            if (line<=max_line) {
+        while (try_count--) {
+            if (line <= max_line) {
                 /*  This loop will only be performed once for advanced viewers */
-                synctex_node_p friend = _synctex_scanner_friend(scanner,tag+line);
+                synctex_node_p friend = _synctex_scanner_friend(scanner, tag + line);
                 if ((node = friend)) {
-                    result = _synctex_display_query_v2(node,tag,line,synctex_YES);
+                    result = _synctex_display_query_v2(node, tag, line, synctex_YES);
                     if (!result) {
                         /*  We did not find any matching boundary, retry including boxes */
-                        node = friend;/*  no need to test it again, already done */
-                        result = _synctex_display_query_v2(node,tag,line,synctex_NO);
+                        node = friend; /*  no need to test it again, already done */
+                        result = _synctex_display_query_v2(node, tag, line, synctex_NO);
                     }
                     /*  Now reverse the order to have nodes in display order, and then keep just a few nodes.
                      *  Order first the best node. */
@@ -8189,56 +8321,58 @@ synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner,const 
                     if (result) {
                         /*  navigate through siblings, then children   */
                         synctex_node_p next_sibling = __synctex_tree_reset_sibling(result);
-                        int best_match = abs(page_hint-_synctex_node_target_page(result));
+                        int best_match = abs(page_hint - _synctex_node_target_page(result));
                         synctex_node_p sibling;
                         int match;
                         _synctex_counted_node_s cn = _synctex_vertically_sorted_v2(result);
                         int count = cn.count;
                         result = cn.node;
-                        while((sibling = next_sibling)) {
+                        while ((sibling = next_sibling)) {
                             /* What is next? Do not miss that step! */
                             next_sibling = __synctex_tree_reset_sibling(sibling);
                             cn = _synctex_vertically_sorted_v2(sibling);
                             count += cn.count;
                             sibling = cn.node;
-                            match = abs(page_hint-_synctex_node_target_page(sibling));
-                            if (match<best_match) {
+                            match = abs(page_hint - _synctex_node_target_page(sibling));
+                            if (match < best_match) {
                                 /*  Order this node first */
-                                __synctex_tree_set_sibling(sibling,result);
+                                __synctex_tree_set_sibling(sibling, result);
                                 result = sibling;
                                 best_match = match;
                             } else /*if (match>=best_match)*/ {
-                                __synctex_tree_set_sibling(sibling,__synctex_tree_sibling(result));
-                                __synctex_tree_set_sibling(result,sibling);
+                                __synctex_tree_set_sibling(sibling, __synctex_tree_sibling(result));
+                                __synctex_tree_set_sibling(result, sibling);
                             }
                         }
-                        return _synctex_iterator_new(result,count);
+                        return _synctex_iterator_new(result, count);
                     }
                 }
-#       if defined(__SYNCTEX_STRONG_DISPLAY_QUERY__)
+#if defined(__SYNCTEX_STRONG_DISPLAY_QUERY__)
                 break;
-#       else
+#else
                 line += line_offset;
-                line_offset=line_offset<0?-(line_offset-1):-(line_offset+1);
+                line_offset = line_offset < 0 ? -(line_offset - 1) : -(line_offset + 1);
                 if (line <= 0) {
                     line += line_offset;
-                    line_offset=line_offset<0?-(line_offset-1):-(line_offset+1);
+                    line_offset = line_offset < 0 ? -(line_offset - 1) : -(line_offset + 1);
                 }
-#       endif
+#endif
             }
         }
     }
     return NULL;
 }
-synctex_status_t synctex_display_query(synctex_scanner_p scanner,const char *  name,int line,int column, int page_hint) {
+synctex_status_t synctex_display_query(synctex_scanner_p scanner, const char *name, int line, int column, int page_hint)
+{
     if (scanner) {
         synctex_iterator_free(scanner->iterator);
-        scanner->iterator = synctex_iterator_new_display(scanner, name,line,column, page_hint);
+        scanner->iterator = synctex_iterator_new_display(scanner, name, line, column, page_hint);
         return synctex_iterator_count(scanner->iterator);
     }
     return SYNCTEX_STATUS_ERROR;
 }
-synctex_status_t synctex_edit_query(synctex_scanner_p scanner,int page,float h,float v) {
+synctex_status_t synctex_edit_query(synctex_scanner_p scanner, int page, float h, float v)
+{
     if (scanner) {
         synctex_iterator_free(scanner->iterator);
         scanner->iterator = synctex_iterator_new_edit(scanner, page, h, v);
@@ -8249,21 +8383,24 @@ synctex_status_t synctex_edit_query(synctex_scanner_p scanner,int page,float h,f
 /**
  *  The next result of a query.
  */
-synctex_node_p synctex_scanner_next_result(synctex_scanner_p scanner) {
-    return scanner? synctex_iterator_next_result(scanner->iterator): NULL;
+synctex_node_p synctex_scanner_next_result(synctex_scanner_p scanner)
+{
+    return scanner ? synctex_iterator_next_result(scanner->iterator) : NULL;
 }
-synctex_status_t synctex_scanner_reset_result(synctex_scanner_p scanner) {
-    return scanner? synctex_iterator_reset(scanner->iterator): SYNCTEX_STATUS_ERROR;
+synctex_status_t synctex_scanner_reset_result(synctex_scanner_p scanner)
+{
+    return scanner ? synctex_iterator_reset(scanner->iterator) : SYNCTEX_STATUS_ERROR;
 }
 
-synctex_node_p synctex_node_target(synctex_node_p node) {
+synctex_node_p synctex_node_target(synctex_node_p node)
+{
     return _synctex_tree_target(node);
 }
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Geometric utilities
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Geometric utilities
+#endif
 
 /** Rougly speaking, this is:
  *  node's h coordinate - hit point's h coordinate.
@@ -8272,153 +8409,12 @@ synctex_node_p synctex_node_target(synctex_node_p node) {
  *  If the argument is a pdf form reference, then the child is used and returned instead.
  *  Last Revision: Mon Apr 24 07:05:27 UTC 2017
  */
-static _synctex_nd_s _synctex_point_h_ordered_distance_v2
-(synctex_point_p hit, synctex_node_p node) {
-    _synctex_nd_s nd = {node,INT_MAX};
-    if (node) {
-        int min,med,max,width;
-        switch(synctex_node_type(node)) {
-                /*  The distance between a point and a box is special.
-                 *  It is not the euclidian distance, nor something similar.
-                 *  We have to take into account the particular layout,
-                 *  and the box hierarchy.
-                 *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
-                 *  The origin being at the top left corner of the page,
-                 *  we also give names to the vertices of the box.
-                 *
-                 *   1 | 2 | 3
-                 *  ---A---B--->
-                 *   4 | 5 | 6
-                 *  ---C---D--->
-                 *   7 | 8 | 9
-                 *     v   v
-                 */
-            case synctex_node_type_vbox:
-            case synctex_node_type_void_vbox:
-            case synctex_node_type_void_hbox:
-                /*  getting the box bounds, taking into account negative width, height and depth. */
-                width = _synctex_data_width(node);
-                min = _synctex_data_h(node);
-                max = min + (width>0?width:-width);
-                /*  We always have min <= max */
-                if (hit->h<min) {
-                    nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
-                } else if (hit->h>max) {
-                    nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
-                } else {
-                    nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
-                }
-                break;
-            case synctex_node_type_proxy_vbox:
-                /*  getting the box bounds, taking into account negative width, height and depth. */
-                width = synctex_node_width(node);
-                min = synctex_node_h(node);
-                max = min + (width>0?width:-width);
-                /*  We always have min <= max */
-                if (hit->h<min) {
-                    nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
-                } else if (hit->h>max) {
-                    nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
-                } else {
-                    nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
-                }
-                break;
-            case synctex_node_type_hbox:
-            case synctex_node_type_proxy_hbox:
-                /*  getting the box bounds, taking into account negative width, height and depth. */
-                width = synctex_node_hbox_width(node);
-                min = synctex_node_hbox_h(node);
-                max = min + (width>0?width:-width);
-                /*  We always have min <= max */
-                if (hit->h<min) {
-                    nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
-                } else if (hit->h>max) {
-                    nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
-                } else {
-                    nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
-                }
-                break;
-            case synctex_node_type_kern:
-                /*  IMPORTANT NOTICE: the location of the kern is recorded AFTER the move.
-                 *  The distance to the kern is very special,
-                 *  in general, there is no text material in the kern,
-                 *  this is why we compute the offset relative to the closest edge of the kern.*/
-                max = _synctex_data_width(node);
-                if (max<0) {
-                    min = _synctex_data_h(node);
-                    max = min - max;
-                } else {
-                    min = -max;
-                    max = _synctex_data_h(node);
-                    min += max;
-                }
-                med = (min+max)/2;
-                /*  positive kern: '.' means text, '>' means kern offset
-                 *      .............
-                 *                   min>>>>med>>>>max
-                 *                                    ...............
-                 *  negative kern: '.' means text, '<' means kern offset
-                 *      ............................
-                 *                 min<<<<med<<<<max
-                 *                 .................................
-                 *  Actually, we do not take into account negative widths.
-                 *  There is a problem for such situation when there is effectively overlapping text.
-                 *  But this should be extremely rare. I guess that in that case, many different choices
-                 *  could be made, one being in contradiction with the other.
-                 *  It means that the best choice should be made according to the situation that occurs
-                 *  most frequently.
-                 */
-                if (hit->h<min) {
-                    nd.distance = min - hit->h + 1; /*  penalty to ensure other nodes are chosen first in case of overlapping ones */
-                } else if (hit->h>max) {
-                    nd.distance = max - hit->h - 1; /*  same kind of penalty */
-                } else if (hit->h>med) {
-                    /*  do things like if the node had 0 width and was placed at the max edge + 1*/
-                    nd.distance = max - hit->h + 1; /*  positive, the kern is to the right of the hit point */
-                } else {
-                    nd.distance = min - hit->h - 1; /*  negative, the kern is to the left of the hit point */
-                }
-                break;
-            case synctex_node_type_rule:/* to do: special management */
-            case synctex_node_type_glue:
-            case synctex_node_type_math:
-            case synctex_node_type_boundary:
-            case synctex_node_type_box_bdry:
-                nd.distance = _synctex_data_h(node) - hit->h;
-                break;
-            case synctex_node_type_ref:
-                nd.node = synctex_node_child(node);
-                nd = _synctex_point_h_ordered_distance_v2(hit,nd.node);
-                break;
-            case synctex_node_type_proxy:
-            case synctex_node_type_proxy_last:
-            {
-                /* shift the hit point to be relative to the proxy origin,
-                 *  then compute the distance to the target
-                 */
-                synctex_point_s otherHit = *hit;
-                otherHit.h -= _synctex_data_h(node);
-                otherHit.v -= _synctex_data_v(node);
-                nd.node = _synctex_tree_target(node);
-                nd = _synctex_point_h_ordered_distance_v2(&otherHit,nd.node);
-                nd.node = node;
-            }
-            default:
-                break;
-        }
-    }
-    return nd;
-}
-/** Rougly speaking, this is:
- *  node's v coordinate - hit point's v coordinate.
- *  If node is at the top of the hit point, then this distance is positive,
- *  if node is at the bottom of the hit point, this distance is negative.
- */
-static _synctex_nd_s _synctex_point_v_ordered_distance_v2
-(synctex_point_p hit, synctex_node_p node) {
+static _synctex_nd_s _synctex_point_h_ordered_distance_v2(synctex_point_p hit, synctex_node_p node)
+{
     _synctex_nd_s nd = {node, INT_MAX};
-    int min,max,depth,height;
-    switch(synctex_node_type(node)) {
+    if (node) {
+        int min, med, max, width;
+        switch (synctex_node_type(node)) {
             /*  The distance between a point and a box is special.
              *  It is not the euclidian distance, nor something similar.
              *  We have to take into account the particular layout,
@@ -8438,80 +8434,220 @@ static _synctex_nd_s _synctex_point_v_ordered_distance_v2
         case synctex_node_type_void_vbox:
         case synctex_node_type_void_hbox:
             /*  getting the box bounds, taking into account negative width, height and depth. */
-            min = synctex_node_v(node);
-            max = min + _synctex_abs(_synctex_data_depth(node));
-            min -= _synctex_abs(_synctex_data_height(node));
+            width = _synctex_data_width(node);
+            min = _synctex_data_h(node);
+            max = min + (width > 0 ? width : -width);
             /*  We always have min <= max */
-            if (hit->v<min) {
-                nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
-            } else if (hit->v>max) {
-                nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+            if (hit->h < min) {
+                nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
+            } else if (hit->h > max) {
+                nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
             } else {
-                nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+                nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
             }
             break;
         case synctex_node_type_proxy_vbox:
             /*  getting the box bounds, taking into account negative width, height and depth. */
-            min = synctex_node_v(node);
-            max = min + _synctex_abs(synctex_node_depth(node));
-            min -= _synctex_abs(synctex_node_height(node));
+            width = synctex_node_width(node);
+            min = synctex_node_h(node);
+            max = min + (width > 0 ? width : -width);
             /*  We always have min <= max */
-            if (hit->v<min) {
-                nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
-            } else if (hit->v>max) {
-                nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+            if (hit->h < min) {
+                nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
+            } else if (hit->h > max) {
+                nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
             } else {
-                nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+                nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
             }
             break;
         case synctex_node_type_hbox:
         case synctex_node_type_proxy_hbox:
-            /*  getting the box bounds, taking into account negative height and depth. */
-            min = synctex_node_hbox_v(node);
-            depth = synctex_node_hbox_depth(node);
-            max = min + (depth>0?depth:-depth);
-            height = synctex_node_hbox_height(node);
-            min -= (height>0?height:-height);
+            /*  getting the box bounds, taking into account negative width, height and depth. */
+            width = synctex_node_hbox_width(node);
+            min = synctex_node_hbox_h(node);
+            max = min + (width > 0 ? width : -width);
             /*  We always have min <= max */
-            if (hit->v<min) {
-                nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
-            } else if (hit->v>max) {
-                nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+            if (hit->h < min) {
+                nd.distance = min - hit->h; /*  regions 1+4+7, result is > 0 */
+            } else if (hit->h > max) {
+                nd.distance = max - hit->h; /*  regions 3+6+9, result is < 0 */
             } else {
-                nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+                nd.distance = 0; /*  regions 2+5+8, inside the box, except for vertical coordinates */
             }
             break;
-        case synctex_node_type_rule:/* to do: special management */
         case synctex_node_type_kern:
+            /*  IMPORTANT NOTICE: the location of the kern is recorded AFTER the move.
+             *  The distance to the kern is very special,
+             *  in general, there is no text material in the kern,
+             *  this is why we compute the offset relative to the closest edge of the kern.*/
+            max = _synctex_data_width(node);
+            if (max < 0) {
+                min = _synctex_data_h(node);
+                max = min - max;
+            } else {
+                min = -max;
+                max = _synctex_data_h(node);
+                min += max;
+            }
+            med = (min + max) / 2;
+            /*  positive kern: '.' means text, '>' means kern offset
+             *      .............
+             *                   min>>>>med>>>>max
+             *                                    ...............
+             *  negative kern: '.' means text, '<' means kern offset
+             *      ............................
+             *                 min<<<<med<<<<max
+             *                 .................................
+             *  Actually, we do not take into account negative widths.
+             *  There is a problem for such situation when there is effectively overlapping text.
+             *  But this should be extremely rare. I guess that in that case, many different choices
+             *  could be made, one being in contradiction with the other.
+             *  It means that the best choice should be made according to the situation that occurs
+             *  most frequently.
+             */
+            if (hit->h < min) {
+                nd.distance = min - hit->h + 1; /*  penalty to ensure other nodes are chosen first in case of overlapping ones */
+            } else if (hit->h > max) {
+                nd.distance = max - hit->h - 1; /*  same kind of penalty */
+            } else if (hit->h > med) {
+                /*  do things like if the node had 0 width and was placed at the max edge + 1*/
+                nd.distance = max - hit->h + 1; /*  positive, the kern is to the right of the hit point */
+            } else {
+                nd.distance = min - hit->h - 1; /*  negative, the kern is to the left of the hit point */
+            }
+            break;
+        case synctex_node_type_rule: /* to do: special management */
         case synctex_node_type_glue:
         case synctex_node_type_math:
-            min = _synctex_data_v(node);
-            max = min + _synctex_abs(_synctex_data_depth(_synctex_tree_parent(node)));
-            min -= _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
-            /*  We always have min <= max */
-            if (hit->v<min) {
-                nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
-            } else if (hit->v>max) {
-                nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
-            } else {
-                nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
-            }
+        case synctex_node_type_boundary:
+        case synctex_node_type_box_bdry:
+            nd.distance = _synctex_data_h(node) - hit->h;
             break;
         case synctex_node_type_ref:
             nd.node = synctex_node_child(node);
-            nd = _synctex_point_v_ordered_distance_v2(hit,nd.node);
+            nd = _synctex_point_h_ordered_distance_v2(hit, nd.node);
             break;
         case synctex_node_type_proxy:
-        case synctex_node_type_proxy_last:
-        {
+        case synctex_node_type_proxy_last: {
+            /* shift the hit point to be relative to the proxy origin,
+             *  then compute the distance to the target
+             */
             synctex_point_s otherHit = *hit;
             otherHit.h -= _synctex_data_h(node);
             otherHit.v -= _synctex_data_v(node);
             nd.node = _synctex_tree_target(node);
-            nd = _synctex_point_v_ordered_distance_v2(&otherHit,nd.node);
+            nd = _synctex_point_h_ordered_distance_v2(&otherHit, nd.node);
             nd.node = node;
         }
-        default: break;
+        default:
+            break;
+        }
+    }
+    return nd;
+}
+/** Rougly speaking, this is:
+ *  node's v coordinate - hit point's v coordinate.
+ *  If node is at the top of the hit point, then this distance is positive,
+ *  if node is at the bottom of the hit point, this distance is negative.
+ */
+static _synctex_nd_s _synctex_point_v_ordered_distance_v2(synctex_point_p hit, synctex_node_p node)
+{
+    _synctex_nd_s nd = {node, INT_MAX};
+    int min, max, depth, height;
+    switch (synctex_node_type(node)) {
+        /*  The distance between a point and a box is special.
+         *  It is not the euclidian distance, nor something similar.
+         *  We have to take into account the particular layout,
+         *  and the box hierarchy.
+         *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
+         *  The origin being at the top left corner of the page,
+         *  we also give names to the vertices of the box.
+         *
+         *   1 | 2 | 3
+         *  ---A---B--->
+         *   4 | 5 | 6
+         *  ---C---D--->
+         *   7 | 8 | 9
+         *     v   v
+         */
+    case synctex_node_type_vbox:
+    case synctex_node_type_void_vbox:
+    case synctex_node_type_void_hbox:
+        /*  getting the box bounds, taking into account negative width, height and depth. */
+        min = synctex_node_v(node);
+        max = min + _synctex_abs(_synctex_data_depth(node));
+        min -= _synctex_abs(_synctex_data_height(node));
+        /*  We always have min <= max */
+        if (hit->v < min) {
+            nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
+        } else if (hit->v > max) {
+            nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+        } else {
+            nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+        }
+        break;
+    case synctex_node_type_proxy_vbox:
+        /*  getting the box bounds, taking into account negative width, height and depth. */
+        min = synctex_node_v(node);
+        max = min + _synctex_abs(synctex_node_depth(node));
+        min -= _synctex_abs(synctex_node_height(node));
+        /*  We always have min <= max */
+        if (hit->v < min) {
+            nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
+        } else if (hit->v > max) {
+            nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+        } else {
+            nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+        }
+        break;
+    case synctex_node_type_hbox:
+    case synctex_node_type_proxy_hbox:
+        /*  getting the box bounds, taking into account negative height and depth. */
+        min = synctex_node_hbox_v(node);
+        depth = synctex_node_hbox_depth(node);
+        max = min + (depth > 0 ? depth : -depth);
+        height = synctex_node_hbox_height(node);
+        min -= (height > 0 ? height : -height);
+        /*  We always have min <= max */
+        if (hit->v < min) {
+            nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
+        } else if (hit->v > max) {
+            nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+        } else {
+            nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+        }
+        break;
+    case synctex_node_type_rule: /* to do: special management */
+    case synctex_node_type_kern:
+    case synctex_node_type_glue:
+    case synctex_node_type_math:
+        min = _synctex_data_v(node);
+        max = min + _synctex_abs(_synctex_data_depth(_synctex_tree_parent(node)));
+        min -= _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
+        /*  We always have min <= max */
+        if (hit->v < min) {
+            nd.distance = min - hit->v; /*  regions 1+2+3, result is > 0 */
+        } else if (hit->v > max) {
+            nd.distance = max - hit->v; /*  regions 7+8+9, result is < 0 */
+        } else {
+            nd.distance = 0; /*  regions 4.5.6, inside the box, except for horizontal coordinates */
+        }
+        break;
+    case synctex_node_type_ref:
+        nd.node = synctex_node_child(node);
+        nd = _synctex_point_v_ordered_distance_v2(hit, nd.node);
+        break;
+    case synctex_node_type_proxy:
+    case synctex_node_type_proxy_last: {
+        synctex_point_s otherHit = *hit;
+        otherHit.h -= _synctex_data_h(node);
+        otherHit.v -= _synctex_data_v(node);
+        nd.node = _synctex_tree_target(node);
+        nd = _synctex_point_v_ordered_distance_v2(&otherHit, nd.node);
+        nd.node = node;
+    }
+    default:
+        break;
     }
     return nd;
 }
@@ -8520,53 +8656,55 @@ static _synctex_nd_s _synctex_point_v_ordered_distance_v2
  *  The area is width*height where width and height may be big.
  *  So there is a real risk of overflow if we stick with ints.
  */
-SYNCTEX_INLINE static synctex_node_p _synctex_smallest_container_v2(synctex_node_p node, synctex_node_p other_node) {
+SYNCTEX_INLINE static synctex_node_p _synctex_smallest_container_v2(synctex_node_p node, synctex_node_p other_node)
+{
     long total_height, other_total_height;
     unsigned long area, other_area;
     long width = synctex_node_hbox_width(node);
     long other_width = synctex_node_hbox_width(other_node);
-    if (width<0) {
+    if (width < 0) {
         width = -width;
     }
-    if (other_width<0) {
+    if (other_width < 0) {
         other_width = -other_width;
     }
     total_height = _synctex_abs(synctex_node_hbox_depth(node)) + _synctex_abs(synctex_node_hbox_height(node));
     other_total_height = _synctex_abs(synctex_node_hbox_depth(other_node)) + _synctex_abs(synctex_node_hbox_height(other_node));
-    area = total_height*width;
-    other_area = other_total_height*other_width;
-    if (area<other_area) {
+    area = total_height * width;
+    other_area = other_total_height * other_width;
+    if (area < other_area) {
         return node;
     }
-    if (area>other_area) {
+    if (area > other_area) {
         return other_node;
     }
-    if (_synctex_abs(_synctex_data_width(node))>_synctex_abs(_synctex_data_width(other_node))) {
+    if (_synctex_abs(_synctex_data_width(node)) > _synctex_abs(_synctex_data_width(other_node))) {
         return node;
     }
-    if (_synctex_abs(_synctex_data_width(node))<_synctex_abs(_synctex_data_width(other_node))) {
+    if (_synctex_abs(_synctex_data_width(node)) < _synctex_abs(_synctex_data_width(other_node))) {
         return other_node;
     }
-    if (total_height<other_total_height) {
+    if (total_height < other_total_height) {
         return node;
     }
-    if (total_height>other_total_height) {
+    if (total_height > other_total_height) {
         return other_node;
     }
     return node;
 }
 
-SYNCTEX_INLINE static synctex_bool_t _synctex_point_in_box_v2(synctex_point_p hit, synctex_node_p node) {
+SYNCTEX_INLINE static synctex_bool_t _synctex_point_in_box_v2(synctex_point_p hit, synctex_node_p node)
+{
     if (node) {
-        if (0 == _synctex_point_h_ordered_distance_v2(hit,node).distance
-            && 0 == _synctex_point_v_ordered_distance_v2(hit,node).distance) {
+        if (0 == _synctex_point_h_ordered_distance_v2(hit, node).distance && 0 == _synctex_point_v_ordered_distance_v2(hit, node).distance) {
             return synctex_YES;
         }
     }
     return synctex_NO;
 }
 
-static int _synctex_distance_to_box_v2(synctex_point_p hit,synctex_box_p box) {
+static int _synctex_distance_to_box_v2(synctex_point_p hit, synctex_box_p box)
+{
     /*  The distance between a point and a box is special.
      *  It is not the euclidian distance, nor something similar.
      *  We have to take into account the particular layout,
@@ -8583,24 +8721,24 @@ static int _synctex_distance_to_box_v2(synctex_point_p hit,synctex_box_p box) {
      *     v   v
      *  In each region, there is a different formula.
      *  In the end we have a continuous distance which may not be a mathematical distance but who cares. */
-    if (hit->v<box->min.v) {
+    if (hit->v < box->min.v) {
         /*  Regions 1, 2 or 3 */
-        if (hit->h<box->min.h) {
+        if (hit->h < box->min.h) {
             /*  This is region 1. The distance to the box is the L1 distance PA. */
-            return box->min.v - hit->v + box->min.h - hit->h;/*  Integer overflow? probability epsilon */
-        } else if (hit->h<=box->max.h) {
+            return box->min.v - hit->v + box->min.h - hit->h; /*  Integer overflow? probability epsilon */
+        } else if (hit->h <= box->max.h) {
             /*  This is region 2. The distance to the box is the geometrical distance to the top edge.  */
             return box->min.v - hit->v;
         } else {
             /*  This is region 3. The distance to the box is the L1 distance PB. */
             return box->min.v - hit->v + hit->h - box->max.h;
         }
-    } else if (hit->v<=box->max.v) {
+    } else if (hit->v <= box->max.v) {
         /*  Regions 4, 5 or 6 */
-        if (hit->h<box->min.h) {
+        if (hit->h < box->min.h) {
             /*  This is region 4. The distance to the box is the geometrical distance to the left edge.  */
             return box->min.h - hit->h;
-        } else if (hit->h<=box->max.h) {
+        } else if (hit->h <= box->max.h) {
             /*  This is region 5. We are inside the box.  */
             return 0;
         } else {
@@ -8609,10 +8747,10 @@ static int _synctex_distance_to_box_v2(synctex_point_p hit,synctex_box_p box) {
         }
     } else {
         /*  Regions 7, 8 or 9 */
-        if (hit->h<box->min.h) {
+        if (hit->h < box->min.h) {
             /*  This is region 7. The distance to the box is the L1 distance PC. */
             return hit->v - box->max.v + box->min.h - hit->h;
-        } else if (hit->h<=box->max.h) {
+        } else if (hit->h <= box->max.h) {
             /*  This is region 8. The distance to the box is the geometrical distance to the top edge.  */
             return hit->v - box->max.v;
         } else {
@@ -8625,80 +8763,82 @@ static int _synctex_distance_to_box_v2(synctex_point_p hit,synctex_box_p box) {
 /**
  *  The distance from the hit point to the node.
  */
-static int _synctex_point_node_distance_v2(synctex_point_p hit, synctex_node_p node) {
+static int _synctex_point_node_distance_v2(synctex_point_p hit, synctex_node_p node)
+{
     int d = INT_MAX;
     if (node) {
-        synctex_box_s box = {{0,0},{0,0}};
+        synctex_box_s box = {{0, 0}, {0, 0}};
         int dd = INT_MAX;
-        switch(synctex_node_type(node)) {
-            case synctex_node_type_vbox:
-                box.min.h = _synctex_data_h(node);
-                box.max.h = box.min.h + _synctex_abs(_synctex_data_width(node));
-                box.min.v = synctex_node_v(node);
-                box.max.v = box.min.v + _synctex_abs(_synctex_data_depth(node));
-                box.min.v -= _synctex_abs(_synctex_data_height(node));
-                return _synctex_distance_to_box_v2(hit,&box);
-            case synctex_node_type_proxy_vbox:
-                box.min.h = synctex_node_h(node);
-                box.max.h = box.min.h + _synctex_abs(synctex_node_width(node));
-                box.min.v = synctex_node_v(node);
-                box.max.v = box.min.v + _synctex_abs(synctex_node_depth(node));
-                box.min.v -= _synctex_abs(synctex_node_height(node));
-                return _synctex_distance_to_box_v2(hit,&box);
-            case synctex_node_type_hbox:
-            case synctex_node_type_proxy_hbox:
-                box.min.h = synctex_node_hbox_h(node);
-                box.max.h = box.min.h + _synctex_abs(synctex_node_hbox_width(node));
-                box.min.v = synctex_node_hbox_v(node);
-                box.max.v = box.min.v + _synctex_abs(synctex_node_hbox_depth(node));
-                box.min.v -= _synctex_abs(synctex_node_hbox_height(node));
-                return _synctex_distance_to_box_v2(hit,&box);
-            case synctex_node_type_void_vbox:
-            case synctex_node_type_void_hbox:
-                /*  best of distances from the left edge and right edge*/
-                box.min.h = _synctex_data_h(node);
-                box.max.h = box.min.h;
-                box.min.v = _synctex_data_v(node);
-                box.max.v = box.min.v + _synctex_abs(_synctex_data_depth(node));
-                box.min.v -= _synctex_abs(_synctex_data_height(node));
-                d = _synctex_distance_to_box_v2(hit,&box);
-                box.min.h = box.min.h + _synctex_abs(_synctex_data_width(node));
-                box.max.h = box.min.h;
-                dd = _synctex_distance_to_box_v2(hit,&box);
-                return d<dd ? d:dd;
-            case synctex_node_type_kern:
-                box.min.h = _synctex_data_h(node);
-                box.max.h = box.min.h;
-                box.max.v = _synctex_data_v(node);
-                box.min.v = box.max.v - _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
-                d = _synctex_distance_to_box_v2(hit,&box);
-                box.min.h -= _synctex_data_width(node);
-                box.max.h = box.min.h;
-                dd = _synctex_distance_to_box_v2(hit,&box);
-                return d<dd ? d:dd;
-            case synctex_node_type_glue:
-            case synctex_node_type_math:
-            case synctex_node_type_boundary:
-            case synctex_node_type_box_bdry:
-                box.min.h = _synctex_data_h(node);
-                box.max.h = box.min.h;
-                box.max.v = _synctex_data_v(node);
-                box.min.v = box.max.v - _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
-                return _synctex_distance_to_box_v2(hit,&box);
-            case synctex_node_type_proxy:
-            case synctex_node_type_proxy_last:
-            {
-                synctex_point_s otherHit = *hit;
-                otherHit.h -= _synctex_data_h(node);
-                otherHit.v -= _synctex_data_v(node);
-                return _synctex_point_node_distance_v2(&otherHit, _synctex_tree_target(node));
-            }
-            default: break;
+        switch (synctex_node_type(node)) {
+        case synctex_node_type_vbox:
+            box.min.h = _synctex_data_h(node);
+            box.max.h = box.min.h + _synctex_abs(_synctex_data_width(node));
+            box.min.v = synctex_node_v(node);
+            box.max.v = box.min.v + _synctex_abs(_synctex_data_depth(node));
+            box.min.v -= _synctex_abs(_synctex_data_height(node));
+            return _synctex_distance_to_box_v2(hit, &box);
+        case synctex_node_type_proxy_vbox:
+            box.min.h = synctex_node_h(node);
+            box.max.h = box.min.h + _synctex_abs(synctex_node_width(node));
+            box.min.v = synctex_node_v(node);
+            box.max.v = box.min.v + _synctex_abs(synctex_node_depth(node));
+            box.min.v -= _synctex_abs(synctex_node_height(node));
+            return _synctex_distance_to_box_v2(hit, &box);
+        case synctex_node_type_hbox:
+        case synctex_node_type_proxy_hbox:
+            box.min.h = synctex_node_hbox_h(node);
+            box.max.h = box.min.h + _synctex_abs(synctex_node_hbox_width(node));
+            box.min.v = synctex_node_hbox_v(node);
+            box.max.v = box.min.v + _synctex_abs(synctex_node_hbox_depth(node));
+            box.min.v -= _synctex_abs(synctex_node_hbox_height(node));
+            return _synctex_distance_to_box_v2(hit, &box);
+        case synctex_node_type_void_vbox:
+        case synctex_node_type_void_hbox:
+            /*  best of distances from the left edge and right edge*/
+            box.min.h = _synctex_data_h(node);
+            box.max.h = box.min.h;
+            box.min.v = _synctex_data_v(node);
+            box.max.v = box.min.v + _synctex_abs(_synctex_data_depth(node));
+            box.min.v -= _synctex_abs(_synctex_data_height(node));
+            d = _synctex_distance_to_box_v2(hit, &box);
+            box.min.h = box.min.h + _synctex_abs(_synctex_data_width(node));
+            box.max.h = box.min.h;
+            dd = _synctex_distance_to_box_v2(hit, &box);
+            return d < dd ? d : dd;
+        case synctex_node_type_kern:
+            box.min.h = _synctex_data_h(node);
+            box.max.h = box.min.h;
+            box.max.v = _synctex_data_v(node);
+            box.min.v = box.max.v - _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
+            d = _synctex_distance_to_box_v2(hit, &box);
+            box.min.h -= _synctex_data_width(node);
+            box.max.h = box.min.h;
+            dd = _synctex_distance_to_box_v2(hit, &box);
+            return d < dd ? d : dd;
+        case synctex_node_type_glue:
+        case synctex_node_type_math:
+        case synctex_node_type_boundary:
+        case synctex_node_type_box_bdry:
+            box.min.h = _synctex_data_h(node);
+            box.max.h = box.min.h;
+            box.max.v = _synctex_data_v(node);
+            box.min.v = box.max.v - _synctex_abs(_synctex_data_height(_synctex_tree_parent(node)));
+            return _synctex_distance_to_box_v2(hit, &box);
+        case synctex_node_type_proxy:
+        case synctex_node_type_proxy_last: {
+            synctex_point_s otherHit = *hit;
+            otherHit.h -= _synctex_data_h(node);
+            otherHit.v -= _synctex_data_v(node);
+            return _synctex_point_node_distance_v2(&otherHit, _synctex_tree_target(node));
+        }
+        default:
+            break;
         }
     }
     return d;
 }
-static synctex_node_p _synctex_eq_deepest_container_v2(synctex_point_p hit, synctex_node_p node) {
+static synctex_node_p _synctex_eq_deepest_container_v2(synctex_point_p hit, synctex_node_p node)
+{
     if (node) {
         /**/
         synctex_node_p child;
@@ -8708,17 +8848,16 @@ static synctex_node_p _synctex_eq_deepest_container_v2(synctex_point_p hit, sync
              *  despite they do contain some black material.
              */
             do {
-                if ((_synctex_point_in_box_v2(hit,child))) {
-                    synctex_node_p deep = _synctex_eq_deepest_container_v2(hit,child);
+                if ((_synctex_point_in_box_v2(hit, child))) {
+                    synctex_node_p deep = _synctex_eq_deepest_container_v2(hit, child);
                     if (deep) {
                         /*  One of the children contains the hit. */
                         return deep;
                     }
                 }
-            } while((child = synctex_node_sibling(child)));
+            } while ((child = synctex_node_sibling(child)));
             /*  is the hit point inside the box? */
-            if (synctex_node_type(node) == synctex_node_type_vbox
-                || synctex_node_type(node) == synctex_node_type_proxy_vbox) {
+            if (synctex_node_type(node) == synctex_node_type_vbox || synctex_node_type(node) == synctex_node_type_proxy_vbox) {
                 /*  For vboxes we try to use some node inside.
                  *  Walk through the list of siblings until we find the closest one.
                  *  Only consider siblings with children inside. */
@@ -8726,25 +8865,26 @@ static synctex_node_p _synctex_eq_deepest_container_v2(synctex_point_p hit, sync
                     _synctex_nd_s best = SYNCTEX_ND_0;
                     do {
                         if (_synctex_tree_child(child)) {
-                            int d = _synctex_point_node_distance_v2(hit,child);
+                            int d = _synctex_point_node_distance_v2(hit, child);
                             if (d <= best.distance) {
                                 best = (_synctex_nd_s){child, d};
                             }
                         }
-                    } while((child = __synctex_tree_sibling(child)));
+                    } while ((child = __synctex_tree_sibling(child)));
                     if (best.node) {
                         return best.node;
                     }
                 }
             }
-            if (_synctex_point_in_box_v2(hit,node)) {
+            if (_synctex_point_in_box_v2(hit, node)) {
                 return node;
             }
         }
     }
     return NULL;
 }
-static _synctex_nd_s _synctex_eq_deepest_container_v3(synctex_point_p hit, synctex_node_p node) {
+static _synctex_nd_s _synctex_eq_deepest_container_v3(synctex_point_p hit, synctex_node_p node)
+{
     if (node) {
         synctex_node_p child = NULL;
         if ((child = synctex_node_child(node))) {
@@ -8758,29 +8898,28 @@ static _synctex_nd_s _synctex_eq_deepest_container_v3(synctex_point_p hit, synct
                     /*  One of the children contains the hit-> */
                     return deep;
                 }
-            } while((child = synctex_node_sibling(child)));
+            } while ((child = synctex_node_sibling(child)));
             /*  For vboxes we try to use some node inside.
              *  Walk through the list of siblings until we find the closest one.
              *  Only consider siblings with children inside. */
-            if (synctex_node_type(node) == synctex_node_type_vbox
-                || synctex_node_type(node) == synctex_node_type_proxy_vbox) {
+            if (synctex_node_type(node) == synctex_node_type_vbox || synctex_node_type(node) == synctex_node_type_proxy_vbox) {
                 if ((child = synctex_node_child(node))) {
                     _synctex_nd_s best = SYNCTEX_ND_0;
                     do {
                         if (synctex_node_child(child)) {
-                            int d = _synctex_point_node_distance_v2(hit,child);
+                            int d = _synctex_point_node_distance_v2(hit, child);
                             if (d < best.distance) {
-                                best = (_synctex_nd_s){child,d};
+                                best = (_synctex_nd_s){child, d};
                             }
                         }
-                    } while((child = synctex_node_sibling(child)));
+                    } while ((child = synctex_node_sibling(child)));
                     if (best.node) {
                         return best;
                     }
                 }
             }
             /*  is the hit point inside the box? */
-            if (_synctex_point_in_box_v2(hit,node)) {
+            if (_synctex_point_in_box_v2(hit, node)) {
                 return (_synctex_nd_s){node, 0};
             }
         }
@@ -8792,13 +8931,14 @@ static _synctex_nd_s _synctex_eq_deepest_container_v3(synctex_point_p hit, synct
  *  the various nodes contained in the box.
  *  As it is an horizontal box, we only compare horizontal coordinates.
  */
-SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_hbox_v2(synctex_point_p hitP, synctex_node_p node) {
+SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_hbox_v2(synctex_point_p hitP, synctex_node_p node)
+{
     _synctex_nd_s childd = SYNCTEX_ND_0;
-    _synctex_nd_lr_s nds = {SYNCTEX_ND_0,SYNCTEX_ND_0};
+    _synctex_nd_lr_s nds = {SYNCTEX_ND_0, SYNCTEX_ND_0};
     if ((childd.node = synctex_node_child(node))) {
         _synctex_nd_s nd = SYNCTEX_ND_0;
         do {
-            childd = _synctex_point_h_ordered_distance_v2(hitP,childd.node);
+            childd = _synctex_point_h_ordered_distance_v2(hitP, childd.node);
             if (childd.distance > 0) {
                 /*  node is to the right of the hit point.
                  *  We compare node and the previously recorded one, through the recorded distance.
@@ -8811,8 +8951,8 @@ SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_hbox
                         && (_synctex_data_line(nds.r.node) > _synctex_data_line(childd.node)
                             || (_synctex_data_line(nds.r.node) == _synctex_data_line(childd.node)
                                 && _synctex_data_column(nds.r.node) > _synctex_data_column(childd.node)))) {
-                                nds.r = childd;
-                            }
+                        nds.r = childd;
+                    }
                 }
             } else if (childd.distance == 0) {
                 /*  hit point is inside node. */
@@ -8829,26 +8969,26 @@ SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_hbox
                         && (_synctex_data_line(nds.l.node) > _synctex_data_line(childd.node)
                             || (_synctex_data_line(nds.l.node) == _synctex_data_line(childd.node)
                                 && _synctex_data_column(nds.l.node) > _synctex_data_column(childd.node)))) {
-                                nds.l = childd;
-                            }
+                        nds.l = childd;
+                    }
                 }
             }
-        } while((childd.node = synctex_node_sibling(childd.node)));
+        } while ((childd.node = synctex_node_sibling(childd.node)));
         if (nds.l.node) {
             /*  the left node is new, try to narrow the result */
-            if ((nd = _synctex_eq_deepest_container_v3(hitP,nds.l.node)).node) {
+            if ((nd = _synctex_eq_deepest_container_v3(hitP, nds.l.node)).node) {
                 nds.l = nd;
             }
-            if((nd = __synctex_closest_deep_child_v2(hitP,nds.l.node)).node) {
+            if ((nd = __synctex_closest_deep_child_v2(hitP, nds.l.node)).node) {
                 nds.l.node = nd.node;
             }
         }
         if (nds.r.node) {
             /*  the right node is new, try to narrow the result */
-            if ((nd = _synctex_eq_deepest_container_v3(hitP,nds.r.node)).node) {
+            if ((nd = _synctex_eq_deepest_container_v3(hitP, nds.r.node)).node) {
                 nds.r = nd;
             }
-            if((nd = __synctex_closest_deep_child_v2(hitP,nds.r.node)).node) {
+            if ((nd = __synctex_closest_deep_child_v2(hitP, nds.r.node)).node) {
                 nds.r.node = nd.node;
             }
         }
@@ -8917,13 +9057,14 @@ SYNCTEX_INLINE static synctex_nd_lr_s __synctex_eq_get_closest_children_in_hbox_
     return nds;
 }
 #endif
-SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_vbox_v2(synctex_point_p hitP, synctex_node_p nodeP) {
+SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_vbox_v2(synctex_point_p hitP, synctex_node_p nodeP)
+{
     SYNCTEX_UNUSED(nodeP)
-    _synctex_nd_lr_s nds = {SYNCTEX_ND_0,SYNCTEX_ND_0};
+    _synctex_nd_lr_s nds = {SYNCTEX_ND_0, SYNCTEX_ND_0};
     _synctex_nd_s nd = SYNCTEX_ND_0;
     if ((nd.node = synctex_node_child(nd.node))) {
         do {
-            nd = _synctex_point_v_ordered_distance_v2(hitP,nd.node);
+            nd = _synctex_point_v_ordered_distance_v2(hitP, nd.node);
             /*  this is what makes the difference with the h version above */
             if (nd.distance > 0) {
                 /*  node is to the top of the hit point (below because TeX is oriented from top to bottom.
@@ -8937,8 +9078,8 @@ SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_vbox
                         && (_synctex_data_line(nds.r.node) > _synctex_data_line(nd.node)
                             || (_synctex_data_line(nds.r.node) == _synctex_data_line(nd.node)
                                 && _synctex_data_column(nds.r.node) > _synctex_data_column(nd.node)))) {
-                                nds.r = nd;
-                            }
+                        nds.r = nd;
+                    }
                 }
             } else if (nd.distance == 0) {
                 nds.l = nd;
@@ -8951,24 +9092,24 @@ SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_vbox
                         && (_synctex_data_line(nds.l.node) > _synctex_data_line(nd.node)
                             || (_synctex_data_line(nds.l.node) == _synctex_data_line(nd.node)
                                 && _synctex_data_column(nds.l.node) > _synctex_data_column(nd.node)))) {
-                                nds.l = nd;
-                            }
+                        nds.l = nd;
+                    }
                 }
             }
-        } while((nd.node = synctex_node_sibling(nd.node)));
+        } while ((nd.node = synctex_node_sibling(nd.node)));
         if (nds.l.node) {
-            if ((nd.node = _synctex_eq_deepest_container_v2(hitP,nds.l.node))) {
+            if ((nd.node = _synctex_eq_deepest_container_v2(hitP, nds.l.node))) {
                 nds.l.node = nd.node;
             }
-            if((nd = _synctex_eq_closest_child_v2(hitP,nds.l.node)).node) {
+            if ((nd = _synctex_eq_closest_child_v2(hitP, nds.l.node)).node) {
                 nds.l.node = nd.node;
             }
         }
         if (nds.r.node) {
-            if ((nd.node = _synctex_eq_deepest_container_v2(hitP,nds.r.node))) {
+            if ((nd.node = _synctex_eq_deepest_container_v2(hitP, nds.r.node))) {
                 nds.r.node = nd.node;
             }
-            if((nd = _synctex_eq_closest_child_v2(hitP,nds.r.node)).node) {
+            if ((nd = _synctex_eq_closest_child_v2(hitP, nds.r.node)).node) {
                 nds.r.node = nd.node;
             }
         }
@@ -8984,13 +9125,13 @@ SYNCTEX_INLINE static _synctex_nd_lr_s __synctex_eq_get_closest_children_in_vbox
  *      SYNCTEX_ND_0 if the parameter node has no children.
  *  - note: recursive call.
  */
-static _synctex_nd_s __synctex_closest_deep_child_v2(synctex_point_p hitP, synctex_node_p node) {
+static _synctex_nd_s __synctex_closest_deep_child_v2(synctex_point_p hitP, synctex_node_p node)
+{
     _synctex_nd_s best = SYNCTEX_ND_0;
     synctex_node_p child = NULL;
     if ((child = synctex_node_child(node))) {
 #if defined(SYNCTEX_DEBUG)
-        printf("Closest deep child on box at line %i\n",
-               SYNCTEX_LINEINDEX(node));
+        printf("Closest deep child on box at line %i\n", SYNCTEX_LINEINDEX(node));
 #endif
         do {
 #if SYNCTEX_DEBUG > 500
@@ -8998,24 +9139,22 @@ static _synctex_nd_s __synctex_closest_deep_child_v2(synctex_point_p hitP, synct
 #endif
             _synctex_nd_s nd = SYNCTEX_ND_0;
             if (_synctex_node_is_box(child)) {
-                nd = __synctex_closest_deep_child_v2(hitP,child);
+                nd = __synctex_closest_deep_child_v2(hitP, child);
             } else {
-                nd = (_synctex_nd_s) {child, _synctex_point_node_distance_v2(hitP,child)};
+                nd = (_synctex_nd_s){child, _synctex_point_node_distance_v2(hitP, child)};
             }
-            if (nd.distance < best.distance ||(nd.distance == best.distance
-                                               && synctex_node_type(nd.node) != synctex_node_type_kern)) {
+            if (nd.distance < best.distance || (nd.distance == best.distance && synctex_node_type(nd.node) != synctex_node_type_kern)) {
 #if defined(SYNCTEX_DEBUG)
-                if(nd.node) {
-                    printf("New best %i<=%i line %i\n",nd.distance,
-                           best.distance,SYNCTEX_LINEINDEX(nd.node));
+                if (nd.node) {
+                    printf("New best %i<=%i line %i\n", nd.distance, best.distance, SYNCTEX_LINEINDEX(nd.node));
                 }
 #endif
                 best = nd;
             }
-        } while((child = synctex_node_sibling(child)));
+        } while ((child = synctex_node_sibling(child)));
 #if defined(SYNCTEX_DEBUG)
-        if(best.node) {
-            printf("Found new best %i line %i\n",best.distance,SYNCTEX_LINEINDEX(best.node));
+        if (best.node) {
+            printf("Found new best %i line %i\n", best.distance, SYNCTEX_LINEINDEX(best.node));
         }
 #endif
     }
@@ -9029,18 +9168,19 @@ static _synctex_nd_s __synctex_closest_deep_child_v2(synctex_point_p hitP, synct
  *  - return: SYNCTEX_ND_0 if node has no child,
  *      the __synctex_closest_deep_child_v2 otherwise.
  */
-static _synctex_nd_s _synctex_eq_closest_child_v2(synctex_point_p hitP, synctex_node_p node) {
+static _synctex_nd_s _synctex_eq_closest_child_v2(synctex_point_p hitP, synctex_node_p node)
+{
     _synctex_nd_s nd = SYNCTEX_ND_0;
     if (_synctex_node_is_box(node)) {
         nd = __synctex_closest_deep_child_v2(hitP, node);
         if (_synctex_node_is_box(nd.node)) {
             synctex_node_p child = NULL;
             if ((child = synctex_node_child(nd.node))) {
-                _synctex_nd_s best = {child,_synctex_point_node_distance_v2(hitP,child)};
-                while((child = synctex_node_sibling(child))) {
-                    int d = _synctex_point_node_distance_v2(hitP,child);
+                _synctex_nd_s best = {child, _synctex_point_node_distance_v2(hitP, child)};
+                while ((child = synctex_node_sibling(child))) {
+                    int d = _synctex_point_node_distance_v2(hitP, child);
                     if (d < best.distance) {
-                        best = (_synctex_nd_s){child,d};
+                        best = (_synctex_nd_s){child, d};
                     } else if (d == best.distance && synctex_node_type(child) != synctex_node_type_kern) {
                         best.node = child;
                     }
@@ -9052,14 +9192,14 @@ static _synctex_nd_s _synctex_eq_closest_child_v2(synctex_point_p hitP, synctex_
     }
     return SYNCTEX_ND_0;
 }
-SYNCTEX_INLINE static _synctex_nd_lr_s _synctex_eq_get_closest_children_in_box_v2(synctex_point_p hitP, synctex_node_p node) {
-    _synctex_nd_lr_s nds = {SYNCTEX_ND_0,SYNCTEX_ND_0};
-    if(_synctex_tree_has_child(node)) { /* node != NULL */
-        if (node->class_->type==synctex_node_type_hbox ||
-            node->class_->type==synctex_node_type_proxy_hbox) {
-            return __synctex_eq_get_closest_children_in_hbox_v2(hitP,node);
+SYNCTEX_INLINE static _synctex_nd_lr_s _synctex_eq_get_closest_children_in_box_v2(synctex_point_p hitP, synctex_node_p node)
+{
+    _synctex_nd_lr_s nds = {SYNCTEX_ND_0, SYNCTEX_ND_0};
+    if (_synctex_tree_has_child(node)) { /* node != NULL */
+        if (node->class_->type == synctex_node_type_hbox || node->class_->type == synctex_node_type_proxy_hbox) {
+            return __synctex_eq_get_closest_children_in_hbox_v2(hitP, node);
         } else {
-            return __synctex_eq_get_closest_children_in_vbox_v2(hitP,node);
+            return __synctex_eq_get_closest_children_in_vbox_v2(hitP, node);
         }
     }
     return nds;
@@ -9067,20 +9207,20 @@ SYNCTEX_INLINE static _synctex_nd_lr_s _synctex_eq_get_closest_children_in_box_v
 
 #ifndef SYNCTEX_NO_UPDATER
 
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Updater
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Updater
+#endif
 
-typedef int (*_synctex_print_f)(synctex_updater_p, const char * , ...); /*  print formatted to either FILE *  or gzFile */
+typedef int (*_synctex_print_f)(synctex_updater_p, const char *, ...); /*  print formatted to either FILE *  or gzFile */
 typedef void (*_synctex_close_f)(synctex_updater_p); /*  close FILE *  or gzFile */
 
-#   define SYNCTEX_BITS_PER_BYTE 8
+#define SYNCTEX_BITS_PER_BYTE 8
 
 typedef union {
     gzFile as_gzFile;
-    FILE * as_FILE_p;
-    void * as_ptr;
+    FILE *as_FILE_p;
+    void *as_ptr;
 } _synctex_file_u;
 
 /**
@@ -9099,33 +9239,32 @@ struct _synctex_updater_t {
 };
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(2, 3)
-static int _synctex_updater_print(synctex_updater_p updater, const char * format, ...) {
+static int _synctex_updater_print(synctex_updater_p updater, const char *format, ...)
+{
     int result = 0;
     if (updater) {
         va_list va;
         va_start(va, format);
-        result = vfprintf(updater->file.as_FILE_p,
-                           format,
-                           va);
+        result = vfprintf(updater->file.as_FILE_p, format, va);
         va_end(va);
     }
     return result;
 }
 #if defined(_MSC_VER)
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 
-static int vasprintf(char **ret,
-                     const char *format,
-                     va_list ap)
+static int vasprintf(char **ret, const char *format, va_list ap)
 {
     int len;
     len = _vsnprintf(NULL, 0, format, ap);
-    if (len < 0) return -1;
+    if (len < 0)
+        return -1;
     *ret = malloc(len + 1);
-    if (!*ret) return -1;
-    _vsnprintf(*ret, len+1, format, ap);
+    if (!*ret)
+        return -1;
+    _vsnprintf(*ret, len + 1, format, ap);
     (*ret)[len] = '\0';
     return len;
 }
@@ -9136,10 +9275,11 @@ static int vasprintf(char **ret,
  *  gzvprintf is not available until OSX 10.10
  */
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(2, 3)
-static int _synctex_updater_print_gz(synctex_updater_p updater, const char * format, ...) {
+static int _synctex_updater_print_gz(synctex_updater_p updater, const char *format, ...)
+{
     int result = 0;
     if (updater) {
-        char * buffer;
+        char *buffer;
         va_list va;
         va_start(va, format);
         if (vasprintf(&buffer, format, va) < 0) {
@@ -9153,21 +9293,24 @@ static int _synctex_updater_print_gz(synctex_updater_p updater, const char * for
     return result;
 }
 
-static void _synctex_updater_close(synctex_updater_p updater) {
+static void _synctex_updater_close(synctex_updater_p updater)
+{
     if (updater) {
         fclose(updater->file.as_FILE_p);
     }
 }
 
-static void _synctex_updater_close_gz(synctex_updater_p updater) {
+static void _synctex_updater_close_gz(synctex_updater_p updater)
+{
     if (updater) {
         gzclose(updater->file.as_gzFile);
     }
 }
 
-synctex_updater_p synctex_updater_new_with_output_file(const char * output, const char * build_directory) {
+synctex_updater_p synctex_updater_new_with_output_file(const char *output, const char *build_directory)
+{
     synctex_updater_p updater = NULL;
-    const char * mode = NULL;
+    const char *mode = NULL;
     _synctex_open_s open;
     /*  prepare the updater, the memory is the only one dynamically allocated */
     updater = (synctex_updater_p)_synctex_malloc(sizeof(_synctex_updater_s));
@@ -9175,9 +9318,9 @@ synctex_updater_p synctex_updater_new_with_output_file(const char * output, cons
         _synctex_error("!  synctex_updater_new_with_file: malloc problem");
         return NULL;
     }
-    open = _synctex_open_v2(output,build_directory,0,synctex_ADD_QUOTES);
+    open = _synctex_open_v2(output, build_directory, 0, synctex_ADD_QUOTES);
     if (open.status < SYNCTEX_STATUS_OK) {
-        open = _synctex_open_v2(output,build_directory,0,synctex_DONT_ADD_QUOTES);
+        open = _synctex_open_v2(output, build_directory, 0, synctex_DONT_ADD_QUOTES);
         if (open.status < SYNCTEX_STATUS_OK) {
         return_on_error:
             _synctex_free(updater);
@@ -9188,62 +9331,65 @@ synctex_updater_p synctex_updater_new_with_output_file(const char * output, cons
      *  The receiver is now the owner of the "synctex" variable. */
     gzclose(open.file);
     updater->file.as_ptr = NULL;
-    mode = _synctex_get_io_mode_name(open.io_mode|synctex_io_append_mask);/* either "a" or "ab", depending on the file extension */
-    if (open.io_mode&synctex_io_gz_mask) {
-        if (NULL == (updater->file.as_FILE_p = fopen(open.synctex,mode))) {
+    mode = _synctex_get_io_mode_name(open.io_mode | synctex_io_append_mask); /* either "a" or "ab", depending on the file extension */
+    if (open.io_mode & synctex_io_gz_mask) {
+        if (NULL == (updater->file.as_FILE_p = fopen(open.synctex, mode))) {
         no_write_error:
-            _synctex_error("!  synctex_updater_new_with_file: Can't append to %s",open.synctex);
+            _synctex_error("!  synctex_updater_new_with_file: Can't append to %s", open.synctex);
             free(open.synctex);
             goto return_on_error;
         }
         updater->print = &_synctex_updater_print;
         updater->close = &_synctex_updater_close;
     } else {
-        if (NULL == (updater->file.as_gzFile = gzopen(open.synctex,mode))) {
+        if (NULL == (updater->file.as_gzFile = gzopen(open.synctex, mode))) {
             goto no_write_error;
         }
         updater->print = &_synctex_updater_print_gz;
         updater->close = &_synctex_updater_close_gz;
     }
-    printf("SyncTeX: updating %s...",open.synctex);
+    printf("SyncTeX: updating %s...", open.synctex);
     _synctex_free(open.synctex);
     return updater;
 }
 
-void synctex_updater_append_magnification(synctex_updater_p updater, char * magnification){
-    if (NULL==updater) {
+void synctex_updater_append_magnification(synctex_updater_p updater, char *magnification)
+{
+    if (NULL == updater) {
         return;
     }
     if (magnification && strlen(magnification)) {
-        updater->length +=
-        updater->print(updater,"Magnification:%s\n",magnification);
+        updater->length += updater->print(updater, "Magnification:%s\n", magnification);
     }
 }
 
-void synctex_updater_append_x_offset(synctex_updater_p updater, char * x_offset){
-    if (NULL==updater) {
+void synctex_updater_append_x_offset(synctex_updater_p updater, char *x_offset)
+{
+    if (NULL == updater) {
         return;
     }
     if (x_offset && strlen(x_offset)) {
-        updater->length += updater->print(updater,"X Offset:%s\n",x_offset);
+        updater->length += updater->print(updater, "X Offset:%s\n", x_offset);
     }
 }
 
-void synctex_updater_append_y_offset(synctex_updater_p updater, char * y_offset){
-    if (NULL==updater) {
+void synctex_updater_append_y_offset(synctex_updater_p updater, char *y_offset)
+{
+    if (NULL == updater) {
         return;
     }
     if (y_offset && strlen(y_offset)) {
-        updater->length += updater->print(updater,"Y Offset:%s\n",y_offset);
+        updater->length += updater->print(updater, "Y Offset:%s\n", y_offset);
     }
 }
 
-void synctex_updater_free(synctex_updater_p updater){
-    if (NULL==updater) {
+void synctex_updater_free(synctex_updater_p updater)
+{
+    if (NULL == updater) {
         return;
     }
-    if (updater->length>0) {
-        updater->print(updater,"!%i\n",updater->length);
+    if (updater->length > 0) {
+        updater->print(updater, "!%i\n", updater->length);
     }
     updater->close(updater);
     _synctex_free(updater);
@@ -9253,10 +9399,10 @@ void synctex_updater_free(synctex_updater_p updater){
 #endif
 
 #if defined(SYNCTEX_TESTING)
-#	ifdef SYNCTEX_NOTHING
-#       pragma mark -
-#       pragma mark Testers
-#   endif
+#ifdef SYNCTEX_NOTHING
+#pragma mark -
+#pragma mark Testers
+#endif
 /**
  *  The next nodes corresponds to a deep first tree traversal.
  *  Does not create child proxies as side effect contrary to
@@ -9264,216 +9410,225 @@ void synctex_updater_free(synctex_updater_p updater){
  *  May loop infinitely many times if the tree
  *  is not properly built (contains loops).
  */
-static synctex_node_p _synctex_node_next(synctex_node_p node) {
+static synctex_node_p _synctex_node_next(synctex_node_p node)
+{
     synctex_node_p N = _synctex_tree_child(node);
     if (N) {
         return N;
     }
     return _synctex_node_sibling_or_parents(node);
 }
-static int _synctex_input_copy_name(synctex_node_p input, char * name) {
-    char * copy = _synctex_malloc(strlen(name)+1);
-    memcpy(copy,name,strlen(name)+1);
-    _synctex_data_set_name(input,copy);
+static int _synctex_input_copy_name(synctex_node_p input, char *name)
+{
+    char *copy = _synctex_malloc(strlen(name) + 1);
+    memcpy(copy, name, strlen(name) + 1);
+    _synctex_data_set_name(input, copy);
     return 0;
 }
-int synctex_test_setup_scanner_sheets_421(synctex_scanner_p scanner) {
+int synctex_test_setup_scanner_sheets_421(synctex_scanner_p scanner)
+{
     int TC = 0;
-    synctex_node_p sheet = synctex_node_new(scanner,synctex_node_type_sheet);
-    _synctex_data_set_page(sheet,4);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet)==4,"");
+    synctex_node_p sheet = synctex_node_new(scanner, synctex_node_type_sheet);
+    _synctex_data_set_page(sheet, 4);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet) == 4, "");
     _synctex_node_free(scanner->sheet);
     scanner->sheet = sheet;
-    sheet = synctex_node_new(scanner,synctex_node_type_sheet);
-    _synctex_data_set_page(sheet,2);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet)==2,"");
+    sheet = synctex_node_new(scanner, synctex_node_type_sheet);
+    _synctex_data_set_page(sheet, 2);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet) == 2, "");
     __synctex_tree_set_sibling(sheet, scanner->sheet);
     scanner->sheet = sheet;
-    sheet = synctex_node_new(scanner,synctex_node_type_sheet);
-    _synctex_data_set_page(sheet,1);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet)==1,"");
+    sheet = synctex_node_new(scanner, synctex_node_type_sheet);
+    _synctex_data_set_page(sheet, 1);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_page(sheet) == 1, "");
     __synctex_tree_set_sibling(sheet, scanner->sheet);
     scanner->sheet = sheet;
     return TC;
 }
-int synctex_test_input(synctex_scanner_p scanner) {
+int synctex_test_input(synctex_scanner_p scanner)
+{
     int TC = 0;
-    synctex_node_p input = synctex_node_new(scanner,synctex_node_type_input);
-    _synctex_data_set_tag(input,421);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input)==421,"");
-    _synctex_data_set_tag(input,124);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input)==124,"");
-    _synctex_data_set_line(input,421);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input)==421,"");
-    _synctex_data_set_line(input,214);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input)==214,"");
-    _synctex_data_set_line(input,214);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input)==214,"");
-    _synctex_input_copy_name(input,"214");
-    SYNCTEX_TEST_BODY(TC, 0==memcmp(_synctex_data_name(input),"214",4),"");
-    _synctex_input_copy_name(input,"421421");
+    synctex_node_p input = synctex_node_new(scanner, synctex_node_type_input);
+    _synctex_data_set_tag(input, 421);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input) == 421, "");
+    _synctex_data_set_tag(input, 124);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input) == 124, "");
+    _synctex_data_set_line(input, 421);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input) == 421, "");
+    _synctex_data_set_line(input, 214);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input) == 214, "");
+    _synctex_data_set_line(input, 214);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input) == 214, "");
+    _synctex_input_copy_name(input, "214");
+    SYNCTEX_TEST_BODY(TC, 0 == memcmp(_synctex_data_name(input), "214", 4), "");
+    _synctex_input_copy_name(input, "421421");
 
-    SYNCTEX_TEST_BODY(TC,
-                      0==memcmp(_synctex_data_name(input),
-                                "421421",
-                                4),
-                      "");
+    SYNCTEX_TEST_BODY(TC, 0 == memcmp(_synctex_data_name(input), "421421", 4), "");
     _synctex_node_free(input);
     return TC;
 }
-int synctex_test_proxy(synctex_scanner_p scanner) {
+int synctex_test_proxy(synctex_scanner_p scanner)
+{
     int TC = 0;
-    synctex_node_p proxy = synctex_node_new(scanner,synctex_node_type_proxy);
-    synctex_node_p target = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_tree_set_target(proxy,target);
-    _synctex_data_set_tag(target,421);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target)==421,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target)==421,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(proxy)==421,"");
+    synctex_node_p proxy = synctex_node_new(scanner, synctex_node_type_proxy);
+    synctex_node_p target = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_tree_set_target(proxy, target);
+    _synctex_data_set_tag(target, 421);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target) == 421, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target) == 421, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(proxy) == 421, "");
     _synctex_node_free(proxy);
     _synctex_node_free(target);
     return TC;
 }
-int synctex_test_handle(synctex_scanner_p scanner) {
+int synctex_test_handle(synctex_scanner_p scanner)
+{
     int TC = 0;
-    synctex_node_p handle = synctex_node_new(scanner,synctex_node_type_handle);
+    synctex_node_p handle = synctex_node_new(scanner, synctex_node_type_handle);
     synctex_node_p proxy = synctex_node_new(scanner, synctex_node_type_proxy);
-    synctex_node_p target = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_tree_set_target(handle,target);
-    _synctex_data_set_tag(target,421);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target)==421,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target)==421,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(handle)==421,"");
-    _synctex_data_set_line(target,214);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(target)==214,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_line(target)==214,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_line(handle)==214,"");
-    _synctex_data_set_column(target,142);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_column(target)==142,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_column(target)==142,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_column(handle)==142,"");
-    _synctex_tree_set_target(proxy,target);
-    _synctex_tree_set_target(handle,proxy);
-    _synctex_data_set_tag(target,412);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target)==412,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target)==412,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_tag(handle)==412,"");
-    _synctex_data_set_line(target,124);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(target)==124,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_line(target)==124,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_line(handle)==124,"");
-    _synctex_data_set_column(target,241);
-    SYNCTEX_TEST_BODY(TC, _synctex_data_column(target)==241,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_column(target)==241,"");
-    SYNCTEX_TEST_BODY(TC, synctex_node_column(handle)==241,"");
+    synctex_node_p target = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_tree_set_target(handle, target);
+    _synctex_data_set_tag(target, 421);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target) == 421, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target) == 421, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(handle) == 421, "");
+    _synctex_data_set_line(target, 214);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(target) == 214, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_line(target) == 214, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_line(handle) == 214, "");
+    _synctex_data_set_column(target, 142);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_column(target) == 142, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_column(target) == 142, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_column(handle) == 142, "");
+    _synctex_tree_set_target(proxy, target);
+    _synctex_tree_set_target(handle, proxy);
+    _synctex_data_set_tag(target, 412);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(target) == 412, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(target) == 412, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_tag(handle) == 412, "");
+    _synctex_data_set_line(target, 124);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(target) == 124, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_line(target) == 124, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_line(handle) == 124, "");
+    _synctex_data_set_column(target, 241);
+    SYNCTEX_TEST_BODY(TC, _synctex_data_column(target) == 241, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_column(target) == 241, "");
+    SYNCTEX_TEST_BODY(TC, synctex_node_column(handle) == 241, "");
     _synctex_node_free(handle);
     _synctex_node_free(proxy);
     _synctex_node_free(target);
     return TC;
 }
-int synctex_test_setup_scanner_input(synctex_scanner_p scanner) {
+int synctex_test_setup_scanner_input(synctex_scanner_p scanner)
+{
     int TC = 0;
-    synctex_node_p input = synctex_node_new(scanner,synctex_node_type_input);
-    _synctex_data_set_tag(input,4);
-    _synctex_input_copy_name(input,"21");
-    _synctex_data_set_line(input,421);
+    synctex_node_p input = synctex_node_new(scanner, synctex_node_type_input);
+    _synctex_data_set_tag(input, 4);
+    _synctex_input_copy_name(input, "21");
+    _synctex_data_set_line(input, 421);
     _synctex_node_free(scanner->input);
     scanner->input = input;
-    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input)==4,"");
-    SYNCTEX_TEST_BODY(TC, strcmp(_synctex_data_name(input),"21")==0,"");
-    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input)==421,"");
+    SYNCTEX_TEST_BODY(TC, _synctex_data_tag(input) == 4, "");
+    SYNCTEX_TEST_BODY(TC, strcmp(_synctex_data_name(input), "21") == 0, "");
+    SYNCTEX_TEST_BODY(TC, _synctex_data_line(input) == 421, "");
     return TC;
 }
-int synctex_test_setup_nodes(synctex_scanner_p scanner, synctex_node_r nodes) {
+int synctex_test_setup_nodes(synctex_scanner_p scanner, synctex_node_r nodes)
+{
     int TC = 0;
     int n;
-    for (n=0;n<synctex_node_number_of_types;++n) {
-        nodes[n] = synctex_node_new(scanner,n);
-        SYNCTEX_TEST_BODY(TC, nodes[n]!=NULL,"");
+    for (n = 0; n < synctex_node_number_of_types; ++n) {
+        nodes[n] = synctex_node_new(scanner, n);
+        SYNCTEX_TEST_BODY(TC, nodes[n] != NULL, "");
     }
     return TC;
 }
-int synctex_test_teardown_nodes(synctex_scanner_p scanner, synctex_node_r nodes) {
+int synctex_test_teardown_nodes(synctex_scanner_p scanner, synctex_node_r nodes)
+{
     int n;
-    for (n=0;n<synctex_node_number_of_types;++n) {
+    for (n = 0; n < synctex_node_number_of_types; ++n) {
         _synctex_node_free(nodes[n]);
-        nodes[n]=NULL;
+        nodes[n] = NULL;
     }
     return 1;
 }
-int synctex_test_tree(synctex_scanner_p scanner) {
+int synctex_test_tree(synctex_scanner_p scanner)
+{
     int TC = 0;
     synctex_node_p nodes1[synctex_node_number_of_types];
     synctex_node_p nodes2[synctex_node_number_of_types];
     synctex_node_p nodes3[synctex_node_number_of_types];
-    int i,j;
-    TC += synctex_test_setup_nodes(scanner,nodes1);
-    TC += synctex_test_setup_nodes(scanner,nodes2);
-    TC += synctex_test_setup_nodes(scanner,nodes3);
+    int i, j;
+    TC += synctex_test_setup_nodes(scanner, nodes1);
+    TC += synctex_test_setup_nodes(scanner, nodes2);
+    TC += synctex_test_setup_nodes(scanner, nodes3);
     /*  Every node has a sibling */
-    for (i=0;i<synctex_node_number_of_types;++i) {
-        for (j=0;j<synctex_node_number_of_types;++j) {
-            _synctex_tree_set_sibling(nodes1[i],nodes2[i]);
-            SYNCTEX_TEST_BODY(TC, nodes2[i]==synctex_node_sibling(nodes1[i]),"");
+    for (i = 0; i < synctex_node_number_of_types; ++i) {
+        for (j = 0; j < synctex_node_number_of_types; ++j) {
+            _synctex_tree_set_sibling(nodes1[i], nodes2[i]);
+            SYNCTEX_TEST_BODY(TC, nodes2[i] == synctex_node_sibling(nodes1[i]), "");
         }
     }
-    synctex_test_teardown_nodes(scanner,nodes3);
-    synctex_test_teardown_nodes(scanner,nodes2);
-    synctex_test_teardown_nodes(scanner,nodes1);
+    synctex_test_teardown_nodes(scanner, nodes3);
+    synctex_test_teardown_nodes(scanner, nodes2);
+    synctex_test_teardown_nodes(scanner, nodes1);
     return TC;
 }
-int synctex_test_page(synctex_scanner_p scanner) {
+int synctex_test_page(synctex_scanner_p scanner)
+{
     int TC = synctex_test_setup_scanner_sheets_421(scanner);
     synctex_node_p sheet = scanner->sheet;
-    synctex_node_p node = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_data_set_tag(node,4);
-    _synctex_data_set_line(node,21);
-    _synctex_node_free(_synctex_node_set_child(sheet,node));
-    SYNCTEX_TEST_BODY(TC, synctex_node_page(node)==synctex_node_page(sheet),"");
+    synctex_node_p node = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_data_set_tag(node, 4);
+    _synctex_data_set_line(node, 21);
+    _synctex_node_free(_synctex_node_set_child(sheet, node));
+    SYNCTEX_TEST_BODY(TC, synctex_node_page(node) == synctex_node_page(sheet), "");
     return TC;
 }
-int synctex_test_display_query(synctex_scanner_p scanner) {
+int synctex_test_display_query(synctex_scanner_p scanner)
+{
     int TC = synctex_test_setup_scanner_sheets_421(scanner);
     synctex_node_p sheet = scanner->sheet;
-    synctex_node_p node = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_data_set_tag(node,4);
-    _synctex_data_set_line(node,21);
-    _synctex_node_free(_synctex_node_set_child(sheet,node));
-    SYNCTEX_TEST_BODY(TC, node==synctex_node_child(sheet),"");
+    synctex_node_p node = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_data_set_tag(node, 4);
+    _synctex_data_set_line(node, 21);
+    _synctex_node_free(_synctex_node_set_child(sheet, node));
+    SYNCTEX_TEST_BODY(TC, node == synctex_node_child(sheet), "");
     __synctex_node_make_friend_tlc(node);
-    SYNCTEX_TEST_BODY(TC, _synctex_scanner_friend(scanner, 25)==node,"");
+    SYNCTEX_TEST_BODY(TC, _synctex_scanner_friend(scanner, 25) == node, "");
     sheet = __synctex_tree_sibling(sheet);
-    node = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_data_set_tag(node,4);
-    _synctex_data_set_line(node,21);
-    _synctex_node_free(_synctex_node_set_child(sheet,node));
-    SYNCTEX_TEST_BODY(TC, node==synctex_node_child(sheet),"");
+    node = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_data_set_tag(node, 4);
+    _synctex_data_set_line(node, 21);
+    _synctex_node_free(_synctex_node_set_child(sheet, node));
+    SYNCTEX_TEST_BODY(TC, node == synctex_node_child(sheet), "");
     __synctex_node_make_friend_tlc(node);
-    SYNCTEX_TEST_BODY(TC, _synctex_scanner_friend(scanner, 25)==node,"");
+    SYNCTEX_TEST_BODY(TC, _synctex_scanner_friend(scanner, 25) == node, "");
     sheet = __synctex_tree_sibling(sheet);
-    node = synctex_node_new(scanner,synctex_node_type_rule);
-    _synctex_data_set_tag(node,4);
-    _synctex_data_set_line(node,21);
-    _synctex_node_free(_synctex_node_set_child(sheet,node));
-    SYNCTEX_TEST_BODY(TC, node==synctex_node_child(sheet),"");
+    node = synctex_node_new(scanner, synctex_node_type_rule);
+    _synctex_data_set_tag(node, 4);
+    _synctex_data_set_line(node, 21);
+    _synctex_node_free(_synctex_node_set_child(sheet, node));
+    SYNCTEX_TEST_BODY(TC, node == synctex_node_child(sheet), "");
     __synctex_node_make_friend_tlc(node);
-    SYNCTEX_TEST_BODY(TC, (_synctex_scanner_friend(scanner, 25)==node),"");
+    SYNCTEX_TEST_BODY(TC, (_synctex_scanner_friend(scanner, 25) == node), "");
     synctex_test_setup_scanner_input(scanner);
     scanner->flags.has_parsed = synctex_YES;
 #if 1
-    SYNCTEX_TEST_BODY(TC, (synctex_display_query(scanner,"21",21,4,-1)==3),"");
+    SYNCTEX_TEST_BODY(TC, (synctex_display_query(scanner, "21", 21, 4, -1) == 3), "");
 #endif
     return TC;
 }
 typedef struct {
-    int s;      /* status */
+    int s; /* status */
     char n[25]; /* name */
 } synctex_test_sn_s;
 
-synctex_test_sn_s synctex_test_tmp_sn(char * content) {
+synctex_test_sn_s synctex_test_tmp_sn(char *content)
+{
     synctex_test_sn_s sn = {0, "/tmp/test.XXXXXX.synctex"};
     FILE *sfp;
-    int fd = mkstemps(sn.n,8);
+    int fd = mkstemps(sn.n, 8);
     if (fd < 0) {
         fprintf(stderr, "%s: %s\n", sn.n, strerror(errno));
         sn.s = -1;
@@ -9486,38 +9641,39 @@ synctex_test_sn_s synctex_test_tmp_sn(char * content) {
         sn.s = -2;
         return sn;
     }
-    sn.s = fputs(content,sfp);
-    printf("temp:%s\n%i\n",sn.n,sn.s);
+    sn.s = fputs(content, sfp);
+    printf("temp:%s\n%i\n", sn.n, sn.s);
     fclose(sfp);
-    if (sn.s==0) {
+    if (sn.s == 0) {
         sn.s = -2;
         unlink(sn.n);
     }
     return sn;
 }
-int synctex_test_sheet_1() {
+int synctex_test_sheet_1()
+{
     int TC = 0;
-    char * content =
-    "SyncTeX Version:1  \n" /*00-19*/
-    "Input:1:./1.tex    \n" /*20-39*/
-    "Output:pdf         \n" /*40-59*/
-    "Magnification:100000000      \n" /*60-89*/
-    "Unit:1   \n"           /*90-99*/
-    "X Offset:0         \n" /*00-19*/
-    "Y Offset:0         \n" /*20-39*/
-    "Content: \n"           /*40-49*/
-    "{1       \n"           /*50-59*/
-    "[1,10:20,350:330,330,0       \n" /*60-89*/
-    "]        \n"           /*90-99*/
-    "}        \n"           /*00-09*/
-    "Postamble:\n";
+    char *content =
+        "SyncTeX Version:1  \n" /*00-19*/
+        "Input:1:./1.tex    \n" /*20-39*/
+        "Output:pdf         \n" /*40-59*/
+        "Magnification:100000000      \n" /*60-89*/
+        "Unit:1   \n" /*90-99*/
+        "X Offset:0         \n" /*00-19*/
+        "Y Offset:0         \n" /*20-39*/
+        "Content: \n" /*40-49*/
+        "{1       \n" /*50-59*/
+        "[1,10:20,350:330,330,0       \n" /*60-89*/
+        "]        \n" /*90-99*/
+        "}        \n" /*00-09*/
+        "Postamble:\n";
     synctex_test_sn_s sn = synctex_test_tmp_sn(content);
-    if (sn.s>0) {
+    if (sn.s > 0) {
         synctex_scanner_p scanner = synctex_scanner_new_with_output_file(sn.n, NULL, synctex_YES);
         synctex_node_p node = synctex_scanner_handle(scanner);
         printf("Created nodes:\n");
         while (node) {
-            printf("%s\n",_synctex_node_abstract(node));
+            printf("%s\n", _synctex_node_abstract(node));
             node = synctex_node_next(node);
         }
         synctex_scanner_free(scanner);
@@ -9527,29 +9683,30 @@ int synctex_test_sheet_1() {
     }
     return TC;
 }
-int synctex_test_sheet_2() {
+int synctex_test_sheet_2()
+{
     int TC = 0;
-    char * content =
-    "SyncTeX Version:1  \n" /*00-19*/
-    "Input:1:./1.tex    \n" /*20-39*/
-    "Output:pdf         \n" /*40-59*/
-    "Magnification:100000000      \n" /*60-89*/
-    "Unit:1   \n"           /*90-99*/
-    "X Offset:0         \n" /*00-19*/
-    "Y Offset:0         \n" /*20-39*/
-    "Content: \n"           /*40-49*/
-    "{1       \n"           /*50-59*/
-    "(1,10:20,350:330,330,0       \n" /*60-89*/
-    ")        \n"           /*90-99*/
-    "}        \n"           /*00-09*/
-    "Postamble:\n";
+    char *content =
+        "SyncTeX Version:1  \n" /*00-19*/
+        "Input:1:./1.tex    \n" /*20-39*/
+        "Output:pdf         \n" /*40-59*/
+        "Magnification:100000000      \n" /*60-89*/
+        "Unit:1   \n" /*90-99*/
+        "X Offset:0         \n" /*00-19*/
+        "Y Offset:0         \n" /*20-39*/
+        "Content: \n" /*40-49*/
+        "{1       \n" /*50-59*/
+        "(1,10:20,350:330,330,0       \n" /*60-89*/
+        ")        \n" /*90-99*/
+        "}        \n" /*00-09*/
+        "Postamble:\n";
     synctex_test_sn_s sn = synctex_test_tmp_sn(content);
-    if (sn.s>0) {
+    if (sn.s > 0) {
         synctex_scanner_p scanner = synctex_scanner_new_with_output_file(sn.n, NULL, synctex_YES);
         synctex_node_p node = synctex_scanner_handle(scanner);
         printf("Created nodes:\n");
         while (node) {
-            printf("%s\n",_synctex_node_abstract(node));
+            printf("%s\n", _synctex_node_abstract(node));
             node = _synctex_node_next(node);
         }
         TC += synctex_scanner_free(scanner);
@@ -9559,32 +9716,33 @@ int synctex_test_sheet_2() {
     }
     return TC;
 }
-int synctex_test_charindex() {
+int synctex_test_charindex()
+{
     int TC = 0;
-    char * content =
-    "SyncTeX Version:1  \n" /*00-19*/
-    "Input:1:./1.tex    \n" /*20-39*/
-    "Output:pdf         \n" /*40-59*/
-    "Magnification:100000000      \n" /*60-89*/
-    "Unit:1   \n"           /*90-99*/
-    "X Offset:0         \n" /*00-19*/
-    "Y Offset:0         \n" /*20-39*/
-    "Content: \n"           /*40-49*/
-    "{1       \n"           /*50-59*/
-    "[1,10:20,350:330,330,0       \n" /*60-89*/
-    "(1,58:20,100:250,10,5        \n" /*90-119*/
-    "f1000:50,100       \n" /*20-39*/
-    ")        \n"           /*40-49*/
-    "]        \n"           /*50-59*/
-    "}        \n"           /*60-69*/
-    "Postamble:\n";
+    char *content =
+        "SyncTeX Version:1  \n" /*00-19*/
+        "Input:1:./1.tex    \n" /*20-39*/
+        "Output:pdf         \n" /*40-59*/
+        "Magnification:100000000      \n" /*60-89*/
+        "Unit:1   \n" /*90-99*/
+        "X Offset:0         \n" /*00-19*/
+        "Y Offset:0         \n" /*20-39*/
+        "Content: \n" /*40-49*/
+        "{1       \n" /*50-59*/
+        "[1,10:20,350:330,330,0       \n" /*60-89*/
+        "(1,58:20,100:250,10,5        \n" /*90-119*/
+        "f1000:50,100       \n" /*20-39*/
+        ")        \n" /*40-49*/
+        "]        \n" /*50-59*/
+        "}        \n" /*60-69*/
+        "Postamble:\n";
     synctex_test_sn_s sn = synctex_test_tmp_sn(content);
-    if (sn.s>0) {
+    if (sn.s > 0) {
         synctex_scanner_p scanner = synctex_scanner_new_with_output_file(sn.n, NULL, synctex_YES);
         synctex_node_p node = synctex_scanner_handle(scanner);
         printf("Created nodes:\n");
         while (node) {
-            printf("%s\n",_synctex_node_abstract(node));
+            printf("%s\n", _synctex_node_abstract(node));
             node = synctex_node_next(node);
         }
         TC += synctex_scanner_free(scanner);
@@ -9594,35 +9752,36 @@ int synctex_test_charindex() {
     }
     return TC;
 }
-int synctex_test_form() {
+int synctex_test_form()
+{
     int TC = 0;
-    char * content =
-    "SyncTeX Version:1  \n" /*00-19*/
-    "Input:1:./1.tex    \n" /*20-39*/
-    "Output:pdf         \n" /*40-59*/
-    "Magnification:100000000      \n" /*60-89*/
-    "Unit:1   \n"           /*90-99*/
-    "X Offset:0         \n" /*00-19*/
-    "Y Offset:0         \n" /*20-39*/
-    "Content: \n"           /*40-49*/
-    "{1       \n"           /*50-59*/
-    "[1,10:20,350:330,330,0       \n" /*60-89*/
-    "(1,58:20,100:250,10,5        \n" /*90-119*/
-    "f1000:50,100       \n" /*20-39*/
-    ")        \n"           /*40-49*/
-    "]        \n"           /*50-59*/
-    "}        \n"           /*60-69*/
-    "<1000    \n"           /*70-79*/
-    "(1,63:0,0:100,8,3  \n" /*80-99*/
-    ")        \n"           /*00-09*/
-    ">        \n"           /*10-19*/
-    "Postamble:\n";
+    char *content =
+        "SyncTeX Version:1  \n" /*00-19*/
+        "Input:1:./1.tex    \n" /*20-39*/
+        "Output:pdf         \n" /*40-59*/
+        "Magnification:100000000      \n" /*60-89*/
+        "Unit:1   \n" /*90-99*/
+        "X Offset:0         \n" /*00-19*/
+        "Y Offset:0         \n" /*20-39*/
+        "Content: \n" /*40-49*/
+        "{1       \n" /*50-59*/
+        "[1,10:20,350:330,330,0       \n" /*60-89*/
+        "(1,58:20,100:250,10,5        \n" /*90-119*/
+        "f1000:50,100       \n" /*20-39*/
+        ")        \n" /*40-49*/
+        "]        \n" /*50-59*/
+        "}        \n" /*60-69*/
+        "<1000    \n" /*70-79*/
+        "(1,63:0,0:100,8,3  \n" /*80-99*/
+        ")        \n" /*00-09*/
+        ">        \n" /*10-19*/
+        "Postamble:\n";
     synctex_test_sn_s sn = synctex_test_tmp_sn(content);
-    if (sn.s>0) {
+    if (sn.s > 0) {
         synctex_scanner_p scanner = synctex_scanner_new_with_output_file(sn.n, NULL, synctex_YES);
         synctex_node_p node = synctex_scanner_handle(scanner);
         while (node) {
-            printf("%s\n",_synctex_node_abstract(node));
+            printf("%s\n", _synctex_node_abstract(node));
             node = _synctex_node_next(node);
         }
         TC += synctex_scanner_free(scanner);
@@ -9634,24 +9793,22 @@ int synctex_test_form() {
 }
 #endif
 
-static void _synctex_node_dump(
-    synctex_node_p node,
-    synctex_printer_f printer,
-    int * depth);
+static void _synctex_node_dump(synctex_node_p node, synctex_printer_f printer, int *depth);
 
-static const char * prefix = ".....................";
-int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer) {
+static const char *prefix = ".....................";
+int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer)
+{
     (*printer)("BEGIN DUMP\n");
     (*printer)("Ouput:%s\n", synctex_scanner_get_output(scanner));
     (*printer)(".synctex:%s\n", synctex_scanner_get_synctex(scanner));
     synctex_node_p N = synctex_scanner_input(scanner);
     if (N) {
         int NN = synctex_node_tag(N);
-        for (int i = 0; i<NN; ) {
+        for (int i = 0; i < NN;) {
             ++i;
             N = synctex_scanner_input(scanner);
             do {
-                if(synctex_node_tag(N) == i) {
+                if (synctex_node_tag(N) == i) {
                     (*printer)("Input:%i:%s\n", i, synctex_node_get_name(N));
                     break;
                 }
@@ -9681,127 +9838,61 @@ int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer) {
     return 0;
 }
 
-#define SYNCTEX_TMP_ITLHV \
-                synctex_node_isa(node),\
-                synctex_node_tag(node),\
-                synctex_node_line(node),\
-                synctex_node_h(node),\
-                synctex_node_v(node)
+#define SYNCTEX_TMP_ITLHV synctex_node_isa(node), synctex_node_tag(node), synctex_node_line(node), synctex_node_h(node), synctex_node_v(node)
 
-#define SYNCTEX_TMP_ITLHVWHD \
-                SYNCTEX_TMP_ITLHV,\
-                synctex_node_width(node),\
-                synctex_node_height(node),\
-                synctex_node_depth(node)
+#define SYNCTEX_TMP_ITLHVWHD SYNCTEX_TMP_ITLHV, synctex_node_width(node), synctex_node_height(node), synctex_node_depth(node)
 
-static void _synctex_node_dump(
-    synctex_node_p node,
-    synctex_printer_f printer,
-    int * depth
-) {
+static void _synctex_node_dump(synctex_node_p node, synctex_printer_f printer, int *depth)
+{
     synctex_node_p N;
-    switch(synctex_node_type(node)) {
-        case synctex_node_type_vbox:
-            (*printer)(
-                "%s%c%s:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_BEGIN_VBOX,
-                SYNCTEX_TMP_ITLHVWHD
-            );
-            //
-            *depth = (*depth+1)%20;
-            if ((N = synctex_node_child(node))) {
-                do {
-                    _synctex_node_dump(N, printer, depth);
-                } while((N = synctex_node_sibling(N)));
-            }
-            *depth = (*depth+19)%20;
-            (*printer)("%s%c\n", prefix+20-*depth, SYNCTEX_CHAR_END_VBOX);
-            break;
-        case synctex_node_type_hbox:
-            (*printer)(
-                "%s%c%s:%i:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_BEGIN_HBOX,
-                SYNCTEX_TMP_ITLHVWHD
-            );
-            *depth = (*depth+1)%20;
-            if ((N = synctex_node_child(node))) {
-                do {
-                    _synctex_node_dump(N, printer, depth);
-                } while((N = synctex_node_sibling(N)));
-            }
-            *depth = (*depth+19)%20;
-            (*printer)("%s%c\n", prefix+20-*depth, SYNCTEX_CHAR_END_HBOX);
-            break;
-        case synctex_node_type_void_vbox:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_VOID_VBOX,
-                SYNCTEX_TMP_ITLHVWHD
-            );
-            break;
-        case synctex_node_type_void_hbox:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_VOID_HBOX,
-                SYNCTEX_TMP_ITLHVWHD
-            );
-            break;
-        case synctex_node_type_kern:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_KERN,
-                SYNCTEX_TMP_ITLHV,
-                synctex_node_width(node)
-            );
-            break;
-        case synctex_node_type_glue:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_GLUE,
-                SYNCTEX_TMP_ITLHV,
-                synctex_node_width(node)
-            );
-            break;
-        case synctex_node_type_rule:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_RULE,
-                SYNCTEX_TMP_ITLHV,
-                synctex_node_width(node)
-            );
-            break;
-        case synctex_node_type_math:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_MATH,
-                SYNCTEX_TMP_ITLHV,
-                synctex_node_width(node)
-            );
-            break;
-        case synctex_node_type_boundary:
-            (*printer)(
-                "%s%c:%s:%i:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_CHAR_BOUNDARY,
-                SYNCTEX_TMP_ITLHV,
-                synctex_node_width(node)
-            );
-            break;
-        case synctex_node_type_box_bdry:
-            (*printer)(
-                "%sb:%s:%i:%i:%i:%i:%i\n",
-                prefix+20-*depth,
-                SYNCTEX_TMP_ITLHV
-            );
-            break;
+    switch (synctex_node_type(node)) {
+    case synctex_node_type_vbox:
+        (*printer)("%s%c%s:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_BEGIN_VBOX, SYNCTEX_TMP_ITLHVWHD);
+        //
+        *depth = (*depth + 1) % 20;
+        if ((N = synctex_node_child(node))) {
+            do {
+                _synctex_node_dump(N, printer, depth);
+            } while ((N = synctex_node_sibling(N)));
+        }
+        *depth = (*depth + 19) % 20;
+        (*printer)("%s%c\n", prefix + 20 - *depth, SYNCTEX_CHAR_END_VBOX);
+        break;
+    case synctex_node_type_hbox:
+        (*printer)("%s%c%s:%i:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_BEGIN_HBOX, SYNCTEX_TMP_ITLHVWHD);
+        *depth = (*depth + 1) % 20;
+        if ((N = synctex_node_child(node))) {
+            do {
+                _synctex_node_dump(N, printer, depth);
+            } while ((N = synctex_node_sibling(N)));
+        }
+        *depth = (*depth + 19) % 20;
+        (*printer)("%s%c\n", prefix + 20 - *depth, SYNCTEX_CHAR_END_HBOX);
+        break;
+    case synctex_node_type_void_vbox:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_VOID_VBOX, SYNCTEX_TMP_ITLHVWHD);
+        break;
+    case synctex_node_type_void_hbox:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_VOID_HBOX, SYNCTEX_TMP_ITLHVWHD);
+        break;
+    case synctex_node_type_kern:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_KERN, SYNCTEX_TMP_ITLHV, synctex_node_width(node));
+        break;
+    case synctex_node_type_glue:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_GLUE, SYNCTEX_TMP_ITLHV, synctex_node_width(node));
+        break;
+    case synctex_node_type_rule:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_RULE, SYNCTEX_TMP_ITLHV, synctex_node_width(node));
+        break;
+    case synctex_node_type_math:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_MATH, SYNCTEX_TMP_ITLHV, synctex_node_width(node));
+        break;
+    case synctex_node_type_boundary:
+        (*printer)("%s%c:%s:%i:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_CHAR_BOUNDARY, SYNCTEX_TMP_ITLHV, synctex_node_width(node));
+        break;
+    case synctex_node_type_box_bdry:
+        (*printer)("%sb:%s:%i:%i:%i:%i:%i\n", prefix + 20 - *depth, SYNCTEX_TMP_ITLHV);
+        break;
 #if 0
         case synctex_node_type_input:
         case synctex_node_type_sheet:
@@ -9814,14 +9905,8 @@ static void _synctex_node_dump(
         case synctex_node_type_proxy_hbox:
         case synctex_node_type_handle:
 #endif
-        default:
-            (*printer)(
-                "%sDump unexpected node %s:%i%i\n",
-                prefix+20-*depth,
-                synctex_node_isa(node),
-                synctex_node_tag(node),
-                synctex_node_line(node)
-            );
-            break;
+    default:
+        (*printer)("%sDump unexpected node %s:%i%i\n", prefix + 20 - *depth, synctex_node_isa(node), synctex_node_tag(node), synctex_node_line(node));
+        break;
     }
 }

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -437,7 +437,7 @@ SYNCTEX_INLINE static synctex_node_p __synctex_tree_##WHAT(synctex_non_null_node
     return node->data[node->class_->navigator->WHAT].as_node;\
 }
 #   define DEFINE_SYNCTEX_TREE_GET(WHAT) \
-DEFINE_SYNCTEX_TREE__GET(WHAT) \
+DEFINE_SYNCTEX_TREE__GET(WHAT); \
 SYNCTEX_INLINE static synctex_node_p _synctex_tree_##WHAT(synctex_node_p node) {\
     if (_synctex_tree_has_##WHAT(node)) {\
         return __synctex_tree_##WHAT(node);\
@@ -451,7 +451,7 @@ SYNCTEX_INLINE static synctex_node_p __synctex_tree_reset_##WHAT(synctex_non_nul
     return old;\
 }
 #   define DEFINE_SYNCTEX_TREE_RESET(WHAT) \
-DEFINE_SYNCTEX_TREE__RESET(WHAT) \
+DEFINE_SYNCTEX_TREE__RESET(WHAT); \
 SYNCTEX_INLINE static synctex_node_p _synctex_tree_reset_##WHAT(synctex_node_p node) {\
         return _synctex_tree_has_##WHAT(node)? \
             __synctex_tree_reset_##WHAT(node): NULL; \
@@ -463,31 +463,31 @@ SYNCTEX_INLINE static synctex_node_p __synctex_tree_set_##WHAT(synctex_non_null_
     return old;\
 }
 #   define DEFINE_SYNCTEX_TREE_SET(WHAT) \
-DEFINE_SYNCTEX_TREE__SET(WHAT) \
+DEFINE_SYNCTEX_TREE__SET(WHAT); \
 SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_##WHAT(synctex_node_p node, synctex_node_p new_value) {\
     return _synctex_tree_has_##WHAT(node)?\
         __synctex_tree_set_##WHAT(node,new_value):NULL;\
 }
 #   define DEFINE_SYNCTEX_TREE__GETSETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE__GET(WHAT) \
-DEFINE_SYNCTEX_TREE__SET(WHAT) \
-DEFINE_SYNCTEX_TREE__RESET(WHAT)
+DEFINE_SYNCTEX_TREE__GET(WHAT); \
+DEFINE_SYNCTEX_TREE__SET(WHAT); \
+DEFINE_SYNCTEX_TREE__RESET(WHAT);
 
 #   define DEFINE_SYNCTEX_TREE_GETSET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT) \
-DEFINE_SYNCTEX_TREE_GET(WHAT) \
-DEFINE_SYNCTEX_TREE_SET(WHAT)
+DEFINE_SYNCTEX_TREE_HAS(WHAT); \
+DEFINE_SYNCTEX_TREE_GET(WHAT); \
+DEFINE_SYNCTEX_TREE_SET(WHAT);
 
 #   define DEFINE_SYNCTEX_TREE_GETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT) \
-DEFINE_SYNCTEX_TREE_GET(WHAT) \
-DEFINE_SYNCTEX_TREE_RESET(WHAT)
+DEFINE_SYNCTEX_TREE_HAS(WHAT); \
+DEFINE_SYNCTEX_TREE_GET(WHAT); \
+DEFINE_SYNCTEX_TREE_RESET(WHAT);
 
 #   define DEFINE_SYNCTEX_TREE_GETSETRESET(WHAT) \
-DEFINE_SYNCTEX_TREE_HAS(WHAT) \
-DEFINE_SYNCTEX_TREE_GET(WHAT) \
-DEFINE_SYNCTEX_TREE_SET(WHAT) \
-DEFINE_SYNCTEX_TREE_RESET(WHAT)
+DEFINE_SYNCTEX_TREE_HAS(WHAT); \
+DEFINE_SYNCTEX_TREE_GET(WHAT); \
+DEFINE_SYNCTEX_TREE_SET(WHAT); \
+DEFINE_SYNCTEX_TREE_RESET(WHAT);
 
 /*
  *  _synctex_tree_set_... methods return the old value.
@@ -531,7 +531,7 @@ DEFINE_SYNCTEX_TREE_RESET(WHAT)
     When the old sibling is not `NULL`, it is no longer owned by the node
     and must be released somehow.
 */
-DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
+DEFINE_SYNCTEX_TREE__GETSETRESET(sibling);
 /* The next macro call creates:
  SYNCTEX_INLINE static synctex_bool_t _synctex_tree_has_parent(synctex_node_p node);
  SYNCTEX_INLINE static synctex_node_p __synctex_tree_parent(synctex_non_null_node_p node);
@@ -610,7 +610,7 @@ DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
     Private function.
     Synonym of `_synctex_tree_set_parent` to `NULL`.
 */
-DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
+DEFINE_SYNCTEX_TREE_GETSETRESET(parent);
 /** @fn __synctex_tree_has_child
     @brief Whether a node possibly has a child.
     @param node
@@ -679,7 +679,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
     Private function.
     Synonym of `_synctex_tree_set_child` to `NULL`.
 */
-DEFINE_SYNCTEX_TREE_GETSETRESET(child)
+DEFINE_SYNCTEX_TREE_GETSETRESET(child);
 /** @fn __synctex_tree_has_friend
     @brief Whether a node possibly has a friend.
     @param node
@@ -741,7 +741,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(child)
     Private function.
     Synonym of `_synctex_tree_set_friend` to `NULL`.
 */
-DEFINE_SYNCTEX_TREE_GETSETRESET(friend)
+DEFINE_SYNCTEX_TREE_GETSETRESET(friend);
 /* The next macro call creates:
  SYNCTEX_INLINE static synctex_bool_t _synctex_tree_has_last(synctex_node_p node);
  SYNCTEX_INLINE static synctex_node_p __synctex_tree_last(synctex_non_null_node_p node);
@@ -749,7 +749,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(friend)
  SYNCTEX_INLINE static synctex_node_p __synctex_tree_set_last(synctex_node_p node, synctex_node_p new_value);
  SYNCTEX_INLINE static synctex_node_p _synctex_tree_set_last(synctex_node_p node, synctex_node_p new_value);
  */
-DEFINE_SYNCTEX_TREE_GETSET(last)
+DEFINE_SYNCTEX_TREE_GETSET(last);
 /** @fn __synctex_tree_has_last
     @brief Whether a node possibly has a last.
     @param node
@@ -795,7 +795,7 @@ DEFINE_SYNCTEX_TREE_GETSET(last)
     If the the node type does not declare a last node,
     nothing is done.
 */
-DEFINE_SYNCTEX_TREE_GETSET(next_hbox)
+DEFINE_SYNCTEX_TREE_GETSET(next_hbox);
 /** @fn __synctex_tree_has_next_hbox
     @brief Whether a node possibly has a next_hbox.
     @param node
@@ -841,7 +841,7 @@ DEFINE_SYNCTEX_TREE_GETSET(next_hbox)
     If the the node type does not declare a next_hbox node,
     nothing is done.
 */
-DEFINE_SYNCTEX_TREE_GETSET(arg_sibling)
+DEFINE_SYNCTEX_TREE_GETSET(arg_sibling);
 /** @fn __synctex_tree_has_arg_sibling
     @brief Whether a node possibly has a arg_sibling.
     @param node
@@ -887,7 +887,7 @@ DEFINE_SYNCTEX_TREE_GETSET(arg_sibling)
     If the the node type does not declare a arg_sibling node,
     nothing is done.
 */
-DEFINE_SYNCTEX_TREE_GETSETRESET(target)
+DEFINE_SYNCTEX_TREE_GETSETRESET(target);
 /** @fn __synctex_tree_has_target
     @brief Whether a node possibly has a target.
     @param node
@@ -1643,7 +1643,7 @@ SYNCTEX_INLINE static synctex_data_p __synctex_data(synctex_node_p node) {
     return node->data+node->class_->navigator->size;
 }
 #   define DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_HAS(WHAT)\
+DEFINE_SYNCTEX_DATA_HAS(WHAT);\
 static int _synctex_data_##WHAT(synctex_node_p node) {\
     if (_synctex_data_has_##WHAT(node)) {\
         return __synctex_data(node)[node->class_->modelator->WHAT].as_integer;\
@@ -1681,7 +1681,7 @@ static synctex_status_t _synctex_data_decode_##WHAT##_v(synctex_node_p node) {\
     return SYNCTEX_STATUS_BAD_ARGUMENT;\
 }
 #define DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_HAS(WHAT)\
+DEFINE_SYNCTEX_DATA_HAS(WHAT);\
 static char * _synctex_data_##WHAT(synctex_node_p node) {\
     if (_synctex_data_has_##WHAT(node)) {\
         return node->data[node->class_->navigator->size+node->class_->modelator->WHAT].as_string;\
@@ -1708,14 +1708,14 @@ static synctex_status_t _synctex_data_decode_##WHAT(synctex_node_p node) {\
     return SYNCTEX_STATUS_BAD_ARGUMENT;\
 }
 #define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT)
+DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT); \
+DEFINE_SYNCTEX_DATA_INT_DECODE(WHAT);
 #define DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE_v(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT)
+DEFINE_SYNCTEX_DATA_INT_GETSET(WHAT); \
+DEFINE_SYNCTEX_DATA_INT_DECODE_v(WHAT);
 #define DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(WHAT) \
-DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT) \
-DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT)
+DEFINE_SYNCTEX_DATA_STR_GETSET(WHAT); \
+DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT);
 
 #	ifdef SYNCTEX_NOTHING
 #       pragma mark -
@@ -1726,9 +1726,9 @@ DEFINE_SYNCTEX_DATA_STR_DECODE(WHAT)
 #       pragma mark input.
 #   endif
 
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(tag)
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(line)
-DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(name)
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(tag);
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(line);
+DEFINE_SYNCTEX_DATA_STR_GETSET_DECODE(name);
 
 /*  Input nodes only know about their sibling, which is another input node.
  *  The synctex information is the _synctex_data_tag and _synctex_data_name
@@ -1855,7 +1855,7 @@ static void _synctex_free_input(synctex_node_p node){
  *  Every node has the same structure, but not the same size.
  */
 
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(page)
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(page);
 
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
@@ -1883,7 +1883,7 @@ static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scanner) {\
 /*  NB: -1 in SYNCTEX_IMPLEMENT_CHARINDEX above because
  *  the first char of the line has been scanned
  */
-DEFINE_synctex_new_scanned_NODE(sheet)
+DEFINE_synctex_new_scanned_NODE(sheet);
 static void _synctex_log_sheet(synctex_node_p node);
 static char * _synctex_abstract_sheet(synctex_node_p node);
 static void _synctex_display_sheet(synctex_node_p node);
@@ -1946,7 +1946,7 @@ typedef struct {
     _synctex_data_u data[synctex_tree_sct_form_max+synctex_data_t_form_max];
 } _synctex_node_form_s;
 
-DEFINE_synctex_new_scanned_NODE(form)
+DEFINE_synctex_new_scanned_NODE(form);
 
 static char * _synctex_abstract_form(synctex_node_p node);
 static void _synctex_display_form(synctex_node_p node);
@@ -2020,7 +2020,7 @@ typedef struct {
 } _synctex_node_vbox_s;
 
 /*  vertical box node creator */
-DEFINE_synctex_new_scanned_NODE(vbox)
+DEFINE_synctex_new_scanned_NODE(vbox);
 
 static char * _synctex_abstract_vbox(synctex_node_p node);
 static void _synctex_display_vbox(synctex_node_p node);
@@ -2040,7 +2040,7 @@ static const _synctex_tree_model_s synctex_tree_model_vbox = {
 
 #define SYNCTEX_DFLT_COLUMN -1
 
-DEFINE_SYNCTEX_DATA_INT_GETSET(column)
+DEFINE_SYNCTEX_DATA_INT_GETSET(column);
 static synctex_status_t _synctex_data_decode_column(synctex_node_p node) {
     if (_synctex_data_has_column(node)) {
         _synctex_is_s is = _synctex_decode_int_opt(node->class_->scanner,
@@ -2057,11 +2057,11 @@ Definitions of
 __synctex_data_has_?, _synctex_data_?, _synctex_data_decode_?
 for ? in h, v, width, height, depth
 */
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(h)
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE_v(v)
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(width)
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(height)
-DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(depth)
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(h);
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE_v(v);
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(width);
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(height);
+DEFINE_SYNCTEX_DATA_INT_GETSET_DECODE(depth);
 
 SYNCTEX_INLINE static void _synctex_data_set_tlc(synctex_node_p node, synctex_node_p model) {
     _synctex_data_set_tag(node, _synctex_data_tag(model));
@@ -2154,13 +2154,13 @@ static const _synctex_tree_model_s synctex_tree_model_hbox = {
     synctex_tree_spcfln_hbox_max,
 };
 
-DEFINE_SYNCTEX_DATA_INT_GETSET(mean_line)
-DEFINE_SYNCTEX_DATA_INT_GETSET(weight)
-DEFINE_SYNCTEX_DATA_INT_GETSET(h_V)
-DEFINE_SYNCTEX_DATA_INT_GETSET(v_V)
-DEFINE_SYNCTEX_DATA_INT_GETSET(width_V)
-DEFINE_SYNCTEX_DATA_INT_GETSET(height_V)
-DEFINE_SYNCTEX_DATA_INT_GETSET(depth_V)
+DEFINE_SYNCTEX_DATA_INT_GETSET(mean_line);
+DEFINE_SYNCTEX_DATA_INT_GETSET(weight);
+DEFINE_SYNCTEX_DATA_INT_GETSET(h_V);
+DEFINE_SYNCTEX_DATA_INT_GETSET(v_V);
+DEFINE_SYNCTEX_DATA_INT_GETSET(width_V);
+DEFINE_SYNCTEX_DATA_INT_GETSET(height_V);
+DEFINE_SYNCTEX_DATA_INT_GETSET(depth_V);
 
 /**
  *  The hbox model.
@@ -2201,7 +2201,7 @@ typedef struct {
 } _synctex_node_hbox_s;
 
 /*  horizontal box node creator */
-DEFINE_synctex_new_scanned_NODE(hbox)
+DEFINE_synctex_new_scanned_NODE(hbox);
 
 static void _synctex_log_hbox(synctex_node_p node);
 static char * _synctex_abstract_hbox(synctex_node_p node);
@@ -2247,7 +2247,7 @@ typedef struct {
 } _synctex_node_void_vbox_s;
 
 /*  vertical void box node creator */
-DEFINE_synctex_new_scanned_NODE(void_vbox)
+DEFINE_synctex_new_scanned_NODE(void_vbox);
 
 static void _synctex_log_void_box(synctex_node_p node);
 static char * _synctex_abstract_void_vbox(synctex_node_p node);
@@ -2275,7 +2275,7 @@ static _synctex_class_s _synctex_class_void_vbox = {
 typedef _synctex_node_void_vbox_s _synctex_node_void_hbox_s;
 
 /*  horizontal void box node creator */
-DEFINE_synctex_new_scanned_NODE(void_hbox)
+DEFINE_synctex_new_scanned_NODE(void_hbox);
 
 static char * _synctex_abstract_void_hbox(synctex_node_p node);
 static void _synctex_display_void_hbox(synctex_node_p node);
@@ -2307,7 +2307,7 @@ typedef struct {
 } _synctex_node_ref_s;
 
 /*  form ref node creator */
-DEFINE_synctex_new_scanned_NODE(ref)
+DEFINE_synctex_new_scanned_NODE(ref);
 
 static void _synctex_log_ref(synctex_node_p node);
 static char * _synctex_abstract_ref(synctex_node_p node);
@@ -2399,7 +2399,7 @@ static void _synctex_log_tlchv_node(synctex_node_p node);
 typedef _synctex_node_tlchv_s _synctex_node_math_s;
 
 /*  math node creator */
-DEFINE_synctex_new_scanned_NODE(math)
+DEFINE_synctex_new_scanned_NODE(math);
 
 static char * _synctex_abstract_math(synctex_node_p node);
 static void _synctex_display_math(synctex_node_p node);
@@ -2464,7 +2464,7 @@ typedef struct {
 } _synctex_node_kern_s;
 
 /*  kern node creator */
-DEFINE_synctex_new_scanned_NODE(kern)
+DEFINE_synctex_new_scanned_NODE(kern);
 
 static void _synctex_log_kern_node(synctex_node_p node);
 static char * _synctex_abstract_kern(synctex_node_p node);
@@ -2508,7 +2508,7 @@ static _synctex_class_s _synctex_class_kern = {
 
 /*  glue node creator */
 typedef _synctex_node_tlchv_s _synctex_node_glue_s;
-DEFINE_synctex_new_scanned_NODE(glue)
+DEFINE_synctex_new_scanned_NODE(glue);
 
 static char * _synctex_abstract_glue(synctex_node_p node);
 static void _synctex_display_glue(synctex_node_p node);
@@ -2540,7 +2540,7 @@ typedef struct {
     _synctex_data_u data[synctex_tree_spf_max+synctex_data_box_max];
 } _synctex_node_rule_s;
 
-DEFINE_synctex_new_scanned_NODE(rule)
+DEFINE_synctex_new_scanned_NODE(rule);
 
 static void _synctex_log_rule(synctex_node_p node);
 static char * _synctex_abstract_rule(synctex_node_p node);
@@ -2580,7 +2580,7 @@ static _synctex_class_s _synctex_class_rule = {
 
 /*  boundary node creator */
 typedef _synctex_node_tlchv_s _synctex_node_boundary_s;
-DEFINE_synctex_new_scanned_NODE(boundary)
+DEFINE_synctex_new_scanned_NODE(boundary);
 
 static char * _synctex_abstract_boundary(synctex_node_p node);
 static void _synctex_display_boundary(synctex_node_p node);
@@ -2622,7 +2622,7 @@ SYNCTEX_INLINE static synctex_node_p _synctex_new_##NAME(synctex_scanner_p scann
     }\
     return NULL;\
 }
-DEFINE_synctex_new_unscanned_NODE(box_bdry)
+DEFINE_synctex_new_unscanned_NODE(box_bdry);
 
 static char * _synctex_abstract_box_bdry(synctex_node_p node);
 static void _synctex_display_box_bdry(synctex_node_p node);
@@ -2756,7 +2756,7 @@ typedef struct {
 } _synctex_node_proxy_hbox_s;
 
 /*  box proxy node creator */
-DEFINE_synctex_new_unscanned_NODE(proxy_hbox)
+DEFINE_synctex_new_unscanned_NODE(proxy_hbox);
 
 static void _synctex_log_proxy(synctex_node_p node);
 static char * _synctex_abstract_proxy_hbox(synctex_node_p node);
@@ -2838,7 +2838,7 @@ typedef struct {
 } _synctex_node_proxy_vbox_s;
 
 /*  box proxy node creator */
-DEFINE_synctex_new_unscanned_NODE(proxy_vbox)
+DEFINE_synctex_new_unscanned_NODE(proxy_vbox);
 
 static void _synctex_log_proxy(synctex_node_p node);
 static char * _synctex_abstract_proxy_vbox(synctex_node_p node);
@@ -2886,7 +2886,7 @@ typedef struct {
 } _synctex_node_proxy_s;
 
 /*  proxy node creator */
-DEFINE_synctex_new_unscanned_NODE(proxy)
+DEFINE_synctex_new_unscanned_NODE(proxy);
 
 static void _synctex_log_proxy(synctex_node_p node);
 static char * _synctex_abstract_proxy(synctex_node_p node);
@@ -2942,7 +2942,7 @@ typedef struct {
 } _synctex_node_proxy_last_s;
 
 /*  proxy node creator */
-DEFINE_synctex_new_unscanned_NODE(proxy_last)
+DEFINE_synctex_new_unscanned_NODE(proxy_last);
 
 static void _synctex_log_proxy(synctex_node_p node);
 static char * _synctex_abstract_proxy(synctex_node_p node);
@@ -3016,7 +3016,7 @@ typedef struct {
 } _synctex_node_handle_s;
 
 /*  handle node creator */
-DEFINE_synctex_new_unscanned_NODE(handle)
+DEFINE_synctex_new_unscanned_NODE(handle);
 
 static void _synctex_log_handle(synctex_node_p node);
 static char * _synctex_abstract_handle(synctex_node_p node);
@@ -7025,19 +7025,19 @@ static int _synctex_proxy_##WHAT(_synctex_proxy_p proxy) { \
  *  - note: recursive call if the parameter has a proxy.
  *  - author: JL
  */
-SYNCTEX_DEFINE_NODE_HVWHD(h)
-SYNCTEX_DEFINE_NODE_HVWHD(v)
-SYNCTEX_DEFINE_NODE_HVWHD(width)
-SYNCTEX_DEFINE_NODE_HVWHD(height)
-SYNCTEX_DEFINE_NODE_HVWHD(depth)
-SYNCTEX_DEFINE_PROXY_TLCWVD(tag)
-SYNCTEX_DEFINE_PROXY_TLCWVD(line)
-SYNCTEX_DEFINE_PROXY_TLCWVD(column)
-SYNCTEX_DEFINE_PROXY_HV(h)
-SYNCTEX_DEFINE_PROXY_HV(v)
-SYNCTEX_DEFINE_PROXY_TLCWVD(width)
-SYNCTEX_DEFINE_PROXY_TLCWVD(height)
-SYNCTEX_DEFINE_PROXY_TLCWVD(depth)
+SYNCTEX_DEFINE_NODE_HVWHD(h);
+SYNCTEX_DEFINE_NODE_HVWHD(v);
+SYNCTEX_DEFINE_NODE_HVWHD(width);
+SYNCTEX_DEFINE_NODE_HVWHD(height);
+SYNCTEX_DEFINE_NODE_HVWHD(depth);
+SYNCTEX_DEFINE_PROXY_TLCWVD(tag);
+SYNCTEX_DEFINE_PROXY_TLCWVD(line);
+SYNCTEX_DEFINE_PROXY_TLCWVD(column);
+SYNCTEX_DEFINE_PROXY_HV(h);
+SYNCTEX_DEFINE_PROXY_HV(v);
+SYNCTEX_DEFINE_PROXY_TLCWVD(width);
+SYNCTEX_DEFINE_PROXY_TLCWVD(height);
+SYNCTEX_DEFINE_PROXY_TLCWVD(depth);
 
 /**
  *  Whether the argument is a box,
@@ -7377,11 +7377,11 @@ _synctex_node_width_V
 _synctex_node_height_V
 _synctex_node_depth_V
 */
-SYNCTEX_DEFINE_V(h)
-SYNCTEX_DEFINE_V(v)
-SYNCTEX_DEFINE_V(width)
-SYNCTEX_DEFINE_V(height)
-SYNCTEX_DEFINE_V(depth)
+SYNCTEX_DEFINE_V(h);
+SYNCTEX_DEFINE_V(v);
+SYNCTEX_DEFINE_V(width);
+SYNCTEX_DEFINE_V(height);
+SYNCTEX_DEFINE_V(depth);
 
 SYNCTEX_INLINE static synctex_point_s _synctex_data_point(synctex_node_p node) {
     return (synctex_point_s){synctex_node_h(node),synctex_node_v(node)};

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -1745,7 +1745,7 @@ static const _synctex_tree_model_s synctex_tree_model_input = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
-    synctex_tree_s_input_max
+    synctex_tree_s_input_max,
 };
 static const _synctex_data_model_s synctex_data_model_input = {
     synctex_data_input_tag_idx, /* tag */
@@ -1765,7 +1765,7 @@ static const _synctex_data_model_s synctex_data_model_input = {
     -1, /* depth_V */
     synctex_data_input_name_idx, /* name */
     -1, /* page */
-    synctex_data_input_tln_max
+    synctex_data_input_tln_max,
 };
 
 #define SYNCTEX_INSPECTOR_GETTER_F(WHAT)\
@@ -1900,7 +1900,7 @@ static const _synctex_tree_model_s synctex_tree_model_sheet = {
     synctex_tree_sc_next_hbox_idx, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
-    synctex_tree_scn_sheet_max
+    synctex_tree_scn_sheet_max,
 };
 static const _synctex_data_model_s synctex_data_model_sheet = {
     -1, /* tag */
@@ -1920,7 +1920,7 @@ static const _synctex_data_model_s synctex_data_model_sheet = {
     -1, /* depth_V */
     -1, /* name */
     synctex_data_sheet_page_idx, /* page */
-    synctex_data_p_sheet_max
+    synctex_data_p_sheet_max,
 };
 static _synctex_class_s _synctex_class_sheet = {
     NULL,                       /*  No scanner yet */
@@ -1964,7 +1964,7 @@ static const _synctex_tree_model_s synctex_tree_model_form = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_sc_target_idx, /* target */
-    synctex_tree_sct_form_max
+    synctex_tree_sct_form_max,
 };
 static const _synctex_data_model_s synctex_data_model_form = {
     synctex_data_form_tag_idx, /* tag */
@@ -1984,7 +1984,7 @@ static const _synctex_data_model_s synctex_data_model_form = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_t_form_max
+    synctex_data_t_form_max,
 };
 
 static const _synctex_tlcpector_s synctex_tlcpector_form = {
@@ -2038,7 +2038,7 @@ static const _synctex_tree_model_s synctex_tree_model_vbox = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
-    synctex_tree_spcfl_vbox_max
+    synctex_tree_spcfl_vbox_max,
 };
 
 #define SYNCTEX_DFLT_COLUMN -1
@@ -2095,7 +2095,7 @@ static const _synctex_data_model_s synctex_data_model_box = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_box_max
+    synctex_data_box_max,
 };
 static const _synctex_tlcpector_s synctex_tlcpector_default = {
     &_synctex_data_tag, /* tag */
@@ -2154,7 +2154,7 @@ static const _synctex_tree_model_s synctex_tree_model_hbox = {
     synctex_tree_spcfl_next_hbox_idx, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
-    synctex_tree_spcfln_hbox_max
+    synctex_tree_spcfln_hbox_max,
 };
 
 DEFINE_SYNCTEX_DATA_INT_GETSET(mean_line)
@@ -2194,7 +2194,7 @@ static const _synctex_data_model_s synctex_data_model_hbox = {
     synctex_data_depth_V_idx, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_hbox_max
+    synctex_data_hbox_max,
 };
 
 typedef struct {
@@ -2241,7 +2241,7 @@ static const _synctex_tree_model_s synctex_tree_model_spf = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     -1, /* target */
-    synctex_tree_spf_max
+    synctex_tree_spf_max,
 };
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
@@ -2325,7 +2325,7 @@ static const _synctex_tree_model_s synctex_tree_model_spfa = {
     -1, /* next_hbox */
     synctex_tree_spf_arg_sibling_idx, /* arg_sibling */
     -1, /* target */
-    synctex_tree_spfa_max
+    synctex_tree_spfa_max,
 };
 static const _synctex_data_model_s synctex_data_model_ref = {
     synctex_data_tag_idx, /* tag */
@@ -2345,7 +2345,7 @@ static const _synctex_data_model_s synctex_data_model_ref = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_ref_thv_max /* size */
+    synctex_data_ref_thv_max, /* size */
 };
 static _synctex_class_s _synctex_class_ref = {
     NULL,                       /*  No scanner yet */
@@ -2384,7 +2384,7 @@ static const _synctex_data_model_s synctex_data_model_tlchv = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_tlchv_max
+    synctex_data_tlchv_max,
 };
 
 typedef struct {
@@ -2458,7 +2458,7 @@ static const _synctex_data_model_s synctex_data_model_tlchvw = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_tlchvw_max
+    synctex_data_tlchvw_max,
 };
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
@@ -2730,7 +2730,7 @@ static const _synctex_tree_model_s synctex_tree_model_proxy_hbox = {
     synctex_tree_spcfl_next_hbox_idx,   /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_spcfln_target_idx, /* target */
-    synctex_tree_spcflnt_proxy_hbox_max
+    synctex_tree_spcflnt_proxy_hbox_max,
 };
 static const _synctex_data_model_s synctex_data_model_proxy = {
     -1, /* tag */
@@ -2750,7 +2750,7 @@ static const _synctex_data_model_s synctex_data_model_proxy = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_proxy_hv_max
+    synctex_data_proxy_hv_max,
 };
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
@@ -2831,7 +2831,7 @@ static const _synctex_tree_model_s synctex_tree_model_proxy_vbox = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_spcfl_target_idx,    /* target */
-    synctex_tree_spcflt_proxy_vbox_max
+    synctex_tree_spcflt_proxy_vbox_max,
 };
 
 typedef struct {
@@ -2879,7 +2879,7 @@ static const _synctex_tree_model_s synctex_tree_model_proxy = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_spf_target_idx,/* target */
-    synctex_tree_spft_proxy_max
+    synctex_tree_spft_proxy_max,
 };
 
 typedef struct {
@@ -2935,7 +2935,7 @@ static const _synctex_tree_model_s synctex_tree_model_proxy_last = {
     -1, /* next_hbox */
     synctex_tree_spf_arg_sibling_idx, /* arg_sibling */
     synctex_tree_spfa_target_idx,     /* target */
-    synctex_tree_spfat_proxy_last_max
+    synctex_tree_spfat_proxy_last_max,
 };
 
 typedef struct {
@@ -2988,7 +2988,7 @@ static const _synctex_tree_model_s synctex_tree_model_handle = {
     -1, /* next_hbox */
     -1, /* arg_sibling */
     synctex_tree_spc_target_idx,/* target */
-    synctex_tree_spct_handle_max
+    synctex_tree_spct_handle_max,
 };
 
 static const _synctex_data_model_s synctex_data_model_handle = {
@@ -3009,7 +3009,7 @@ static const _synctex_data_model_s synctex_data_model_handle = {
     -1, /* depth_V */
     -1, /* name */
     -1, /* page */
-    synctex_data_handle_w_max
+    synctex_data_handle_w_max,
 };
 
 typedef struct {

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -1,15 +1,15 @@
 /*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
- 
+
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,22 +30,22 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  Acknowledgments:
  ----------------
  The author received useful remarks from the pdfTeX developers, especially Hahn The Thanh,
  and significant help from XeTeX developer Jonathan Kew
- 
+
  Nota Bene:
  ----------
  If you include or use a significant part of the synctex package into a software,
  I would appreciate to be listed as contributor and see "SyncTeX" highlighted.
- 
+
  */
 
 /*  We assume that high level application like pdf viewers will want
@@ -147,7 +147,7 @@ typedef char *(*_synctex_node_str_f)(synctex_node_p);
 /**
  * @brief A tree model structure
  * @author: Jérôme LAURENS
- * 
+ *
  * 8 fields + size: `spcflnat` referring to the first letters of each field.
  */
 typedef struct synctex_tree_model_t {
@@ -206,13 +206,13 @@ typedef const _synctex_data_model_s * _synctex_data_model_p;
 /**
  * @brief node -> integer function type
  * @author: Jérôme LAURENS
- * 
+ *
  */
 typedef int (*_synctex_int_getter_f)(synctex_node_p);
 
 /**
  * @brief tlc inspector structure
- * 
+ *
  */
 typedef struct _synctex_tlcpector_t {
     /** tag getter */
@@ -235,7 +235,7 @@ static const _synctex_tlcpector_s synctex_tlcpector_none = {
 
 /**
  * @brief Geometry inspector structure
- * 
+ *
  */
 typedef struct _synctex_inspector_t {
     /** h getter */
@@ -261,7 +261,7 @@ static const _synctex_inspector_s synctex_inspector_none = {
 typedef float (*_synctex_float_getter_f)(synctex_node_p);
 /**
  * @brief vi inspector data structure.
- * 
+ *
  */
 typedef struct _synctex_vispector_t {
     /** h attribute getter */
@@ -491,7 +491,7 @@ DEFINE_SYNCTEX_TREE_RESET(WHAT)
 
 /*
  *  _synctex_tree_set_... methods return the old value.
- *  The return value of _synctex_tree_set_child and 
+ *  The return value of _synctex_tree_set_child and
  *  _synctex_tree_set_sibling must be released somehow.
  */
 /* The next macro call creates:
@@ -512,7 +512,7 @@ DEFINE_SYNCTEX_TREE_RESET(WHAT)
     @param node
     @param sibling
     @return old sibling if any
-    
+
     Private function.
     Set the sibling of the given node assuming the node type declares a sibling.
     When the sibling is not `NULL`, it is owned by the node.
@@ -523,7 +523,7 @@ DEFINE_SYNCTEX_TREE_RESET(WHAT)
     @brief Reset the sibling of the given node.
     @param node
     @return sibling
-    
+
     Private function.
     Set the sibling of the given node to NULL assuming the node type
     declares a sibling.
@@ -571,10 +571,10 @@ DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
     @param node
     @param parent
     @return node
-    
+
     Private function.
     Set the parent of the given node assuming the node type declares a parent.
-    The node is not yet the child of the parent: 
+    The node is not yet the child of the parent:
     `__synctex_tree_set_child` must also be called.
     When the parent is not `NULL`, it is the owner of the node.
 */
@@ -583,12 +583,12 @@ DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
     @param node
     @param parent
     @return node
-    
+
     Private function.
     If the the node type declares a parent, set it to the given node.
     In that case, set the parent of the given node.
     When the parent is not `NULL`, it becomes the owner of the node.
-    The node is not yet the child of the parent: 
+    The node is not yet the child of the parent:
     `__synctex_tree_set_child` must also be called.
     The old child must be managed as well, if any.
     If the the node type does not declare a parent,
@@ -598,7 +598,7 @@ DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
     @brief Reset the parent of the given node.
     @param node
     @return old parent
-    
+
     Private function.
     Synonym of `__synctex_tree_set_parent` to `NULL`.
 */
@@ -606,7 +606,7 @@ DEFINE_SYNCTEX_TREE__GETSETRESET(sibling)
     @brief Reset the parent of the given node.
     @param node
     @return old parent
-    
+
     Private function.
     Synonym of `_synctex_tree_set_parent` to `NULL`.
 */
@@ -641,10 +641,10 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
     @param node
     @param child
     @return old child
-    
+
     Private function.
     Set the child of the given node assuming the node type declares a child.
-    The node is not yet the parent of the child: 
+    The node is not yet the parent of the child:
     `__synctex_tree_set_parent` must also be called.
     When the child is not `NULL`, it is owned by the node.
 */
@@ -653,11 +653,11 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
     @param node
     @param child
     @return old child
-    
+
     Private function.
     If the the node type declares a child, set it to the given node.
     When the child is not `NULL`, it becomes owned by the node.
-    The node is not yet the parent of the child: 
+    The node is not yet the parent of the child:
     `__synctex_tree_set_parent` must also be called.
     The old child must be managed as well, if any.
     If the the node type does not declare a child,
@@ -667,7 +667,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
     @brief Reset the child of the given node.
     @param node
     @return old child
-    
+
     Private function.
     Synonym of `__synctex_tree_set_child` to `NULL`.
 */
@@ -675,7 +675,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(parent)
     @brief Reset the child of the given node.
     @param node
     @return old child
-    
+
     Private function.
     Synonym of `_synctex_tree_set_child` to `NULL`.
 */
@@ -710,7 +710,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(child)
     @param node
     @param friend
     @return old friend
-    
+
     Private function.
     Set the friend of the given node assuming the node type declares a friend.
 */
@@ -719,7 +719,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(child)
     @param node
     @param friend
     @return old friend
-    
+
     Private function.
     If the the node type declares a friend, set it to the given node.
     If the the node type does not declare a friend,
@@ -729,7 +729,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(child)
     @brief Reset the friend of the given node.
     @param node
     @return old friend
-    
+
     Private function.
     Synonym of `__synctex_tree_set_friend` to `NULL`.
 */
@@ -737,7 +737,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(child)
     @brief Reset the friend of the given node.
     @param node
     @return old friend
-    
+
     Private function.
     Synonym of `_synctex_tree_set_friend` to `NULL`.
 */
@@ -780,7 +780,7 @@ DEFINE_SYNCTEX_TREE_GETSET(last)
     @param node
     @param last
     @return old last
-    
+
     Private function.
     Set the last of the given node assuming the node type declares a last node.
 */
@@ -789,7 +789,7 @@ DEFINE_SYNCTEX_TREE_GETSET(last)
     @param node
     @param last
     @return old last
-    
+
     Private function.
     If the the node type declares a last node, set it to the given node.
     If the the node type does not declare a last node,
@@ -826,7 +826,7 @@ DEFINE_SYNCTEX_TREE_GETSET(next_hbox)
     @param node
     @param next_hbox
     @return old next_hbox
-    
+
     Private function.
     Set the next_hbox of the given node assuming the node type declares a next_hbox node.
 */
@@ -835,7 +835,7 @@ DEFINE_SYNCTEX_TREE_GETSET(next_hbox)
     @param node
     @param next_hbox
     @return old next_hbox
-    
+
     Private function.
     If the the node type declares a next_hbox node, set it to the given node.
     If the the node type does not declare a next_hbox node,
@@ -872,7 +872,7 @@ DEFINE_SYNCTEX_TREE_GETSET(arg_sibling)
     @param node
     @param arg_sibling
     @return old arg_sibling
-    
+
     Private function.
     Set the arg_sibling of the given node assuming the node type declares a arg_sibling node.
 */
@@ -881,7 +881,7 @@ DEFINE_SYNCTEX_TREE_GETSET(arg_sibling)
     @param node
     @param arg_sibling
     @return old arg_sibling
-    
+
     Private function.
     If the the node type declares a arg_sibling node, set it to the given node.
     If the the node type does not declare a arg_sibling node,
@@ -918,7 +918,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(target)
     @param node
     @param target
     @return old target
-    
+
     Private function.
     Set the target of the given node assuming the node type declares a target node.
 */
@@ -927,7 +927,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(target)
     @param node
     @param target
     @return old target
-    
+
     Private function.
     If the the node type declares a target node, set it to the given node.
     If the the node type does not declare a target node,
@@ -1000,7 +1000,7 @@ DEFINE_SYNCTEX_TREE_GETSETRESET(target)
 
 /**
  * @brief Data structure fot a file reader
- * 
+ *
  */
 typedef struct _synctex_reader_t {
     /** The (possibly compressed) file */
@@ -1028,13 +1028,13 @@ typedef struct _synctex_reader_t {
 
 /**
  * @brief Reader structure
- * 
+ *
  */
 typedef _synctex_reader_s * synctex_reader_p;
 
 /**
  * @brief Return structure
- * 
+ *
  * This is the return structure of the open functions.
  */
 typedef struct {
@@ -1295,7 +1295,7 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
 
 /**
  *  The synctex scanner is the root object.
- * 
+ *
  *  Is is initialized with the contents of a text file or a gzipped file.
  *  The buffer_.* are first used to parse the text.
  */
@@ -1341,7 +1341,7 @@ struct _synctex_scanner_t {
     synctex_node_p sheet;
     /** The first form, its siblings are the other forms */
     synctex_node_p form;
-    /** The first form ref node in sheet, its friends are the other form ref nodes */    
+    /** The first form ref node in sheet, its friends are the other form ref nodes */
     synctex_node_p ref_in_sheet;
     /** The first form ref node, its friends are the other form ref nodes in sheet */
     synctex_node_p ref_in_form;
@@ -1361,10 +1361,10 @@ struct _synctex_scanner_t {
 
 /**
  * @brief Create a new node of the given type.
- * 
- * @param scanner 
+ *
+ * @param scanner
  * @param type no type checking
- * @return synctex_node_p 
+ * @return synctex_node_p
  */
 synctex_node_p synctex_node_new(synctex_scanner_p scanner, synctex_node_type_t type) {
     return scanner? scanner->class_[type].new(scanner):NULL;
@@ -1422,7 +1422,7 @@ SYNCTEX_INLINE static void _synctex_will_free(synctex_node_p node) {
  *  - note: a node is meant to own its child and sibling.
  *  It is not owned by its parent, unless it is its first child.
  *  This destructor is for all nodes with children.
- * 
+ *
  * There is no recursion.
  * TODO: Here we cherry pick nodes to be freed one by one.
  * The memory management should be enhanced to free everything all at once,
@@ -1595,7 +1595,7 @@ static _synctex_is_s _synctex_decode_int_v(synctex_scanner_p scanner);
 
 /**
  * @brief String+status structure.
- * 
+ *
  * Used to return multiple values from functions.
  */
 typedef struct {
@@ -1800,7 +1800,7 @@ static _synctex_class_s _synctex_class_input = {
 
 /**
  * @brief Input node structure
- * 
+ *
  */
 typedef struct {
     SYNCTEX_DECLARE_CHARINDEX
@@ -1810,9 +1810,9 @@ typedef struct {
 
 /**
  * @brief Input node constructor
- * 
- * @param scanner 
- * @return synctex_node_p 
+ *
+ * @param scanner
+ * @return synctex_node_p
  */
 static synctex_node_p _synctex_new_input(synctex_scanner_p scanner) {
     if (scanner) {
@@ -1830,8 +1830,8 @@ static synctex_node_p _synctex_new_input(synctex_scanner_p scanner) {
 
 /**
  * @brief Input node destructor
- * 
- * @param node 
+ *
+ * @param node
  */
 static void _synctex_free_input(synctex_node_p node){
     if (node) {
@@ -2710,7 +2710,7 @@ static _synctex_class_s _synctex_class_box_bdry = {
  *  After all the refs are replaced, there are only root nodes
  *  targeting standard node. We make sure that each child proxy
  *  also targets a standard node.
- *  It is possible for a proxy to have a standard sibling 
+ *  It is possible for a proxy to have a standard sibling
  *  whereas its target has no sibling at all. Root proxies
  *  are such nodes, and are the only ones.
  *  The consequence is that proxies created on the fly
@@ -4428,7 +4428,7 @@ static void _synctex_display_handle(synctex_node_p node) {
 #   endif
 /**
  * @brief size+status structure
- * 
+ *
  * Used to return multiple values from a function.
  */
 typedef struct {
@@ -4443,7 +4443,7 @@ static synctex_status_t _synctex_match_string(synctex_scanner_p scanner, const c
 
 /**
  * @brief node+status structure
- * 
+ *
  * Used to return multiple values from a function.
  */
 typedef struct {
@@ -4456,7 +4456,7 @@ static _synctex_ns_s __synctex_parse_new_input(synctex_scanner_p scanner);
 static synctex_status_t _synctex_scan_preamble(synctex_scanner_p scanner);
 /**
  * @brief float+status structure
- * 
+ *
  * Used to return multiple values from a function.
  */
 typedef struct {
@@ -6723,7 +6723,7 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner) {
      *  If there is a post scriptum section, this value will be overridden by the real life value */
     scanner->x_offset = scanner->y_offset = 6.027e23f;
     scanner->reader->line_number = 1;
-    
+
     synctex_scanner_set_display_switcher(scanner, 1000);
     SYNCTEX_END = SYNCTEX_START+SYNCTEX_BUFFER_SIZE;
     /*  SYNCTEX_END always points to a null terminating character.
@@ -6849,11 +6849,11 @@ void synctex_scanner_display(synctex_scanner_p scanner) {
 /*  Public */
 /**
  * @brief Get the name of an input node.
- * 
+ *
  * Corresponds to `Input:<tag>:<name>` entries in the `.synctex` file.
- * @param scanner 
- * @param tag 
- * @return const char* 
+ * @param scanner
+ * @param tag
+ * @return const char*
  */
 const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag) {
     synctex_node_p input = NULL;
@@ -6871,9 +6871,9 @@ const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag) {
 }
 /**
  * @brief Get the name of a node.
- * 
+ *
  * Forwards to the node's scanner for the node's tag.
- * @param node 
+ * @param node
  * @return const char
  * @see synctex_scanner_get_name
  */
@@ -6920,9 +6920,9 @@ static int _synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name)
 
 /**
  * @brief Get the tag for a given name.
- * 
- * @param scanner 
- * @param name 
+ *
+ * @param scanner
+ * @param name
  * @return int, 0 for an unknown tag.
  */
 int synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name) {
@@ -7100,10 +7100,10 @@ SYNCTEX_INLINE static synctex_bool_t _synctex_node_is_hbox(synctex_node_p node) 
 
 /**
  * @brief The horizontal location of the first box enclosing node.
- * 
+ *
  * The first box enclosing a box is itself.
  * @param node a node with geometrical information.
- * @return int in TeX sp coordinates. 
+ * @return int in TeX sp coordinates.
  */
 int synctex_node_box_h(synctex_node_p node) {
     if (_synctex_node_is_box(node) || (node = _synctex_tree_parent(node))) {
@@ -7113,7 +7113,7 @@ int synctex_node_box_h(synctex_node_p node) {
 }
 /**
  * @brief The vertical location of the first box enclosing node.
- * 
+ *
  * The first box enclosing a box is itself.
  * @param node a node with geometrical information.
  * @return int in TeX sp coordinates
@@ -7373,7 +7373,7 @@ SYNCTEX_INLINE static int _synctex_node_##WHAT##_V(synctex_node_p node) { \
     } \
 }
 /*
-Definitions of 
+Definitions of
 _synctex_node_h_V
 _synctex_node_v_V
 _synctex_node_width_V
@@ -7635,8 +7635,8 @@ int synctex_node_mean_line(synctex_node_p node) {
 
 /**
  * @brief The weight of the node.
- * 
- * @param node 
+ *
+ * @param node
  * @return int. -1 if node is NULL, 0 if the node is not an hbox.
  * @author Jérôme LAURENS
  */
@@ -9088,7 +9088,7 @@ typedef union {
 
 /**
  * @brief Update data structure
- * 
+ *
  */
 struct _synctex_updater_t {
     /** The file union */

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -9684,6 +9684,19 @@ int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer) {
     return 0;
 }
 
+#define SYNCTEX_TMP_ITLHV \
+                synctex_node_isa(node),\
+                synctex_node_tag(node),\
+                synctex_node_line(node),\
+                synctex_node_h(node),\
+                synctex_node_v(node)
+
+#define SYNCTEX_TMP_ITLHVWHD \
+                SYNCTEX_TMP_ITLHV,\
+                synctex_node_width(node),\
+                synctex_node_height(node),\
+                synctex_node_depth(node)
+
 static void _synctex_node_dump(
     synctex_node_p node,
     synctex_printer_f printer,
@@ -9696,17 +9709,6 @@ static void _synctex_node_dump(
                 "%s%c%s:%i:%i:%i:%i:%i\n",
                 prefix+20-*depth,
                 SYNCTEX_CHAR_BEGIN_VBOX,
-#define SYNCTEX_TMP_ITLHV \
-                synctex_node_isa(node),\
-                synctex_node_tag(node),\
-                synctex_node_line(node),\
-                synctex_node_h(node),\
-                synctex_node_v(node)
-#define SYNCTEX_TMP_ITLHVWHD \
-                SYNCTEX_TMP_ITLHV,\
-                synctex_node_width(node),\
-                synctex_node_height(node),\
-                synctex_node_depth(node)
                 SYNCTEX_TMP_ITLHVWHD
             );
             //

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -1768,9 +1768,6 @@ static const _synctex_data_model_s synctex_data_model_input = {
     synctex_data_input_tln_max,
 };
 
-#define SYNCTEX_INSPECTOR_GETTER_F(WHAT)\
-&_synctex_data_##WHAT, &_synctex_data_set_##WHAT
-
 static synctex_node_p _synctex_new_input(synctex_scanner_p scanner);
 static void _synctex_free_input(synctex_node_p node);
 static void _synctex_log_input(synctex_node_p node);

--- a/synctex_parser.h
+++ b/synctex_parser.h
@@ -1,15 +1,15 @@
 /*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
- 
+
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,19 +30,19 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  ## Acknowledgments:
- 
+
  The author received useful remarks from the __pdfTeX__ developers, especially Hahn The Thanh,
  and significant help from __XeTeX__ developer Jonathan Kew.
- 
+
  ## Nota Bene:
- 
+
  If you include or use a significant part of the __SyncTeX__ package into a software,
  I would appreciate to be listed as contributor and see "__SyncTeX__" highlighted.
 */
@@ -55,9 +55,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
 /** @defgroup Scanner Main scanner object.
- *  
+ *
  * The main synctex object is a scanner.
  * The basic workflow is
  * -   create a "synctex scanner" with the contents of a file
@@ -71,15 +71,15 @@ extern "C" {
     typedef struct _synctex_scanner_t _synctex_scanner_s;
     /**
      * @brief Main synctex object.
-     * 
+     *
      * Its implementation is considered private.
      */
     typedef _synctex_scanner_s * synctex_scanner_p;
-    
+
     /**
      * @brief This is the designated method to create
      *  a new synctex scanner object.
-     * 
+     *
      * @param output the pdf/dvi/xdv file associated
      *      to the synctex file.
      *      If necessary, it can be the tex file that
@@ -101,7 +101,7 @@ extern "C" {
      *      this build directory.
      *      It is the directory where all the auxiliary
      *      stuff is created. Sometimes, the synctex output
-     *      file and the pdf, dvi or xdv files are not 
+     *      file and the pdf, dvi or xdv files are not
      *      created in the same location. See MikTeX.
      *      This directory path can be NULL,
      *      it will be ignored then.
@@ -118,7 +118,7 @@ extern "C" {
      *      of an error or non existent file.
      */
     synctex_scanner_p synctex_scanner_new_with_output_file(const char * output, const char * build_directory, int parse);
-    
+
     /**
      * @brief Scanner destructor
      *
@@ -129,10 +129,10 @@ extern "C" {
      * @return int an integer mainly used for testing purposes.
      */
     int synctex_scanner_free(synctex_scanner_p scanner);
-    
+
     /**
      * @brief Ask the scanner to parse the .synctex file.
-     * 
+     *
      *  Send this message to force the scanner to
      *  parse the contents of the synctex output file.
      *  Nothing is performed if the file was already parsed.
@@ -147,22 +147,22 @@ extern "C" {
      *		}
      *  - returns: the argument on success.
      *      On failure, frees scanner and returns NULL.
-     * 
-     * @param scanner 
+     *
+     * @param scanner
      * @return synctex_scanner_p the argument on success.
      *      On failure, frees scanner and returns NULL.
      */
     synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner);
-    
+
     /** @} */
 
     /*  synctex_node_p is the type for all synctex nodes.
      *  Its implementation is considered private.
      *  The synctex file is parsed into a tree of nodes, either sheet, form, boxes, math nodes... */
-    
+
     typedef struct _synctex_node_t _synctex_node_s;
     typedef _synctex_node_s * synctex_node_p;
-    
+
     /** @defgroup Query  Text and display query.
      *
      * Both methods are conservative, in the sense that matching is weak.
@@ -175,12 +175,12 @@ extern "C" {
 
     /**
      * @brief Type for status as return value
-     * 
+     *
      */
     typedef long synctex_status_t;
     /**
      * @brief Display query
-     * 
+     *
      * Given an input file name, a line and a column number,
      * `synctex_display_query` returns the number of nodes
      * satisfying the constrain. Use code like
@@ -198,7 +198,7 @@ extern "C" {
      *  there is a new argument page_hint.
      *  The results in pages closer to page_hint are given first.
      *  For example, one can
-     * 
+     *
      * - highlight each resulting node in the output,
      *   using `synctex_node_visible_h` and `synctex_node_visible_v`
      * - highlight all the rectangles enclosing those nodes,
@@ -209,7 +209,7 @@ extern "C" {
      * ```
      * synctex view -i <line>:<column>:<page_hint>:<input> ...
      * ```
-     * 
+     *
      * @param scanner built with the appropriate `.synctex` file.
      * @param input the absolute path to a source input file
      * @param line the line number in the input file
@@ -229,10 +229,10 @@ extern "C" {
 
     /**
      * @brief Edit query
-     * 
+     *
      * Given the page and the position in the page, synctex_edit_query returns the number of nodes
      * satisfying the constrain.
-     * 
+     *
      * Usage:
      * ```
      * if(synctex_edit_query(scanner,page,h,v)>0) {
@@ -243,7 +243,7 @@ extern "C" {
      *   }
      * }
      * ```
-     * 
+     *
      *  For example, one can
      * - highlight each resulting line in the input,
      * - highlight just the character using that information
@@ -252,12 +252,12 @@ extern "C" {
      * If you need to make more than one query
      * in parallel, use the iterator API exposed in
      * the `synctex_parser_advanced.h` header.
-     * 
+     *
      * It corresponds to the command
      * ```
      * synctex edit -o <page>:<h>:<v>:<output> ...\n"
      * ```
-     * 
+     *
      * @param scanner built with the appropriate `.synctex` file.
      * @param page the page number in the output file, 1 based
      * @param h the horizontal coordinate in 72 dpi unit from top left corner of the page
@@ -270,19 +270,19 @@ extern "C" {
 
     /**
      * @brief Answer to queries
-     * 
-     * @param scanner 
+     *
+     * @param scanner
      * @return synctex_node_p The next node of the query,
      *   NULL when there are no node left.
      * @see `synctex_edit_query` and `synctex_view_query`.
      */
     synctex_node_p synctex_scanner_next_result(synctex_scanner_p scanner);
-    
+
     /**
      * @brief Reset to the first result
-     * 
-     * @param scanner 
-     * @return synctex_status_t 
+     *
+     * @param scanner
+     * @return synctex_status_t
      */
     synctex_status_t synctex_scanner_reset_result(synctex_scanner_p scanner);
     /** @} */
@@ -296,10 +296,10 @@ extern "C" {
      *  Code example for Qt5:
      *  (from TeXworks source TWSynchronize.cpp)
      *  QRectF nodeRect(synctex_node_box_visible_h(node),
-     *      synctex_node_box_visible_v(node) - 
+     *      synctex_node_box_visible_v(node) -
      *          synctex_node_box_visible_height(node),
      *      synctex_node_box_visible_width(node),
-     *      synctex_node_box_visible_height(node) + 
+     *      synctex_node_box_visible_height(node) +
      *          synctex_node_box_visible_depth(node));
      *  Code example for Cocoa:
      *  NSRect bounds = [pdfPage
@@ -368,7 +368,7 @@ extern "C" {
     int synctex_node_mean_line(synctex_node_p node);
     int synctex_node_column(synctex_node_p node);
     const char * synctex_node_get_name(synctex_node_p node);
-    
+
     /**
      This is the page where the node appears.
      *  This is a 1 based index as given by TeX.
@@ -385,7 +385,7 @@ extern "C" {
      *  This is mainly for informational purpose to help developers.
      */
     void synctex_scanner_display(synctex_scanner_p scanner);
-    
+
     /*  Managing the input file names.
      *  Given a tag, synctex_scanner_get_name will return the corresponding file name.
      *  Conversely, given a file name, synctex_scanner_get_tag will return, the corresponding tag.
@@ -408,12 +408,12 @@ extern "C" {
      *  it was obtained from output by setting the proper file extension.
      */
     const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag);
-    
+
     int synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name);
     /** @} */
-    
+
     /** @defgroup Tree Node tree
-     * 
+     *
      * parent, child and sibling are standard names for tree nodes.
      * The parent is one level higher,
      * the child is one level deeper,
@@ -434,7 +434,7 @@ extern "C" {
      *   // do something with node
      * }
      * ```
-     * 
+     *
      *  With `synctex_sheet_content` and `synctex_form_content`,
      *  you can retrieve the sheet node given the page
      *  or form tag.
@@ -449,44 +449,44 @@ extern "C" {
 
     /**
      * @brief First input node.
-     * 
-     * @param scanner 
-     * @return * synctex_node_p 
+     *
+     * @param scanner
+     * @return * synctex_node_p
      */
     synctex_node_p synctex_scanner_input(synctex_scanner_p scanner);
     /**
      * @brief First input node with a given tag.
-     * 
+     *
      * Corresponds to `Input:<tag>:<file>` entries in the `.sycntex` file.
-     * @param scanner 
-     * @param tag 
-     * @return * synctex_node_p 
+     * @param scanner
+     * @param tag
+     * @return * synctex_node_p
      */
     synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner,int tag);
     /**
      * @brief Path to the output file
-     * 
-     * @param scanner 
-     * @return const char* 
+     *
+     * @param scanner
+     * @return const char*
      */
     const char * synctex_scanner_get_output(synctex_scanner_p scanner);
     /**
      * @brief Path to the synctex file
-     * 
-     * @param scanner 
-     * @return const char* 
+     *
+     * @param scanner
+     * @return const char*
      */
     const char * synctex_scanner_get_synctex(synctex_scanner_p scanner);
     /**
      * @brief Format of the output
-     * 
+     *
      * From the content of the synctex file.
-     * @param scanner 
-     * @return const char* 
+     * @param scanner
+     * @return const char*
      */
     const char * synctex_scanner_get_output_fmt(synctex_scanner_p scanner);
     /** @} */
-    
+
     /*  The x and y offset of the origin in TeX coordinates. The magnification
      These are used by pdf viewers that want to display the real box size.
      For example, getting the horizontal coordinates of a node would require
@@ -498,37 +498,37 @@ extern "C" {
 
     /**
      * @brief Horizontal offset of coordinates.
-     * 
+     *
      * 1in default in TeX.
-     * @param scanner 
-     * @return int 
+     * @param scanner
+     * @return int
      */
     int synctex_scanner_x_offset(synctex_scanner_p scanner);
     /**
      * @brief Vertical offset of coordinates.
-     * 
+     *
      * 1in default in TeX.
-     * @param scanner 
-     * @return int 
+     * @param scanner
+     * @return int
      */
     int synctex_scanner_y_offset(synctex_scanner_p scanner);
     /**
      * @brief Magnification
-     * 
+     *
      * 1000 default in TeX.
-     * @param scanner 
-     * @return float 
+     * @param scanner
+     * @return float
      */
     float synctex_scanner_magnification(synctex_scanner_p scanner);
-    
+
     typedef int (synctex_printer_f) (const char *, ...);
 
     /**
      * @brief Dump the scanner
-     * 
-     * @param scanner 
-     * @param printer 
-     * @return int 
+     *
+     * @param scanner
+     * @param printer
+     * @return int
      */
     int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer);
     /** @} */
@@ -536,82 +536,82 @@ extern "C" {
     /** @addtogroup Tree
      * @{
      */
-    
+
     /**
      * @brief Parent
-     * 
-     * @param node 
+     *
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_parent(synctex_node_p node);
     /**
      * @brief Parent sheet
-     * 
-     * @param node 
+     *
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_parent_sheet(synctex_node_p node);
     /**
      * @brief Parent sheet
-     * 
-     * @param node 
+     *
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_parent_form(synctex_node_p node);
     /**
      * @brief First child
-     * 
-     * @param node 
+     *
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_child(synctex_node_p node);
     /**
      * @brief Last child
-     * 
+     *
      * Last sibling of the first child, if any.
-     * @param node 
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_last_child(synctex_node_p node);
     /**
      * @brief First sibling
-     * 
-     * @param node 
+     *
+     * @param node
      * @return synctex_node_p possibly NULL.
      */
     synctex_node_p synctex_node_sibling(synctex_node_p node);
     /**
      * @brief Last sibling
-     * 
+     *
      * Last sibling of the first sibling of the node, if any,
      * the node itself otherwise.
-     * @param node 
+     * @param node
      * @return synctex_node_p possibly NULL.
      * @see synctex_node_last_child
      */
     synctex_node_p synctex_node_last_sibling(synctex_node_p node);
     /**
-     * @brief 
-     * 
-     * @param node 
-     * @return synctex_node_p 
+     * @brief
+     *
+     * @param node
+     * @return synctex_node_p
      */
     synctex_node_p synctex_node_arg_sibling(synctex_node_p node);
 
     /**
      * @brief Next node.
-     * 
+     *
      * Deep first traversal of the tree of nodes.
      * First child if any,
      * first sibling if any,
      * parent's first sibling if any,
      * parent's parent's first sibling if any,
      * ...
-     * @param node 
-     * @return synctex_node_p 
+     * @param node
+     * @return synctex_node_p
      */
     synctex_node_p synctex_node_next(synctex_node_p node);
-    
+
     /**
      *  Top level entry points.
      *  The scanner owns a list of sheet siblings and
@@ -624,29 +624,29 @@ extern "C" {
     synctex_node_p synctex_sheet(synctex_scanner_p scanner,int page);
     /**
      * @brief Sheet content at a given page.
-     * 
-     * @param scanner 
-     * @param page 
-     * @return synctex_node_p 
+     *
+     * @param scanner
+     * @param page
+     * @return synctex_node_p
      */
     synctex_node_p synctex_sheet_content(synctex_scanner_p scanner,int page);
     /**
      * @brief Form for a given tag
-     * 
-     * @param scanner 
-     * @param tag 
-     * @return synctex_node_p 
+     *
+     * @param scanner
+     * @param tag
+     * @return synctex_node_p
      */
     synctex_node_p synctex_form(synctex_scanner_p scanner,int tag);
     /**
      * @brief Form content for given tag.
-     * 
-     * @param scanner 
-     * @param tag 
-     * @return synctex_node_p 
+     *
+     * @param scanner
+     * @param tag
+     * @return synctex_node_p
      */
     synctex_node_p synctex_form_content(synctex_scanner_p scanner,int tag);
-    
+
     /** @} */
 
     /*  This is primarily used for debugging purpose.
@@ -654,22 +654,22 @@ extern "C" {
 
     /**
      * @brief Log a node
-     * 
+     *
      * This is primarily used for debugging purpose.
-     * @param node 
+     * @param node
      */
     void synctex_node_log(synctex_node_p node);
     /**
      * @brief Display a node
-     * 
+     *
      * This is primarily used for debugging purpose.
-     * @param node 
+     * @param node
      */
     void synctex_node_display(synctex_node_p node);
-    
+
     /**
-     * @defgroup Geometry Node geometry 
-     * 
+     * @defgroup Geometry Node geometry
+     *
      * For quite all nodes, horizontal, vertical coordinates, and width.
      * These are expressed in TeX small points coordinates,
      * with origin at the top left corner.
@@ -679,40 +679,40 @@ extern "C" {
 
     /**
      * @brief Horizontal coordinate
-     * 
-     * @param node 
+     *
+     * @param node
      * @return int in TeX sp from top left corner of the page
      */
     int synctex_node_h(synctex_node_p node);
     /**
      * @brief Vertical coordinate
-     * 
-     * @param node 
+     *
+     * @param node
      * @return int in TeX sp from top left corner of the page
      */
     int synctex_node_v(synctex_node_p node);
     /**
      * @brief Width
-     * 
-     * @param node 
+     *
+     * @param node
      * @return int in TeX sp
      */
     int synctex_node_width(synctex_node_p node);
     /**
      * @brief Height
-     * 
-     * @param node 
+     *
+     * @param node
      * @return int in TeX sp, 0 when irrelevant
      */
     int synctex_node_height(synctex_node_p node);
     /**
      * @brief Depth
-     * 
-     * @param node 
+     *
+     * @param node
      * @return int in TeX sp, 0 when irrelevant
      */
     int synctex_node_depth(synctex_node_p node);
-    
+
     /*  For all nodes, dimensions of the enclosing box.
      *  These are expressed in TeX small points coordinates, with origin at the top left corner.
      *  A box is enclosing itself.

--- a/synctex_parser.h
+++ b/synctex_parser.h
@@ -48,7 +48,7 @@
 */
 
 #ifndef _SYNCTEX_PARSER_H_
-#   define _SYNCTEX_PARSER_H_
+#define _SYNCTEX_PARSER_H_
 
 #include "synctex_version.h"
 
@@ -68,661 +68,661 @@ extern "C" {
  * @{
  */
 
-    typedef struct _synctex_scanner_t _synctex_scanner_s;
-    /**
-     * @brief Main synctex object.
-     *
-     * Its implementation is considered private.
-     */
-    typedef _synctex_scanner_s * synctex_scanner_p;
+typedef struct _synctex_scanner_t _synctex_scanner_s;
+/**
+ * @brief Main synctex object.
+ *
+ * Its implementation is considered private.
+ */
+typedef _synctex_scanner_s *synctex_scanner_p;
 
-    /**
-     * @brief This is the designated method to create
-     *  a new synctex scanner object.
-     *
-     * @param output the pdf/dvi/xdv file associated
-     *      to the synctex file.
-     *      If necessary, it can be the tex file that
-     *      originated the synctex file but this might cause
-     *      problems if the `\jobname` has a custom value.
-     *      Despite this method can accept a relative path
-     *      in practice, you should only pass full paths.
-     *      The path should be encoded by the underlying
-     *      file system, assuming that it is based on
-     *      8 bits characters, including UTF8,
-     *      not 16 bits nor 32 bits.
-     *      The last file extension is removed and
-     *      replaced by the proper extension,
-     *      either `synctex` or `synctex.gz`.
-     * @param build_directory It is the directory where
-     *      all the auxiliary stuff is created.
-     *      If no synctex file is found in the same directory
-     *      as the output file, then we try to find one in
-     *      this build directory.
-     *      It is the directory where all the auxiliary
-     *      stuff is created. Sometimes, the synctex output
-     *      file and the pdf, dvi or xdv files are not
-     *      created in the same location. See MikTeX.
-     *      This directory path can be NULL,
-     *      it will be ignored then.
-     *      It can be either absolute or relative to the
-     *      directory of the output pdf (dvi or xdv) file.
-     *      Please note that this new argument is provided
-     *      as a convenience but should not be used.
-     *      Available since version 1.5.
-     * @param parse In general, use 1.
-     *      Use 0 only if you do not want to parse the
-     *      content but just check for existence.
-     *      Available since version 1.5
-     * @return synctex_scanner_p NULL is returned in case
-     *      of an error or non existent file.
-     */
-    synctex_scanner_p synctex_scanner_new_with_output_file(const char * output, const char * build_directory, int parse);
+/**
+ * @brief This is the designated method to create
+ *  a new synctex scanner object.
+ *
+ * @param output the pdf/dvi/xdv file associated
+ *      to the synctex file.
+ *      If necessary, it can be the tex file that
+ *      originated the synctex file but this might cause
+ *      problems if the `\jobname` has a custom value.
+ *      Despite this method can accept a relative path
+ *      in practice, you should only pass full paths.
+ *      The path should be encoded by the underlying
+ *      file system, assuming that it is based on
+ *      8 bits characters, including UTF8,
+ *      not 16 bits nor 32 bits.
+ *      The last file extension is removed and
+ *      replaced by the proper extension,
+ *      either `synctex` or `synctex.gz`.
+ * @param build_directory It is the directory where
+ *      all the auxiliary stuff is created.
+ *      If no synctex file is found in the same directory
+ *      as the output file, then we try to find one in
+ *      this build directory.
+ *      It is the directory where all the auxiliary
+ *      stuff is created. Sometimes, the synctex output
+ *      file and the pdf, dvi or xdv files are not
+ *      created in the same location. See MikTeX.
+ *      This directory path can be NULL,
+ *      it will be ignored then.
+ *      It can be either absolute or relative to the
+ *      directory of the output pdf (dvi or xdv) file.
+ *      Please note that this new argument is provided
+ *      as a convenience but should not be used.
+ *      Available since version 1.5.
+ * @param parse In general, use 1.
+ *      Use 0 only if you do not want to parse the
+ *      content but just check for existence.
+ *      Available since version 1.5
+ * @return synctex_scanner_p NULL is returned in case
+ *      of an error or non existent file.
+ */
+synctex_scanner_p synctex_scanner_new_with_output_file(const char *output, const char *build_directory, int parse);
 
-    /**
-     * @brief Scanner destructor
-     *
-     * Designated method to delete a synctex scanner object,
-     * including all its internal resources.
-     * Frees all the memory, you must call it when you are finished with the scanner.
-     * @param scanner  a scanner.
-     * @return int an integer mainly used for testing purposes.
-     */
-    int synctex_scanner_free(synctex_scanner_p scanner);
+/**
+ * @brief Scanner destructor
+ *
+ * Designated method to delete a synctex scanner object,
+ * including all its internal resources.
+ * Frees all the memory, you must call it when you are finished with the scanner.
+ * @param scanner  a scanner.
+ * @return int an integer mainly used for testing purposes.
+ */
+int synctex_scanner_free(synctex_scanner_p scanner);
 
-    /**
-     * @brief Ask the scanner to parse the .synctex file.
-     *
-     *  Send this message to force the scanner to
-     *  parse the contents of the synctex output file.
-     *  Nothing is performed if the file was already parsed.
-     *  In each query below, this message is sent,
-     *  but if you need to access information more directly,
-     *  you must ensure that the parsing did occur.
-     *  Usage:
-     *		if((my_scanner = synctex_scanner_parse(my_scanner))) {
-     *			continue with my_scanner...
-     *		} else {
-     *			there was a problem
-     *		}
-     *  - returns: the argument on success.
-     *      On failure, frees scanner and returns NULL.
-     *
-     * @param scanner
-     * @return synctex_scanner_p the argument on success.
-     *      On failure, frees scanner and returns NULL.
-     */
-    synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner);
+/**
+ * @brief Ask the scanner to parse the .synctex file.
+ *
+ *  Send this message to force the scanner to
+ *  parse the contents of the synctex output file.
+ *  Nothing is performed if the file was already parsed.
+ *  In each query below, this message is sent,
+ *  but if you need to access information more directly,
+ *  you must ensure that the parsing did occur.
+ *  Usage:
+ *		if((my_scanner = synctex_scanner_parse(my_scanner))) {
+ *			continue with my_scanner...
+ *		} else {
+ *			there was a problem
+ *		}
+ *  - returns: the argument on success.
+ *      On failure, frees scanner and returns NULL.
+ *
+ * @param scanner
+ * @return synctex_scanner_p the argument on success.
+ *      On failure, frees scanner and returns NULL.
+ */
+synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner);
 
-    /** @} */
+/** @} */
 
-    /*  synctex_node_p is the type for all synctex nodes.
-     *  Its implementation is considered private.
-     *  The synctex file is parsed into a tree of nodes, either sheet, form, boxes, math nodes... */
+/*  synctex_node_p is the type for all synctex nodes.
+ *  Its implementation is considered private.
+ *  The synctex file is parsed into a tree of nodes, either sheet, form, boxes, math nodes... */
 
-    typedef struct _synctex_node_t _synctex_node_s;
-    typedef _synctex_node_s * synctex_node_p;
+typedef struct _synctex_node_t _synctex_node_s;
+typedef _synctex_node_s *synctex_node_p;
 
-    /** @defgroup Query  Text and display query.
-     *
-     * Both methods are conservative, in the sense that matching is weak.
-     * If the exact column number is not found, there will be an answer with the whole line.
-     *
-     * Sumatra-PDF, Skim, iTeXMac2, TeXShop and Texworks are examples of open source software that use this library.
-     * You can browse their code for a concrete implementation.
-     * @{
-     */
+/** @defgroup Query  Text and display query.
+ *
+ * Both methods are conservative, in the sense that matching is weak.
+ * If the exact column number is not found, there will be an answer with the whole line.
+ *
+ * Sumatra-PDF, Skim, iTeXMac2, TeXShop and Texworks are examples of open source software that use this library.
+ * You can browse their code for a concrete implementation.
+ * @{
+ */
 
-    /**
-     * @brief Type for status as return value
-     *
-     */
-    typedef long synctex_status_t;
-    /**
-     * @brief Display query
-     *
-     * Given an input file name, a line and a column number,
-     * `synctex_display_query` returns the number of nodes
-     * satisfying the constrain. Use code like
-     *
-     * ```
-     * if(synctex_display_query(scanner,name,line,column,page_hint)>0) {
-     *   synctex_node_p node;
-     *   while((node = synctex_scanner_next_result(scanner))) {
-     *     // do something with node
-     *     ...
-     *   }
-     * }
-     * ```
-     *  Please notice that since version 1.19,
-     *  there is a new argument page_hint.
-     *  The results in pages closer to page_hint are given first.
-     *  For example, one can
-     *
-     * - highlight each resulting node in the output,
-     *   using `synctex_node_visible_h` and `synctex_node_visible_v`
-     * - highlight all the rectangles enclosing those nodes,
-     *   using `synctex_node_box_visible_...` functions
-     * - highlight just the character that fits best to that information
-     *
-     * It corresponds to the command
-     * ```
-     * synctex view -i <line>:<column>:<page_hint>:<input> ...
-     * ```
-     *
-     * @param scanner built with the appropriate `.synctex` file.
-     * @param input the absolute path to a source input file
-     * @param line the line number in the input file
-     * @param column the column number in the input file
-     * @param page_hint a page number used to resolve ambiguities.
-     *   Whenever, different matches occur, the ones closest
-     *   to this page number will be given first.
-     *   Pass the currently displayed page number if available.
-     *   Pass 0 to have matches with lower page numbers first.
-     *   Pass 1000 to have matches with higher page numbers first.
-     *   Using pdf forms may lead to ambiguities.
-     * @return synctex_status_t, an error status when negative,
-     *   the number of results found otherwise.
-     * @see synctex_scanner_next_result
-     */
-    synctex_status_t synctex_display_query(synctex_scanner_p scanner,const char *  input,int line,int column, int page_hint);
+/**
+ * @brief Type for status as return value
+ *
+ */
+typedef long synctex_status_t;
+/**
+ * @brief Display query
+ *
+ * Given an input file name, a line and a column number,
+ * `synctex_display_query` returns the number of nodes
+ * satisfying the constrain. Use code like
+ *
+ * ```
+ * if(synctex_display_query(scanner,name,line,column,page_hint)>0) {
+ *   synctex_node_p node;
+ *   while((node = synctex_scanner_next_result(scanner))) {
+ *     // do something with node
+ *     ...
+ *   }
+ * }
+ * ```
+ *  Please notice that since version 1.19,
+ *  there is a new argument page_hint.
+ *  The results in pages closer to page_hint are given first.
+ *  For example, one can
+ *
+ * - highlight each resulting node in the output,
+ *   using `synctex_node_visible_h` and `synctex_node_visible_v`
+ * - highlight all the rectangles enclosing those nodes,
+ *   using `synctex_node_box_visible_...` functions
+ * - highlight just the character that fits best to that information
+ *
+ * It corresponds to the command
+ * ```
+ * synctex view -i <line>:<column>:<page_hint>:<input> ...
+ * ```
+ *
+ * @param scanner built with the appropriate `.synctex` file.
+ * @param input the absolute path to a source input file
+ * @param line the line number in the input file
+ * @param column the column number in the input file
+ * @param page_hint a page number used to resolve ambiguities.
+ *   Whenever, different matches occur, the ones closest
+ *   to this page number will be given first.
+ *   Pass the currently displayed page number if available.
+ *   Pass 0 to have matches with lower page numbers first.
+ *   Pass 1000 to have matches with higher page numbers first.
+ *   Using pdf forms may lead to ambiguities.
+ * @return synctex_status_t, an error status when negative,
+ *   the number of results found otherwise.
+ * @see synctex_scanner_next_result
+ */
+synctex_status_t synctex_display_query(synctex_scanner_p scanner, const char *input, int line, int column, int page_hint);
 
-    /**
-     * @brief Edit query
-     *
-     * Given the page and the position in the page, synctex_edit_query returns the number of nodes
-     * satisfying the constrain.
-     *
-     * Usage:
-     * ```
-     * if(synctex_edit_query(scanner,page,h,v)>0) {
-     *   synctex_node_p node;
-     *   while(node = synctex_scanner_next_result(scanner)) {
-     *     // do something with node
-     *     ...
-     *   }
-     * }
-     * ```
-     *
-     *  For example, one can
-     * - highlight each resulting line in the input,
-     * - highlight just the character using that information
-     *
-     * If you make a new query, the result of the previous one is discarded.
-     * If you need to make more than one query
-     * in parallel, use the iterator API exposed in
-     * the `synctex_parser_advanced.h` header.
-     *
-     * It corresponds to the command
-     * ```
-     * synctex edit -o <page>:<h>:<v>:<output> ...\n"
-     * ```
-     *
-     * @param scanner built with the appropriate `.synctex` file.
-     * @param page the page number in the output file, 1 based
-     * @param h the horizontal coordinate in 72 dpi unit from top left corner of the page
-     * @param v the vertical coordinate in 72 dpi unit from top left corner of the page
-     * @return synctex_status_t, an error status when negative,
-     *   the number of results found otherwise.
-     * @see synctex_scanner_next_result
-     */
-    synctex_status_t synctex_edit_query(synctex_scanner_p scanner,int page,float h,float v);
+/**
+ * @brief Edit query
+ *
+ * Given the page and the position in the page, synctex_edit_query returns the number of nodes
+ * satisfying the constrain.
+ *
+ * Usage:
+ * ```
+ * if(synctex_edit_query(scanner,page,h,v)>0) {
+ *   synctex_node_p node;
+ *   while(node = synctex_scanner_next_result(scanner)) {
+ *     // do something with node
+ *     ...
+ *   }
+ * }
+ * ```
+ *
+ *  For example, one can
+ * - highlight each resulting line in the input,
+ * - highlight just the character using that information
+ *
+ * If you make a new query, the result of the previous one is discarded.
+ * If you need to make more than one query
+ * in parallel, use the iterator API exposed in
+ * the `synctex_parser_advanced.h` header.
+ *
+ * It corresponds to the command
+ * ```
+ * synctex edit -o <page>:<h>:<v>:<output> ...\n"
+ * ```
+ *
+ * @param scanner built with the appropriate `.synctex` file.
+ * @param page the page number in the output file, 1 based
+ * @param h the horizontal coordinate in 72 dpi unit from top left corner of the page
+ * @param v the vertical coordinate in 72 dpi unit from top left corner of the page
+ * @return synctex_status_t, an error status when negative,
+ *   the number of results found otherwise.
+ * @see synctex_scanner_next_result
+ */
+synctex_status_t synctex_edit_query(synctex_scanner_p scanner, int page, float h, float v);
 
-    /**
-     * @brief Answer to queries
-     *
-     * @param scanner
-     * @return synctex_node_p The next node of the query,
-     *   NULL when there are no node left.
-     * @see `synctex_edit_query` and `synctex_view_query`.
-     */
-    synctex_node_p synctex_scanner_next_result(synctex_scanner_p scanner);
+/**
+ * @brief Answer to queries
+ *
+ * @param scanner
+ * @return synctex_node_p The next node of the query,
+ *   NULL when there are no node left.
+ * @see `synctex_edit_query` and `synctex_view_query`.
+ */
+synctex_node_p synctex_scanner_next_result(synctex_scanner_p scanner);
 
-    /**
-     * @brief Reset to the first result
-     *
-     * @param scanner
-     * @return synctex_status_t
-     */
-    synctex_status_t synctex_scanner_reset_result(synctex_scanner_p scanner);
-    /** @} */
+/**
+ * @brief Reset to the first result
+ *
+ * @param scanner
+ * @return synctex_status_t
+ */
+synctex_status_t synctex_scanner_reset_result(synctex_scanner_p scanner);
+/** @} */
 
-    /**
-     *  The horizontal and vertical location,
-     *  the width, height and depth of a box enclosing node.
-     *  All dimensions are given in page coordinates
-     *  as opposite to TeX coordinates.
-     *  The origin is at the top left corner of the page.
-     *  Code example for Qt5:
-     *  (from TeXworks source TWSynchronize.cpp)
-     *  QRectF nodeRect(synctex_node_box_visible_h(node),
-     *      synctex_node_box_visible_v(node) -
-     *          synctex_node_box_visible_height(node),
-     *      synctex_node_box_visible_width(node),
-     *      synctex_node_box_visible_height(node) +
-     *          synctex_node_box_visible_depth(node));
-     *  Code example for Cocoa:
-     *  NSRect bounds = [pdfPage
-     *      boundsForBox:kPDFDisplayBoxMediaBox];
-     *  NSRect nodeRect = NSMakeRect(
-     *      synctex_node_box_visible_h(node),
-     *      NSMaxY(bounds)-synctex_node_box_visible_v(node) +
-     *          synctex_node_box_visible_height(node),
-     *      synctex_node_box_visible_width(node),
-     *      synctex_node_box_visible_height(node) +
-     *          synctex_node_box_visible_depth(node)
-     *      );
-     *  The visible dimensions are bigger than real ones
-     *  to compensate 0 width boxes or nodes intentionally
-     *  put outside the box (using \kern for example).
-     *  - parameter node: a node.
-     *  - returns: a float.
-     *  - author: JL
-     */
-    float synctex_node_box_visible_h(synctex_node_p node);
-    float synctex_node_box_visible_v(synctex_node_p node);
-    float synctex_node_box_visible_width(synctex_node_p node);
-    float synctex_node_box_visible_height(synctex_node_p node);
-    float synctex_node_box_visible_depth(synctex_node_p node);
+/**
+ *  The horizontal and vertical location,
+ *  the width, height and depth of a box enclosing node.
+ *  All dimensions are given in page coordinates
+ *  as opposite to TeX coordinates.
+ *  The origin is at the top left corner of the page.
+ *  Code example for Qt5:
+ *  (from TeXworks source TWSynchronize.cpp)
+ *  QRectF nodeRect(synctex_node_box_visible_h(node),
+ *      synctex_node_box_visible_v(node) -
+ *          synctex_node_box_visible_height(node),
+ *      synctex_node_box_visible_width(node),
+ *      synctex_node_box_visible_height(node) +
+ *          synctex_node_box_visible_depth(node));
+ *  Code example for Cocoa:
+ *  NSRect bounds = [pdfPage
+ *      boundsForBox:kPDFDisplayBoxMediaBox];
+ *  NSRect nodeRect = NSMakeRect(
+ *      synctex_node_box_visible_h(node),
+ *      NSMaxY(bounds)-synctex_node_box_visible_v(node) +
+ *          synctex_node_box_visible_height(node),
+ *      synctex_node_box_visible_width(node),
+ *      synctex_node_box_visible_height(node) +
+ *          synctex_node_box_visible_depth(node)
+ *      );
+ *  The visible dimensions are bigger than real ones
+ *  to compensate 0 width boxes or nodes intentionally
+ *  put outside the box (using \kern for example).
+ *  - parameter node: a node.
+ *  - returns: a float.
+ *  - author: JL
+ */
+float synctex_node_box_visible_h(synctex_node_p node);
+float synctex_node_box_visible_v(synctex_node_p node);
+float synctex_node_box_visible_width(synctex_node_p node);
+float synctex_node_box_visible_height(synctex_node_p node);
+float synctex_node_box_visible_depth(synctex_node_p node);
 
-    /**
-     *  For quite all nodes, horizontal and vertical coordinates, and width.
-     *  All dimensions are given in page coordinates
-     *  as opposite to TeX coordinates.
-     *  The origin is at the top left corner of the page.
-     *  The visible dimensions are bigger than real ones
-     *  to compensate 0 width boxes or nodes intentionally
-     *  put outside the box (using \kern for example).
-     *  All nodes have coordinates, but all nodes don't
-     *  have non null size. For example, math nodes
-     *  have no width according to TeX, and in that case
-     *  synctex_node_visible_width simply returns 0.
-     *  The same holds for kern nodes that do not have
-     *  height nor depth, etc...
-     */
-    float synctex_node_visible_h(synctex_node_p node);
-    float synctex_node_visible_v(synctex_node_p node);
-    float synctex_node_visible_width(synctex_node_p node);
-    float synctex_node_visible_height(synctex_node_p node);
-    float synctex_node_visible_depth(synctex_node_p node);
+/**
+ *  For quite all nodes, horizontal and vertical coordinates, and width.
+ *  All dimensions are given in page coordinates
+ *  as opposite to TeX coordinates.
+ *  The origin is at the top left corner of the page.
+ *  The visible dimensions are bigger than real ones
+ *  to compensate 0 width boxes or nodes intentionally
+ *  put outside the box (using \kern for example).
+ *  All nodes have coordinates, but all nodes don't
+ *  have non null size. For example, math nodes
+ *  have no width according to TeX, and in that case
+ *  synctex_node_visible_width simply returns 0.
+ *  The same holds for kern nodes that do not have
+ *  height nor depth, etc...
+ */
+float synctex_node_visible_h(synctex_node_p node);
+float synctex_node_visible_v(synctex_node_p node);
+float synctex_node_visible_width(synctex_node_p node);
+float synctex_node_visible_height(synctex_node_p node);
+float synctex_node_visible_depth(synctex_node_p node);
 
-    /**
-     *  Given a node, access to its tag, line and column.
-     *  The line and column numbers are 1 based.
-     *  The latter is not yet fully supported in TeX,
-     *  the default implementation returns 0
-     *  which means the whole line.
-     *  synctex_node_get_name returns the path of the
-     *  TeX source file that was used to create the node.
-     *  When the tag is known, the scanner of the node
-     *  will also give that same file name, see
-     *  synctex_scanner_get_name below.
-     *  For an hbox node, the mean line is the mean
-     *  of all the lines of the child nodes.
-     *  Sometimes, when synchronization form pdf to source
-     *  fails with the line, one should try with the
-     *  mean line.
-     */
-    int synctex_node_tag(synctex_node_p node);
-    int synctex_node_line(synctex_node_p node);
-    int synctex_node_mean_line(synctex_node_p node);
-    int synctex_node_column(synctex_node_p node);
-    const char * synctex_node_get_name(synctex_node_p node);
+/**
+ *  Given a node, access to its tag, line and column.
+ *  The line and column numbers are 1 based.
+ *  The latter is not yet fully supported in TeX,
+ *  the default implementation returns 0
+ *  which means the whole line.
+ *  synctex_node_get_name returns the path of the
+ *  TeX source file that was used to create the node.
+ *  When the tag is known, the scanner of the node
+ *  will also give that same file name, see
+ *  synctex_scanner_get_name below.
+ *  For an hbox node, the mean line is the mean
+ *  of all the lines of the child nodes.
+ *  Sometimes, when synchronization form pdf to source
+ *  fails with the line, one should try with the
+ *  mean line.
+ */
+int synctex_node_tag(synctex_node_p node);
+int synctex_node_line(synctex_node_p node);
+int synctex_node_mean_line(synctex_node_p node);
+int synctex_node_column(synctex_node_p node);
+const char *synctex_node_get_name(synctex_node_p node);
 
-    /**
-     This is the page where the node appears.
-     *  This is a 1 based index as given by TeX.
-     */
-    int synctex_node_page(synctex_node_p node);
+/**
+ This is the page where the node appears.
+ *  This is a 1 based index as given by TeX.
+ */
+int synctex_node_page(synctex_node_p node);
 
-    /** @addtogroup Scanner
-     * @{
-     */
+/** @addtogroup Scanner
+ * @{
+ */
 
-    /**
-     *  Display all the information contained in the scanner.
-     *  If the records are too numerous, only the first ones are displayed.
-     *  This is mainly for informational purpose to help developers.
-     */
-    void synctex_scanner_display(synctex_scanner_p scanner);
+/**
+ *  Display all the information contained in the scanner.
+ *  If the records are too numerous, only the first ones are displayed.
+ *  This is mainly for informational purpose to help developers.
+ */
+void synctex_scanner_display(synctex_scanner_p scanner);
 
-    /*  Managing the input file names.
-     *  Given a tag, synctex_scanner_get_name will return the corresponding file name.
-     *  Conversely, given a file name, synctex_scanner_get_tag will return, the corresponding tag.
-     *  The file name must be the very same as understood by TeX.
-     *  For example, if you \input myDir/foo.tex, the file name is myDir/foo.tex.
-     *  No automatic path expansion is performed.
-     *  Finally, synctex_scanner_input is the first input node of the scanner.
-     *  To browse all the input node, use a loop like
-     *      ...
-     *      synctex_node_p = input_node;
-     *      ...
-     *      if((input_node = synctex_scanner_input(scanner))) {
-     *          do {
-     *              blah
-     *          } while((input_node=synctex_node_sibling(input_node)));
-     *     }
-     *
-     *  The output is the name that was used to create the scanner.
-     *  The synctex is the real name of the synctex file,
-     *  it was obtained from output by setting the proper file extension.
-     */
-    const char * synctex_scanner_get_name(synctex_scanner_p scanner,int tag);
+/*  Managing the input file names.
+ *  Given a tag, synctex_scanner_get_name will return the corresponding file name.
+ *  Conversely, given a file name, synctex_scanner_get_tag will return, the corresponding tag.
+ *  The file name must be the very same as understood by TeX.
+ *  For example, if you \input myDir/foo.tex, the file name is myDir/foo.tex.
+ *  No automatic path expansion is performed.
+ *  Finally, synctex_scanner_input is the first input node of the scanner.
+ *  To browse all the input node, use a loop like
+ *      ...
+ *      synctex_node_p = input_node;
+ *      ...
+ *      if((input_node = synctex_scanner_input(scanner))) {
+ *          do {
+ *              blah
+ *          } while((input_node=synctex_node_sibling(input_node)));
+ *     }
+ *
+ *  The output is the name that was used to create the scanner.
+ *  The synctex is the real name of the synctex file,
+ *  it was obtained from output by setting the proper file extension.
+ */
+const char *synctex_scanner_get_name(synctex_scanner_p scanner, int tag);
 
-    int synctex_scanner_get_tag(synctex_scanner_p scanner,const char * name);
-    /** @} */
+int synctex_scanner_get_tag(synctex_scanner_p scanner, const char *name);
+/** @} */
 
-    /** @defgroup Tree Node tree
-     *
-     * parent, child and sibling are standard names for tree nodes.
-     * The parent is one level higher,
-     * the child is one level deeper,
-     * and the sibling is at the same level.
-     * A node and its sibling have the same parent.
-     * A node is the parent of its children.
-     * A node is either the child of its parent,
-     * or belongs to the sibling chain of its parent's child.
-     * The sheet or form of a node is the topmost ancestor,
-     * it is of type sheet or form.
-     * The next node is either the child, the sibling or the parent's sibling,
-     * unless the parent is a sheet, a form or NULL.
-     * This allows to navigate through all the nodes of a given sheet node:
-     *
-     * ```C
-     * synctex_node_p node = ...;
-     * while((node = synctex_node_next(node))) {
-     *   // do something with node
-     * }
-     * ```
-     *
-     *  With `synctex_sheet_content` and `synctex_form_content`,
-     *  you can retrieve the sheet node given the page
-     *  or form tag.
-     *  The page is 1 based, according to TeX standards.
-     *  Conversely `synctex_node_parent_sheet` or
-     *  `synctex_node_parent_form` allows to retrieve
-     *  the sheet or the form containing a given node.
-     *  Notice that a node is not contained in a sheet
-     *  and a form at the same time.
-     *  Some nodes are not contained in either (handles).
-     * @{ */
+/** @defgroup Tree Node tree
+ *
+ * parent, child and sibling are standard names for tree nodes.
+ * The parent is one level higher,
+ * the child is one level deeper,
+ * and the sibling is at the same level.
+ * A node and its sibling have the same parent.
+ * A node is the parent of its children.
+ * A node is either the child of its parent,
+ * or belongs to the sibling chain of its parent's child.
+ * The sheet or form of a node is the topmost ancestor,
+ * it is of type sheet or form.
+ * The next node is either the child, the sibling or the parent's sibling,
+ * unless the parent is a sheet, a form or NULL.
+ * This allows to navigate through all the nodes of a given sheet node:
+ *
+ * ```C
+ * synctex_node_p node = ...;
+ * while((node = synctex_node_next(node))) {
+ *   // do something with node
+ * }
+ * ```
+ *
+ *  With `synctex_sheet_content` and `synctex_form_content`,
+ *  you can retrieve the sheet node given the page
+ *  or form tag.
+ *  The page is 1 based, according to TeX standards.
+ *  Conversely `synctex_node_parent_sheet` or
+ *  `synctex_node_parent_form` allows to retrieve
+ *  the sheet or the form containing a given node.
+ *  Notice that a node is not contained in a sheet
+ *  and a form at the same time.
+ *  Some nodes are not contained in either (handles).
+ * @{ */
 
-    /**
-     * @brief First input node.
-     *
-     * @param scanner
-     * @return * synctex_node_p
-     */
-    synctex_node_p synctex_scanner_input(synctex_scanner_p scanner);
-    /**
-     * @brief First input node with a given tag.
-     *
-     * Corresponds to `Input:<tag>:<file>` entries in the `.sycntex` file.
-     * @param scanner
-     * @param tag
-     * @return * synctex_node_p
-     */
-    synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner,int tag);
-    /**
-     * @brief Path to the output file
-     *
-     * @param scanner
-     * @return const char*
-     */
-    const char * synctex_scanner_get_output(synctex_scanner_p scanner);
-    /**
-     * @brief Path to the synctex file
-     *
-     * @param scanner
-     * @return const char*
-     */
-    const char * synctex_scanner_get_synctex(synctex_scanner_p scanner);
-    /**
-     * @brief Format of the output
-     *
-     * From the content of the synctex file.
-     * @param scanner
-     * @return const char*
-     */
-    const char * synctex_scanner_get_output_fmt(synctex_scanner_p scanner);
-    /** @} */
+/**
+ * @brief First input node.
+ *
+ * @param scanner
+ * @return * synctex_node_p
+ */
+synctex_node_p synctex_scanner_input(synctex_scanner_p scanner);
+/**
+ * @brief First input node with a given tag.
+ *
+ * Corresponds to `Input:<tag>:<file>` entries in the `.sycntex` file.
+ * @param scanner
+ * @param tag
+ * @return * synctex_node_p
+ */
+synctex_node_p synctex_scanner_input_with_tag(synctex_scanner_p scanner, int tag);
+/**
+ * @brief Path to the output file
+ *
+ * @param scanner
+ * @return const char*
+ */
+const char *synctex_scanner_get_output(synctex_scanner_p scanner);
+/**
+ * @brief Path to the synctex file
+ *
+ * @param scanner
+ * @return const char*
+ */
+const char *synctex_scanner_get_synctex(synctex_scanner_p scanner);
+/**
+ * @brief Format of the output
+ *
+ * From the content of the synctex file.
+ * @param scanner
+ * @return const char*
+ */
+const char *synctex_scanner_get_output_fmt(synctex_scanner_p scanner);
+/** @} */
 
-    /*  The x and y offset of the origin in TeX coordinates. The magnification
-     These are used by pdf viewers that want to display the real box size.
-     For example, getting the horizontal coordinates of a node would require
-     synctex_node_box_h(node)*synctex_scanner_magnification(scanner)+synctex_scanner_x_offset(scanner)
-     Getting its TeX width would simply require
-     synctex_node_box_width(node)*synctex_scanner_magnification(scanner)
-     but direct methods are available for that below.
-     */
+/*  The x and y offset of the origin in TeX coordinates. The magnification
+ These are used by pdf viewers that want to display the real box size.
+ For example, getting the horizontal coordinates of a node would require
+ synctex_node_box_h(node)*synctex_scanner_magnification(scanner)+synctex_scanner_x_offset(scanner)
+ Getting its TeX width would simply require
+ synctex_node_box_width(node)*synctex_scanner_magnification(scanner)
+ but direct methods are available for that below.
+ */
 
-    /**
-     * @brief Horizontal offset of coordinates.
-     *
-     * 1in default in TeX.
-     * @param scanner
-     * @return int
-     */
-    int synctex_scanner_x_offset(synctex_scanner_p scanner);
-    /**
-     * @brief Vertical offset of coordinates.
-     *
-     * 1in default in TeX.
-     * @param scanner
-     * @return int
-     */
-    int synctex_scanner_y_offset(synctex_scanner_p scanner);
-    /**
-     * @brief Magnification
-     *
-     * 1000 default in TeX.
-     * @param scanner
-     * @return float
-     */
-    float synctex_scanner_magnification(synctex_scanner_p scanner);
+/**
+ * @brief Horizontal offset of coordinates.
+ *
+ * 1in default in TeX.
+ * @param scanner
+ * @return int
+ */
+int synctex_scanner_x_offset(synctex_scanner_p scanner);
+/**
+ * @brief Vertical offset of coordinates.
+ *
+ * 1in default in TeX.
+ * @param scanner
+ * @return int
+ */
+int synctex_scanner_y_offset(synctex_scanner_p scanner);
+/**
+ * @brief Magnification
+ *
+ * 1000 default in TeX.
+ * @param scanner
+ * @return float
+ */
+float synctex_scanner_magnification(synctex_scanner_p scanner);
 
-    typedef int (synctex_printer_f) (const char *, ...);
+typedef int(synctex_printer_f)(const char *, ...);
 
-    /**
-     * @brief Dump the scanner
-     *
-     * @param scanner
-     * @param printer
-     * @return int
-     */
-    int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer);
-    /** @} */
+/**
+ * @brief Dump the scanner
+ *
+ * @param scanner
+ * @param printer
+ * @return int
+ */
+int synctex_scanner_dump(synctex_scanner_p scanner, synctex_printer_f printer);
+/** @} */
 
-    /** @addtogroup Tree
-     * @{
-     */
+/** @addtogroup Tree
+ * @{
+ */
 
-    /**
-     * @brief Parent
-     *
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_parent(synctex_node_p node);
-    /**
-     * @brief Parent sheet
-     *
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_parent_sheet(synctex_node_p node);
-    /**
-     * @brief Parent sheet
-     *
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_parent_form(synctex_node_p node);
-    /**
-     * @brief First child
-     *
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_child(synctex_node_p node);
-    /**
-     * @brief Last child
-     *
-     * Last sibling of the first child, if any.
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_last_child(synctex_node_p node);
-    /**
-     * @brief First sibling
-     *
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     */
-    synctex_node_p synctex_node_sibling(synctex_node_p node);
-    /**
-     * @brief Last sibling
-     *
-     * Last sibling of the first sibling of the node, if any,
-     * the node itself otherwise.
-     * @param node
-     * @return synctex_node_p possibly NULL.
-     * @see synctex_node_last_child
-     */
-    synctex_node_p synctex_node_last_sibling(synctex_node_p node);
-    /**
-     * @brief
-     *
-     * @param node
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_node_arg_sibling(synctex_node_p node);
+/**
+ * @brief Parent
+ *
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_parent(synctex_node_p node);
+/**
+ * @brief Parent sheet
+ *
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_parent_sheet(synctex_node_p node);
+/**
+ * @brief Parent sheet
+ *
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_parent_form(synctex_node_p node);
+/**
+ * @brief First child
+ *
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_child(synctex_node_p node);
+/**
+ * @brief Last child
+ *
+ * Last sibling of the first child, if any.
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_last_child(synctex_node_p node);
+/**
+ * @brief First sibling
+ *
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ */
+synctex_node_p synctex_node_sibling(synctex_node_p node);
+/**
+ * @brief Last sibling
+ *
+ * Last sibling of the first sibling of the node, if any,
+ * the node itself otherwise.
+ * @param node
+ * @return synctex_node_p possibly NULL.
+ * @see synctex_node_last_child
+ */
+synctex_node_p synctex_node_last_sibling(synctex_node_p node);
+/**
+ * @brief
+ *
+ * @param node
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_node_arg_sibling(synctex_node_p node);
 
-    /**
-     * @brief Next node.
-     *
-     * Deep first traversal of the tree of nodes.
-     * First child if any,
-     * first sibling if any,
-     * parent's first sibling if any,
-     * parent's parent's first sibling if any,
-     * ...
-     * @param node
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_node_next(synctex_node_p node);
+/**
+ * @brief Next node.
+ *
+ * Deep first traversal of the tree of nodes.
+ * First child if any,
+ * first sibling if any,
+ * parent's first sibling if any,
+ * parent's parent's first sibling if any,
+ * ...
+ * @param node
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_node_next(synctex_node_p node);
 
-    /**
-     *  Top level entry points.
-     *  The scanner owns a list of sheet siblings and
-     *  a list of form siblings.
-     *  Sheets or forms have one child which is a box:
-     *  their contents.
-     *  - argument page: 1 based sheet page number.
-     *  - argument tag: 1 based form tag number.
-     */
-    synctex_node_p synctex_sheet(synctex_scanner_p scanner,int page);
-    /**
-     * @brief Sheet content at a given page.
-     *
-     * @param scanner
-     * @param page
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_sheet_content(synctex_scanner_p scanner,int page);
-    /**
-     * @brief Form for a given tag
-     *
-     * @param scanner
-     * @param tag
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_form(synctex_scanner_p scanner,int tag);
-    /**
-     * @brief Form content for given tag.
-     *
-     * @param scanner
-     * @param tag
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_form_content(synctex_scanner_p scanner,int tag);
+/**
+ *  Top level entry points.
+ *  The scanner owns a list of sheet siblings and
+ *  a list of form siblings.
+ *  Sheets or forms have one child which is a box:
+ *  their contents.
+ *  - argument page: 1 based sheet page number.
+ *  - argument tag: 1 based form tag number.
+ */
+synctex_node_p synctex_sheet(synctex_scanner_p scanner, int page);
+/**
+ * @brief Sheet content at a given page.
+ *
+ * @param scanner
+ * @param page
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_sheet_content(synctex_scanner_p scanner, int page);
+/**
+ * @brief Form for a given tag
+ *
+ * @param scanner
+ * @param tag
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_form(synctex_scanner_p scanner, int tag);
+/**
+ * @brief Form content for given tag.
+ *
+ * @param scanner
+ * @param tag
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_form_content(synctex_scanner_p scanner, int tag);
 
-    /** @} */
+/** @} */
 
-    /*  This is primarily used for debugging purpose.
-     *  The second one logs information for the node and recursively displays information for its next node */
+/*  This is primarily used for debugging purpose.
+ *  The second one logs information for the node and recursively displays information for its next node */
 
-    /**
-     * @brief Log a node
-     *
-     * This is primarily used for debugging purpose.
-     * @param node
-     */
-    void synctex_node_log(synctex_node_p node);
-    /**
-     * @brief Display a node
-     *
-     * This is primarily used for debugging purpose.
-     * @param node
-     */
-    void synctex_node_display(synctex_node_p node);
+/**
+ * @brief Log a node
+ *
+ * This is primarily used for debugging purpose.
+ * @param node
+ */
+void synctex_node_log(synctex_node_p node);
+/**
+ * @brief Display a node
+ *
+ * This is primarily used for debugging purpose.
+ * @param node
+ */
+void synctex_node_display(synctex_node_p node);
 
-    /**
-     * @defgroup Geometry Node geometry
-     *
-     * For quite all nodes, horizontal, vertical coordinates, and width.
-     * These are expressed in TeX small points coordinates,
-     * with origin at the top left corner.
-     * For nodes without depth or height, 0 is returned.
-     * @{
-     */
+/**
+ * @defgroup Geometry Node geometry
+ *
+ * For quite all nodes, horizontal, vertical coordinates, and width.
+ * These are expressed in TeX small points coordinates,
+ * with origin at the top left corner.
+ * For nodes without depth or height, 0 is returned.
+ * @{
+ */
 
-    /**
-     * @brief Horizontal coordinate
-     *
-     * @param node
-     * @return int in TeX sp from top left corner of the page
-     */
-    int synctex_node_h(synctex_node_p node);
-    /**
-     * @brief Vertical coordinate
-     *
-     * @param node
-     * @return int in TeX sp from top left corner of the page
-     */
-    int synctex_node_v(synctex_node_p node);
-    /**
-     * @brief Width
-     *
-     * @param node
-     * @return int in TeX sp
-     */
-    int synctex_node_width(synctex_node_p node);
-    /**
-     * @brief Height
-     *
-     * @param node
-     * @return int in TeX sp, 0 when irrelevant
-     */
-    int synctex_node_height(synctex_node_p node);
-    /**
-     * @brief Depth
-     *
-     * @param node
-     * @return int in TeX sp, 0 when irrelevant
-     */
-    int synctex_node_depth(synctex_node_p node);
+/**
+ * @brief Horizontal coordinate
+ *
+ * @param node
+ * @return int in TeX sp from top left corner of the page
+ */
+int synctex_node_h(synctex_node_p node);
+/**
+ * @brief Vertical coordinate
+ *
+ * @param node
+ * @return int in TeX sp from top left corner of the page
+ */
+int synctex_node_v(synctex_node_p node);
+/**
+ * @brief Width
+ *
+ * @param node
+ * @return int in TeX sp
+ */
+int synctex_node_width(synctex_node_p node);
+/**
+ * @brief Height
+ *
+ * @param node
+ * @return int in TeX sp, 0 when irrelevant
+ */
+int synctex_node_height(synctex_node_p node);
+/**
+ * @brief Depth
+ *
+ * @param node
+ * @return int in TeX sp, 0 when irrelevant
+ */
+int synctex_node_depth(synctex_node_p node);
 
-    /*  For all nodes, dimensions of the enclosing box.
-     *  These are expressed in TeX small points coordinates, with origin at the top left corner.
-     *  A box is enclosing itself.
-     */
-    int synctex_node_box_h(synctex_node_p node);
-    int synctex_node_box_v(synctex_node_p node);
-    int synctex_node_box_width(synctex_node_p node);
-    int synctex_node_box_height(synctex_node_p node);
-    int synctex_node_box_depth(synctex_node_p node);
-    /** @} */
+/*  For all nodes, dimensions of the enclosing box.
+ *  These are expressed in TeX small points coordinates, with origin at the top left corner.
+ *  A box is enclosing itself.
+ */
+int synctex_node_box_h(synctex_node_p node);
+int synctex_node_box_v(synctex_node_p node);
+int synctex_node_box_width(synctex_node_p node);
+int synctex_node_box_height(synctex_node_p node);
+int synctex_node_box_depth(synctex_node_p node);
+/** @} */
 #ifdef __cplusplus
 }
 #endif

--- a/synctex_parser_advanced.h
+++ b/synctex_parser_advanced.h
@@ -1,15 +1,15 @@
 /*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
- 
+
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,7 +30,7 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
@@ -43,9 +43,9 @@
  * @brief More header declaration than in `synctex_parser.h`.
  * @version 0.1
  * @date 2024-03-22
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 /*  Here are the control characters that strat each line of the synctex output file.
@@ -84,7 +84,7 @@ extern "C" {
 #endif
     /**
      * @brief Reminder that the argument must not be NULL.
-     * 
+     *
      * Some functions require a non NULL node pointer argument.
      */
     typedef synctex_node_p synctex_non_null_node_p;
@@ -102,7 +102,7 @@ extern "C" {
      *  A friend is a node with very close tag and line numbers.
      *  Finally, the info field point to a method giving the private node info offset.
      */
-    
+
     /*
      *  These are the mask hekpers for the synctex node types.
      */
@@ -244,7 +244,7 @@ extern "C" {
         synctex_tree_spc_target_idx     =  3,
         synctex_tree_spct_handle_max    =  4,
     };
-    
+
     enum {
         /* input */
         synctex_data_input_tag_idx  =  0,
@@ -296,7 +296,7 @@ extern "C" {
 
     /*  each synctex node has a class */
     typedef struct _synctex_class_t _synctex_class_s;
-    
+
     /**
      * @brief Pointer to a pseudo class.
      * @typedef synctex_class_p
@@ -312,13 +312,13 @@ extern "C" {
      * Inspectors give access to data and tree elements.
      */
     typedef _synctex_class_s * synctex_class_p;
-    
+
     /**
      * @typedef synctex_node_p
      * @brief Pointer to a node structure
-     * 
+     *
      * The eventual target of the pointer is a private `_synctex_node_s` structure.
-     * 
+     *
      *  class is a pointer to the class object the node belongs to.
      *  implementation is meant to contain the private data of the node
      *  basically, there are 2 kinds of information: navigation information and
@@ -336,10 +336,10 @@ extern "C" {
 
     /**
      * @brief Pointer to an opaque node data structure.
-     * 
+     *
      */
     typedef _synctex_data_u * synctex_data_p;
-    
+
 #   if defined(SYNCTEX_USE_CHARINDEX)
     typedef unsigned int synctex_charindex_t;
     synctex_charindex_t synctex_node_charindex(synctex_node_p node);
@@ -357,7 +357,7 @@ extern "C" {
 #   endif
 /**
  * @brief Node data model.
- * 
+ *
  */
     struct _synctex_node_t {
         SYNCTEX_DECLARE_CHARINDEX
@@ -370,18 +370,18 @@ extern "C" {
         _synctex_data_u data[1];
 #endif
     };
-    
+
     /**
      * @brief A pointer to an node pointer.
-     * 
+     *
      * First element of an array of node pointers.
      * Mainly the list of friends of a node.
      */
     typedef synctex_node_p * synctex_node_r;
-    
+
     /**
      * @brief 2D point with integer coordinates.
-     * 
+     *
      * Used at various places.
      * For the hit point in the output file for example.
      */
@@ -391,13 +391,13 @@ extern "C" {
         /** Vertical coordinate. */
         int v;
     } synctex_point_s;
-    
+
     /**
      * @brief Pointer to a 2D point.
-     * 
+     *
      */
     typedef synctex_point_s * synctex_point_p;
-    
+
     /**
      * @brief 2D rectangle
      * Used for boxes.
@@ -408,21 +408,21 @@ extern "C" {
         /** bottom right */
         synctex_point_s max;
     } synctex_box_s;
-    
+
     /**
      * @brief Pointer to 2D rectangle
      * Used for NULL terminated lists of boxes.
      */
     typedef synctex_box_s * synctex_box_p;
-    
+
     /**
      * @brief Types of the synctex nodes.
      *
      * These are exactly the TeX nodes but somehow related.
      * No real need to use them but the compiler needs them here.
-     * 
+     *
      * Each node type uniquely identifies a node class.
-     * 
+     *
      * There are 3 kinds of nodes.
      * - primary nodes, created when parsing the `.synctex` file.
      *   They correspond to lines in the `.synctex` file.
@@ -479,12 +479,12 @@ extern "C" {
         /** Number of types */
         synctex_node_number_of_types
     } synctex_node_type_t;
-    
+
     /**
      * @brief The type of a given node, as integer.
     */
     synctex_node_type_t synctex_node_type(synctex_node_p node);
-    
+
     /**
      * @brief The type of a given node, as a human readable text.
     */
@@ -492,20 +492,20 @@ extern "C" {
 
     /**
      * @brief The node type of the target.
-     * 
-     * @param node 
-     * @return synctex_node_type_t 
+     *
+     * @param node
+     * @return synctex_node_type_t
      */
     synctex_node_type_t synctex_node_target_type(synctex_node_p node);
-    
+
     /*  Given a node, access to the location in the synctex file where it is defined.
      */
 
     int synctex_node_weight(synctex_node_p node);
     int synctex_node_child_count(synctex_node_p node);
-    
+
     /** \defgroup AdvancedGeometry Node geometry (advance)
-     * 
+     *
      *   Available in `synctex_parser_advanced.h`.
      * @{
      */
@@ -514,20 +514,20 @@ extern "C" {
     int synctex_node_box_width(synctex_node_p node);
     int synctex_node_box_height(synctex_node_p node);
     int synctex_node_box_depth(synctex_node_p node);
-    
+
     int synctex_node_hbox_h(synctex_node_p node);
     int synctex_node_hbox_v(synctex_node_p node);
     int synctex_node_hbox_width(synctex_node_p node);
     int synctex_node_hbox_height(synctex_node_p node);
     int synctex_node_hbox_depth(synctex_node_p node);
     /** @} */
-    
+
     synctex_node_p synctex_node_new(synctex_scanner_p scanner,synctex_node_type_t type);
 
     /**
      * @brief Designated scanner constructor.
-     * 
-     * @return synctex_scanner_p 
+     *
+     * @return synctex_scanner_p
      */
     synctex_scanner_p synctex_scanner_new(void);
 
@@ -536,24 +536,24 @@ extern "C" {
      */
 
 /** @defgroup Iterator Managing the answer to queries.
- *  
+ *
  * Answers to edit and view queries are special structure.
  * @{
  */
 
     /**
      * @brief Scanner display switcher getter
-     * 
-     * @param scanR 
-     * @return int 
+     *
+     * @param scanR
+     * @return int
      * @see `synctex_scanner_set_display_switcher`
      */
     int synctex_scanner_display_switcher(synctex_scanner_p scanR);
-    
+
     /**
      * @brief Scanner display switcher setter.
-     * 
-     * @param scanR 
+     *
+     * @param scanR
      * @param switcher
      * If the switcher is 0, `synctex_node_display` is disabled.
      * If the switcher is <0, `synctex_node_display` has no limit.
@@ -564,32 +564,32 @@ extern "C" {
     /** @} */
 
 /** @defgroup Iterator Managing the answer to queries.
- *  
+ *
  * Answers to edit and view queries are special structure.
  * @{
  */
 
     /**
      * @brief Structure used to traverse the answer to client queries.
-     * 
+     *
      * First answers are the best matches, according
      * to criteria explained below.
      * Next answers are not ordered.
      * Objects are handles to nodes in the synctex node tree starting at scanner.
      */
     typedef struct synctex_iterator_t synctex_iterator_s;
-    
+
     /**
      * @brief Pointer to an iterator structure.
-     * 
+     *
      */
     typedef synctex_iterator_s * synctex_iterator_p;
 
     /**
      * Designated creator for a display query.
-     * 
+     *
      * A display query is used in forward navigation from source to output.
-     * 
+     *
      * Returns NULL if the query has no answer.
      * Code example:
      * ```
@@ -606,7 +606,7 @@ extern "C" {
     synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner,const char *  name,int line,int column, int page_hint);
     /**
      *  Designated creator for an  edit query.
-     * 
+     *
      * An edit query is used in backward navigation from output to source.
      *  Code example:
      * ```
@@ -623,13 +623,13 @@ extern "C" {
     synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,float h,float v);
 
     /*
-     *  
+     *
      *  - argument iterator: the object to free...
      */
 
     /**
      * @brief Free all the resources associate to the iterator.
-     * 
+     *
      * You should free the iterator before the scanner
      * owning the nodes it iterates with.
      *
@@ -639,39 +639,39 @@ extern "C" {
 
     /**
      * @brief Whether the iterator actually points to a node.
-     * 
+     *
      * @param iterator the object to iterate on...
-     * @return synctex_bool_t 
+     * @return synctex_bool_t
      */
     synctex_bool_t synctex_iterator_has_next(synctex_iterator_p iterator);
-    
+
     /**
      * @brief Get the next query result.
-     * 
+     *
      * Returns the pointed object and advance the cursor
      * to the next object. Returns NULL and does nothing
      * if the end has already been reached.
-     * 
+     *
      * @param iterator the object to iterate on...
-     * @return synctex_node_p 
+     * @return synctex_node_p
      */
     synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator);
-    
+
     /**
      * @brief Reset the cursor position to the first result.
-     * 
+     *
      * @param iterator the object to iterate on...
      * @return int the number of results
      */
     int synctex_iterator_reset(synctex_iterator_p iterator);
-    
+
 /** @} */ // end of group Iterator
- 
+
     /**
      * @brief The number of objects left.
-     * 
+     *
      * @param iterator the object to iterate on...
-     * @return int 
+     * @return int
      */
     int synctex_iterator_count(synctex_iterator_p iterator);
 
@@ -680,10 +680,10 @@ extern "C" {
      *  The target of the node, either a handle or a proxy.
      */
     synctex_node_p synctex_node_target(synctex_node_p node);
-    
+
 #ifndef SYNCTEX_NO_UPDATER
 /** @defgroup Updater A way to alter synctex files.
- *  
+ *
  * Sometimes it is necessary to modify the `.synctex` file.
  * An updater is used to append information to the synctex file.
  * Its implementation is considered unstable.
@@ -693,20 +693,20 @@ extern "C" {
  */
    /**
     * @brief Updater data structure.
-    * 
+    *
     */
     typedef struct _synctex_updater_t _synctex_updater_s;
    /**
     * @brief Pointer to a `synctex_updater_s` updater data structure.
-    * 
+    *
     */
     typedef _synctex_updater_s * synctex_updater_p;
-    
+
     /**
      * @brief Updater designated creator.
-     * 
+     *
      * Once you are done with your whole job, free the updater.
-     * 
+     *
      * @param output name of a pdf file
      * @param directory optional directory where the pdf file is,
      *   defaults to the current working directory.
@@ -714,42 +714,42 @@ extern "C" {
      * @see synctex_updater_free
      */
     synctex_updater_p synctex_updater_new_with_output_file(const char * output, const char * directory);
-    
+
     /**
      * @brief Append a magnification record.
-     * 
-     * @param updater 
-     * @param magnification 
+     *
+     * @param updater
+     * @param magnification
      */
     void synctex_updater_append_magnification(synctex_updater_p updater, char *  magnification);
 
     /**
      * @brief Append an x-offset record.
-     * 
-     * @param updater 
-     * @param x_offset 
+     *
+     * @param updater
+     * @param x_offset
      */
     void synctex_updater_append_x_offset(synctex_updater_p updater, char *  x_offset);
 
     /**
      * @brief Append an y-offset record.
-     * 
-     * @param updater 
-     * @param y_offset 
+     *
+     * @param updater
+     * @param y_offset
      */
     void synctex_updater_append_y_offset(synctex_updater_p updater, char *  y_offset);
-    
+
     /*  You MUST free the updater, once everything is properly appended */
 
     /**
      * @brief Updater designated destructor.
-     * 
-     * @param updater 
+     *
+     * @param updater
      */
     void synctex_updater_free(synctex_updater_p updater);
 /** @} */ // end of group Updater
 #endif
-    
+
 #if defined(SYNCTEX_DEBUG)
 #   include "assert.h"
 #   define SYNCTEX_ASSERT assert
@@ -763,13 +763,13 @@ extern "C" {
 #define __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
 _Pragma("clang diagnostic push") \
 _Pragma("clang diagnostic ignored \"-Wformat-extra-args\"")
-    
+
 #define __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS _Pragma("clang diagnostic pop")
 #else
 #define __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS
 #define __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS
 #endif
-    
+
 #   define SYNCTEX_TEST_BODY(counter, condition, desc, ...) \
     do {				\
         __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
@@ -780,9 +780,9 @@ _Pragma("clang diagnostic ignored \"-Wformat-extra-args\"")
         }				\
         __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
     } while(0)
-        
+
 #   define SYNCTEX_TEST_PARAMETER(counter, condition) SYNCTEX_TEST_BODY(counter, (condition), "Invalid parameter not satisfying: %s", #condition)
-    
+
     int synctex_test_input(synctex_scanner_p scanner);
     int synctex_test_proxy(synctex_scanner_p scanner);
     int synctex_test_tree(synctex_scanner_p scanner);

--- a/synctex_parser_advanced.h
+++ b/synctex_parser_advanced.h
@@ -51,25 +51,27 @@
 /*  Here are the control characters that strat each line of the synctex output file.
  *  Their values define the meaning of the line.
  */
-#   define SYNCTEX_CHAR_BEGIN_SHEET '{'
-#   define SYNCTEX_CHAR_END_SHEET   '}'
-#   define SYNCTEX_CHAR_BEGIN_FORM  '<'
-#   define SYNCTEX_CHAR_END_FORM    '>'
-#   define SYNCTEX_CHAR_BEGIN_VBOX  '['
-#   define SYNCTEX_CHAR_END_VBOX    ']'
-#   define SYNCTEX_CHAR_BEGIN_HBOX  '('
-#   define SYNCTEX_CHAR_END_HBOX    ')'
-#   define SYNCTEX_CHAR_ANCHOR      '!'
-#   define SYNCTEX_CHAR_VOID_VBOX   'v'
-#   define SYNCTEX_CHAR_VOID_HBOX   'h'
-#   define SYNCTEX_CHAR_KERN        'k'
-#   define SYNCTEX_CHAR_GLUE        'g'
-#   define SYNCTEX_CHAR_RULE        'r'
-#   define SYNCTEX_CHAR_MATH        '$'
-#   define SYNCTEX_CHAR_FORM_REF    'f'
-#   define SYNCTEX_CHAR_BOUNDARY    'x'
-#   define SYNCTEX_CHAR_CHARACTER   'c'
-#   define SYNCTEX_CHAR_COMMENT     '%'
+// clang-format off
+#define SYNCTEX_CHAR_BEGIN_SHEET '{'
+#define SYNCTEX_CHAR_END_SHEET   '}'
+#define SYNCTEX_CHAR_BEGIN_FORM  '<'
+#define SYNCTEX_CHAR_END_FORM    '>'
+#define SYNCTEX_CHAR_BEGIN_VBOX  '['
+#define SYNCTEX_CHAR_END_VBOX    ']'
+#define SYNCTEX_CHAR_BEGIN_HBOX  '('
+#define SYNCTEX_CHAR_END_HBOX    ')'
+#define SYNCTEX_CHAR_ANCHOR      '!'
+#define SYNCTEX_CHAR_VOID_VBOX   'v'
+#define SYNCTEX_CHAR_VOID_HBOX   'h'
+#define SYNCTEX_CHAR_KERN        'k'
+#define SYNCTEX_CHAR_GLUE        'g'
+#define SYNCTEX_CHAR_RULE        'r'
+#define SYNCTEX_CHAR_MATH        '$'
+#define SYNCTEX_CHAR_FORM_REF    'f'
+#define SYNCTEX_CHAR_BOUNDARY    'x'
+#define SYNCTEX_CHAR_CHARACTER   'c'
+#define SYNCTEX_CHAR_COMMENT     '%'
+// clang-format on
 
 #   if !defined(_SYNCTEX_ONLY_CHAR_DEFINITION_)
 

--- a/synctex_parser_advanced.h
+++ b/synctex_parser_advanced.h
@@ -73,77 +73,73 @@
 #define SYNCTEX_CHAR_COMMENT     '%'
 // clang-format on
 
-#   if !defined(_SYNCTEX_ONLY_CHAR_DEFINITION_)
+#if !defined(_SYNCTEX_ONLY_CHAR_DEFINITION_)
 
 #include "synctex_parser.h"
 #include "synctex_parser_utils.h"
 
 #ifndef _SYNCTEX_PARSER_ADVANCED_H_
-#   define _SYNCTEX_PARSER_ADVANCED_H_
+#define _SYNCTEX_PARSER_ADVANCED_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    /**
-     * @brief Reminder that the argument must not be NULL.
-     *
-     * Some functions require a non NULL node pointer argument.
-     */
-    typedef synctex_node_p synctex_non_null_node_p;
+/**
+ * @brief Reminder that the argument must not be NULL.
+ *
+ * Some functions require a non NULL node pointer argument.
+ */
+typedef synctex_node_p synctex_non_null_node_p;
 
-    /*  Each node of the tree, except the scanner itself belongs to a class.
-     *  The class object is just a struct declaring the owning scanner
-     *  This is a pointer to the scanner as root of the tree.
-     *  The type is used to identify the kind of node.
-     *  The class declares pointers to a creator and a destructor method.
-     *  The log and display fields are used to log and display the node.
-     *  display will also display the child, sibling and parent sibling.
-     *  parent, child and sibling are used to navigate the tree,
-     *  from TeX box hierarchy point of view.
-     *  The friend field points to a method which allows to navigate from friend to friend.
-     *  A friend is a node with very close tag and line numbers.
-     *  Finally, the info field point to a method giving the private node info offset.
-     */
+/*  Each node of the tree, except the scanner itself belongs to a class.
+ *  The class object is just a struct declaring the owning scanner
+ *  This is a pointer to the scanner as root of the tree.
+ *  The type is used to identify the kind of node.
+ *  The class declares pointers to a creator and a destructor method.
+ *  The log and display fields are used to log and display the node.
+ *  display will also display the child, sibling and parent sibling.
+ *  parent, child and sibling are used to navigate the tree,
+ *  from TeX box hierarchy point of view.
+ *  The friend field points to a method which allows to navigate from friend to friend.
+ *  A friend is a node with very close tag and line numbers.
+ *  Finally, the info field point to a method giving the private node info offset.
+ */
 
-    /*
-     *  These are the mask hekpers for the synctex node types.
-     */
-    enum {
-        synctex_shift_root,
-        synctex_shift_no_root,
-        synctex_shift_void,
-        synctex_shift_no_void,
-        synctex_shift_box,
-        synctex_shift_no_box,
-        synctex_shift_proxy,
-        synctex_shift_no_proxy,
-        synctex_shift_h,
-        synctex_shift_v
-    };
-    /*
-     *  These are the masks for the synctex node types.
-     *  int's are 32 bits at leats.
-     */
-    enum {
-        synctex_mask_root      = 1,
-        synctex_mask_no_root   = synctex_mask_root<<1,
-        synctex_mask_void      = synctex_mask_no_root<<1,
-        synctex_mask_no_void   = synctex_mask_void<<1,
-        synctex_mask_box       = synctex_mask_no_void<<1,
-        synctex_mask_no_box    = synctex_mask_box<<1,
-        synctex_mask_proxy     = synctex_mask_no_box<<1,
-        synctex_mask_no_proxy  = synctex_mask_proxy<<1,
-        synctex_mask_h         = synctex_mask_no_proxy<<1,
-        synctex_mask_v         = synctex_mask_h<<1,
-    };
-    enum {
-        synctex_mask_non_void_hbox = synctex_mask_no_void
-        | synctex_mask_box
-        | synctex_mask_h,
-        synctex_mask_non_void_vbox = synctex_mask_no_void
-        | synctex_mask_box
-        | synctex_mask_v
-    };
+/*
+ *  These are the mask hekpers for the synctex node types.
+ */
+enum {
+    synctex_shift_root,
+    synctex_shift_no_root,
+    synctex_shift_void,
+    synctex_shift_no_void,
+    synctex_shift_box,
+    synctex_shift_no_box,
+    synctex_shift_proxy,
+    synctex_shift_no_proxy,
+    synctex_shift_h,
+    synctex_shift_v
+};
+/*
+ *  These are the masks for the synctex node types.
+ *  int's are 32 bits at leats.
+ */
+enum {
+    synctex_mask_root = 1,
+    synctex_mask_no_root = synctex_mask_root << 1,
+    synctex_mask_void = synctex_mask_no_root << 1,
+    synctex_mask_no_void = synctex_mask_void << 1,
+    synctex_mask_box = synctex_mask_no_void << 1,
+    synctex_mask_no_box = synctex_mask_box << 1,
+    synctex_mask_proxy = synctex_mask_no_box << 1,
+    synctex_mask_no_proxy = synctex_mask_proxy << 1,
+    synctex_mask_h = synctex_mask_no_proxy << 1,
+    synctex_mask_v = synctex_mask_h << 1,
+};
+enum {
+    synctex_mask_non_void_hbox = synctex_mask_no_void | synctex_mask_box | synctex_mask_h,
+    synctex_mask_non_void_vbox = synctex_mask_no_void | synctex_mask_box | synctex_mask_v
+};
 #if 0
     typedef enum {
         synctex_node_mask_sf =
@@ -204,338 +200,337 @@ extern "C" {
         |synctex_mask_proxy
     } synctex_node_mask_t;
 #endif
-    enum {
-        /* input */
-        synctex_tree_sibling_idx        =  0,
-        synctex_tree_s_input_max        =  1,
-        /* All */
-        synctex_tree_s_parent_idx       =  1,
-        synctex_tree_sp_child_idx       =  2,
-        synctex_tree_spc_friend_idx     =  3,
-        synctex_tree_spcf_last_idx      =  4,
-        synctex_tree_spcfl_vbox_max     =  5,
-        /* hbox supplement */
-        synctex_tree_spcfl_next_hbox_idx  =  5,
-        synctex_tree_spcfln_hbox_max      =  6,
-        /* hbox proxy supplement */
-        synctex_tree_spcfln_target_idx        =  6,
-        synctex_tree_spcflnt_proxy_hbox_max   =  7,
-        /* vbox proxy supplement */
-        synctex_tree_spcfl_target_idx         =  5,
-        synctex_tree_spcflt_proxy_vbox_max    =  6,
-        /*  spf supplement*/
-        synctex_tree_sp_friend_idx  =  2,
-        synctex_tree_spf_max        =  3,
-        /*  box boundary supplement */
-        synctex_tree_spf_arg_sibling_idx   =  3,
-        synctex_tree_spfa_max              =  4,
-        /*  proxy supplement */
-        synctex_tree_spf_target_idx    =  3,
-        synctex_tree_spft_proxy_max    =  4,
-        /*  last proxy supplement */
-        synctex_tree_spfa_target_idx      =  4,
-        synctex_tree_spfat_proxy_last_max =  5,
-        /* sheet supplement */
-        synctex_tree_s_child_idx        =  1,
-        synctex_tree_sc_next_hbox_idx   =  2,
-        synctex_tree_scn_sheet_max      =  3,
-        /* form supplement */
-        synctex_tree_sc_target_idx      =  2,
-        synctex_tree_sct_form_max       =  3,
-        /* spct */
-        synctex_tree_spc_target_idx     =  3,
-        synctex_tree_spct_handle_max    =  4,
-    };
+enum {
+    /* input */
+    synctex_tree_sibling_idx = 0,
+    synctex_tree_s_input_max = 1,
+    /* All */
+    synctex_tree_s_parent_idx = 1,
+    synctex_tree_sp_child_idx = 2,
+    synctex_tree_spc_friend_idx = 3,
+    synctex_tree_spcf_last_idx = 4,
+    synctex_tree_spcfl_vbox_max = 5,
+    /* hbox supplement */
+    synctex_tree_spcfl_next_hbox_idx = 5,
+    synctex_tree_spcfln_hbox_max = 6,
+    /* hbox proxy supplement */
+    synctex_tree_spcfln_target_idx = 6,
+    synctex_tree_spcflnt_proxy_hbox_max = 7,
+    /* vbox proxy supplement */
+    synctex_tree_spcfl_target_idx = 5,
+    synctex_tree_spcflt_proxy_vbox_max = 6,
+    /*  spf supplement*/
+    synctex_tree_sp_friend_idx = 2,
+    synctex_tree_spf_max = 3,
+    /*  box boundary supplement */
+    synctex_tree_spf_arg_sibling_idx = 3,
+    synctex_tree_spfa_max = 4,
+    /*  proxy supplement */
+    synctex_tree_spf_target_idx = 3,
+    synctex_tree_spft_proxy_max = 4,
+    /*  last proxy supplement */
+    synctex_tree_spfa_target_idx = 4,
+    synctex_tree_spfat_proxy_last_max = 5,
+    /* sheet supplement */
+    synctex_tree_s_child_idx = 1,
+    synctex_tree_sc_next_hbox_idx = 2,
+    synctex_tree_scn_sheet_max = 3,
+    /* form supplement */
+    synctex_tree_sc_target_idx = 2,
+    synctex_tree_sct_form_max = 3,
+    /* spct */
+    synctex_tree_spc_target_idx = 3,
+    synctex_tree_spct_handle_max = 4,
+};
 
-    enum {
-        /* input */
-        synctex_data_input_tag_idx  =  0,
-        synctex_data_input_line_idx =  1,
-        synctex_data_input_name_idx =  2,
-        synctex_data_input_tln_max  =  3,
-        /* sheet */
-        synctex_data_sheet_page_idx =  0,
-        synctex_data_p_sheet_max    =  1,
-        /* form */
-        synctex_data_form_tag_idx   =  0,
-        synctex_data_t_form_max     =  1,
-        /* tlchv */
-        synctex_data_tag_idx        =  0,
-        synctex_data_line_idx       =  1,
-        synctex_data_column_idx     =  2,
-        synctex_data_h_idx          =  3,
-        synctex_data_v_idx          =  4,
-        synctex_data_tlchv_max      =  5,
-        /* tlchvw */
-        synctex_data_width_idx      =  5,
-        synctex_data_tlchvw_max     =  6,
-        /* box */
-        synctex_data_height_idx     =  6,
-        synctex_data_depth_idx      =  7,
-        synctex_data_box_max        =  8,
-        /* hbox supplement */
-        synctex_data_mean_line_idx  =  8,
-        synctex_data_weight_idx     =  9,
-        synctex_data_h_V_idx        = 10,
-        synctex_data_v_V_idx        = 11,
-        synctex_data_width_V_idx    = 12,
-        synctex_data_height_V_idx   = 13,
-        synctex_data_depth_V_idx    = 14,
-        synctex_data_hbox_max       = 15,
-        /* ref */
-        synctex_data_ref_tag_idx    =  0,
-        synctex_data_ref_h_idx      =  1,
-        synctex_data_ref_v_idx      =  2,
-        synctex_data_ref_thv_max    =  3,
-        /* proxy */
-        synctex_data_proxy_h_idx    =  0,
-        synctex_data_proxy_v_idx    =  1,
-        synctex_data_proxy_hv_max   =  2,
-        /* handle */
-        synctex_data_handle_w_idx   =  0,
-        synctex_data_handle_w_max   =  1,
-    };
+enum {
+    /* input */
+    synctex_data_input_tag_idx = 0,
+    synctex_data_input_line_idx = 1,
+    synctex_data_input_name_idx = 2,
+    synctex_data_input_tln_max = 3,
+    /* sheet */
+    synctex_data_sheet_page_idx = 0,
+    synctex_data_p_sheet_max = 1,
+    /* form */
+    synctex_data_form_tag_idx = 0,
+    synctex_data_t_form_max = 1,
+    /* tlchv */
+    synctex_data_tag_idx = 0,
+    synctex_data_line_idx = 1,
+    synctex_data_column_idx = 2,
+    synctex_data_h_idx = 3,
+    synctex_data_v_idx = 4,
+    synctex_data_tlchv_max = 5,
+    /* tlchvw */
+    synctex_data_width_idx = 5,
+    synctex_data_tlchvw_max = 6,
+    /* box */
+    synctex_data_height_idx = 6,
+    synctex_data_depth_idx = 7,
+    synctex_data_box_max = 8,
+    /* hbox supplement */
+    synctex_data_mean_line_idx = 8,
+    synctex_data_weight_idx = 9,
+    synctex_data_h_V_idx = 10,
+    synctex_data_v_V_idx = 11,
+    synctex_data_width_V_idx = 12,
+    synctex_data_height_V_idx = 13,
+    synctex_data_depth_V_idx = 14,
+    synctex_data_hbox_max = 15,
+    /* ref */
+    synctex_data_ref_tag_idx = 0,
+    synctex_data_ref_h_idx = 1,
+    synctex_data_ref_v_idx = 2,
+    synctex_data_ref_thv_max = 3,
+    /* proxy */
+    synctex_data_proxy_h_idx = 0,
+    synctex_data_proxy_v_idx = 1,
+    synctex_data_proxy_hv_max = 2,
+    /* handle */
+    synctex_data_handle_w_idx = 0,
+    synctex_data_handle_w_max = 1,
+};
 
-    /*  each synctex node has a class */
-    typedef struct _synctex_class_t _synctex_class_s;
+/*  each synctex node has a class */
+typedef struct _synctex_class_t _synctex_class_s;
 
-    /**
-     * @brief Pointer to a pseudo class.
-     * @typedef synctex_class_p
-     * @author: Jérôme LAURENS
-     *
-     * Each node has a class, it is therefore called an object.
-     * Each class has a unique scanner.
-     * Each class has a type which is a unique identifier.
-     * The class points to various methods,
-     * each of them vary amongst objects.
-     * Each class has a data model which stores node's attributes.
-     * Each class has an tree model which stores children and parent.
-     * Inspectors give access to data and tree elements.
-     */
-    typedef _synctex_class_s * synctex_class_p;
+/**
+ * @brief Pointer to a pseudo class.
+ * @typedef synctex_class_p
+ * @author: Jérôme LAURENS
+ *
+ * Each node has a class, it is therefore called an object.
+ * Each class has a unique scanner.
+ * Each class has a type which is a unique identifier.
+ * The class points to various methods,
+ * each of them vary amongst objects.
+ * Each class has a data model which stores node's attributes.
+ * Each class has an tree model which stores children and parent.
+ * Inspectors give access to data and tree elements.
+ */
+typedef _synctex_class_s *synctex_class_p;
 
-    /**
-     * @typedef synctex_node_p
-     * @brief Pointer to a node structure
-     *
-     * The eventual target of the pointer is a private `_synctex_node_s` structure.
-     *
-     *  class is a pointer to the class object the node belongs to.
-     *  implementation is meant to contain the private data of the node
-     *  basically, there are 2 kinds of information: navigation information and
-     *  synctex information. Both will depend on the type of the node,
-     *  thus different nodes will have different private data.
-     *  There is no inheritancy overhead.
-     */
+/**
+ * @typedef synctex_node_p
+ * @brief Pointer to a node structure
+ *
+ * The eventual target of the pointer is a private `_synctex_node_s` structure.
+ *
+ *  class is a pointer to the class object the node belongs to.
+ *  implementation is meant to contain the private data of the node
+ *  basically, there are 2 kinds of information: navigation information and
+ *  synctex information. Both will depend on the type of the node,
+ *  thus different nodes will have different private data.
+ *  There is no inheritancy overhead.
+ */
 
-    typedef union {
-        synctex_node_p as_node;
-        int    as_integer;
-        char * as_string;
-        void * as_pointer;
-    } _synctex_data_u;
+typedef union {
+    synctex_node_p as_node;
+    int as_integer;
+    char *as_string;
+    void *as_pointer;
+} _synctex_data_u;
 
-    /**
-     * @brief Pointer to an opaque node data structure.
-     *
-     */
-    typedef _synctex_data_u * synctex_data_p;
+/**
+ * @brief Pointer to an opaque node data structure.
+ *
+ */
+typedef _synctex_data_u *synctex_data_p;
 
-#   if defined(SYNCTEX_USE_CHARINDEX)
-    typedef unsigned int synctex_charindex_t;
-    synctex_charindex_t synctex_node_charindex(synctex_node_p node);
-    typedef synctex_charindex_t synctex_lineindex_t;
-    synctex_lineindex_t synctex_node_lineindex(synctex_node_p node);
-    synctex_node_p synctex_scanner_handle(synctex_scanner_p scanner);
-#       define SYNCTEX_DECLARE_CHARINDEX \
-            synctex_charindex_t char_index;\
-            synctex_lineindex_t line_index;
-#       define SYNCTEX_DECLARE_CHAR_OFFSET \
-            synctex_charindex_t charindex_offset;
-#   else
-#       define SYNCTEX_DECLARE_CHARINDEX
-#       define SYNCTEX_DECLARE_CHAR_OFFSET
-#   endif
+#if defined(SYNCTEX_USE_CHARINDEX)
+typedef unsigned int synctex_charindex_t;
+synctex_charindex_t synctex_node_charindex(synctex_node_p node);
+typedef synctex_charindex_t synctex_lineindex_t;
+synctex_lineindex_t synctex_node_lineindex(synctex_node_p node);
+synctex_node_p synctex_scanner_handle(synctex_scanner_p scanner);
+#define SYNCTEX_DECLARE_CHARINDEX                                                                                                                              \
+    synctex_charindex_t char_index;                                                                                                                            \
+    synctex_lineindex_t line_index;
+#define SYNCTEX_DECLARE_CHAR_OFFSET synctex_charindex_t charindex_offset;
+#else
+#define SYNCTEX_DECLARE_CHARINDEX
+#define SYNCTEX_DECLARE_CHAR_OFFSET
+#endif
 /**
  * @brief Node data model.
  *
  */
-    struct _synctex_node_t {
-        SYNCTEX_DECLARE_CHARINDEX
-        /** Each node has an associate class. */
-        synctex_class_p class_;
+struct _synctex_node_t {
+    SYNCTEX_DECLARE_CHARINDEX
+    /** Each node has an associate class. */
+    synctex_class_p class_;
 #ifdef DEBUG
-        _synctex_data_u data[22];
+    _synctex_data_u data[22];
 #else
-        /** Each node has associate data. */
-        _synctex_data_u data[1];
+    /** Each node has associate data. */
+    _synctex_data_u data[1];
 #endif
-    };
+};
 
-    /**
-     * @brief A pointer to an node pointer.
-     *
-     * First element of an array of node pointers.
-     * Mainly the list of friends of a node.
-     */
-    typedef synctex_node_p * synctex_node_r;
+/**
+ * @brief A pointer to an node pointer.
+ *
+ * First element of an array of node pointers.
+ * Mainly the list of friends of a node.
+ */
+typedef synctex_node_p *synctex_node_r;
 
-    /**
-     * @brief 2D point with integer coordinates.
-     *
-     * Used at various places.
-     * For the hit point in the output file for example.
-     */
-    typedef struct {
-        /** Horizontal coordinate. */
-        int h;
-        /** Vertical coordinate. */
-        int v;
-    } synctex_point_s;
+/**
+ * @brief 2D point with integer coordinates.
+ *
+ * Used at various places.
+ * For the hit point in the output file for example.
+ */
+typedef struct {
+    /** Horizontal coordinate. */
+    int h;
+    /** Vertical coordinate. */
+    int v;
+} synctex_point_s;
 
-    /**
-     * @brief Pointer to a 2D point.
-     *
-     */
-    typedef synctex_point_s * synctex_point_p;
+/**
+ * @brief Pointer to a 2D point.
+ *
+ */
+typedef synctex_point_s *synctex_point_p;
 
-    /**
-     * @brief 2D rectangle
-     * Used for boxes.
-     */
-    typedef struct {
-        /** top left */
-        synctex_point_s min;
-        /** bottom right */
-        synctex_point_s max;
-    } synctex_box_s;
+/**
+ * @brief 2D rectangle
+ * Used for boxes.
+ */
+typedef struct {
+    /** top left */
+    synctex_point_s min;
+    /** bottom right */
+    synctex_point_s max;
+} synctex_box_s;
 
-    /**
-     * @brief Pointer to 2D rectangle
-     * Used for NULL terminated lists of boxes.
-     */
-    typedef synctex_box_s * synctex_box_p;
+/**
+ * @brief Pointer to 2D rectangle
+ * Used for NULL terminated lists of boxes.
+ */
+typedef synctex_box_s *synctex_box_p;
 
-    /**
-     * @brief Types of the synctex nodes.
-     *
-     * These are exactly the TeX nodes but somehow related.
-     * No real need to use them but the compiler needs them here.
-     *
-     * Each node type uniquely identifies a node class.
-     *
-     * There are 3 kinds of nodes.
-     * - primary nodes, created when parsing the `.synctex` file.
-     *   They correspond to lines in the `.synctex` file.
-     * - proxies, used to support pdf forms,
-     *   The ref primary nodes are replaced by a tree
-     *   of proxy nodes which duplicate the tree of primary
-     *   nodes available in the refered form.
-     *   Roughly speaking, the primary nodes of the form
-     *   know what to display, the proxy nodes know where.
-     * - handles are used in queries. They point to either
-     *   primary nodes or proxies.
-     */
-    typedef enum {
-        /** No correspondance in `.synctex` file. */
-        synctex_node_type_none = 0,
-        /** line starting with `Input:` */
-        synctex_node_type_input,
-        /** line starting with `{` */
-        synctex_node_type_sheet,
-        /** line starting with `<` */
-        synctex_node_type_form,
-        /** line starting with `f` */
-        synctex_node_type_ref,
-        /** line starting with `[` */
-        synctex_node_type_vbox,/*5*/
-        /** line starting with `v` */
-        synctex_node_type_void_vbox,
-        /** line starting with `(` */
-        synctex_node_type_hbox,
-        /** line starting with `h` */
-        synctex_node_type_void_hbox,
-        /** line starting with `k` */
-        synctex_node_type_kern,
-        /** line starting with `g` */
-        synctex_node_type_glue,/*10*/
-        /** line starting with `r` */
-        synctex_node_type_rule,
-        /** line starting with `$` */
-        synctex_node_type_math,
-        /** line starting with `x` */
-        synctex_node_type_boundary,
-        /** Undocumented */
-        synctex_node_type_box_bdry,
-        /** Undocumented */
-        synctex_node_type_proxy,/*15*/
-        /** Undocumented */
-        synctex_node_type_proxy_last,
-        /** Undocumented */
-        synctex_node_type_proxy_vbox,
-        /** Undocumented */
-        synctex_node_type_proxy_hbox,
-        /** Undocumented */
-        synctex_node_type_handle,
-        /** Number of types */
-        synctex_node_number_of_types
-    } synctex_node_type_t;
+/**
+ * @brief Types of the synctex nodes.
+ *
+ * These are exactly the TeX nodes but somehow related.
+ * No real need to use them but the compiler needs them here.
+ *
+ * Each node type uniquely identifies a node class.
+ *
+ * There are 3 kinds of nodes.
+ * - primary nodes, created when parsing the `.synctex` file.
+ *   They correspond to lines in the `.synctex` file.
+ * - proxies, used to support pdf forms,
+ *   The ref primary nodes are replaced by a tree
+ *   of proxy nodes which duplicate the tree of primary
+ *   nodes available in the refered form.
+ *   Roughly speaking, the primary nodes of the form
+ *   know what to display, the proxy nodes know where.
+ * - handles are used in queries. They point to either
+ *   primary nodes or proxies.
+ */
+typedef enum {
+    /** No correspondance in `.synctex` file. */
+    synctex_node_type_none = 0,
+    /** line starting with `Input:` */
+    synctex_node_type_input,
+    /** line starting with `{` */
+    synctex_node_type_sheet,
+    /** line starting with `<` */
+    synctex_node_type_form,
+    /** line starting with `f` */
+    synctex_node_type_ref,
+    /** line starting with `[` */
+    synctex_node_type_vbox, /*5*/
+    /** line starting with `v` */
+    synctex_node_type_void_vbox,
+    /** line starting with `(` */
+    synctex_node_type_hbox,
+    /** line starting with `h` */
+    synctex_node_type_void_hbox,
+    /** line starting with `k` */
+    synctex_node_type_kern,
+    /** line starting with `g` */
+    synctex_node_type_glue, /*10*/
+    /** line starting with `r` */
+    synctex_node_type_rule,
+    /** line starting with `$` */
+    synctex_node_type_math,
+    /** line starting with `x` */
+    synctex_node_type_boundary,
+    /** Undocumented */
+    synctex_node_type_box_bdry,
+    /** Undocumented */
+    synctex_node_type_proxy, /*15*/
+    /** Undocumented */
+    synctex_node_type_proxy_last,
+    /** Undocumented */
+    synctex_node_type_proxy_vbox,
+    /** Undocumented */
+    synctex_node_type_proxy_hbox,
+    /** Undocumented */
+    synctex_node_type_handle,
+    /** Number of types */
+    synctex_node_number_of_types
+} synctex_node_type_t;
 
-    /**
-     * @brief The type of a given node, as integer.
-    */
-    synctex_node_type_t synctex_node_type(synctex_node_p node);
+/**
+ * @brief The type of a given node, as integer.
+ */
+synctex_node_type_t synctex_node_type(synctex_node_p node);
 
-    /**
-     * @brief The type of a given node, as a human readable text.
-    */
-    const char * synctex_node_isa(synctex_node_p node);
+/**
+ * @brief The type of a given node, as a human readable text.
+ */
+const char *synctex_node_isa(synctex_node_p node);
 
-    /**
-     * @brief The node type of the target.
-     *
-     * @param node
-     * @return synctex_node_type_t
-     */
-    synctex_node_type_t synctex_node_target_type(synctex_node_p node);
+/**
+ * @brief The node type of the target.
+ *
+ * @param node
+ * @return synctex_node_type_t
+ */
+synctex_node_type_t synctex_node_target_type(synctex_node_p node);
 
-    /*  Given a node, access to the location in the synctex file where it is defined.
-     */
+/*  Given a node, access to the location in the synctex file where it is defined.
+ */
 
-    int synctex_node_weight(synctex_node_p node);
-    int synctex_node_child_count(synctex_node_p node);
+int synctex_node_weight(synctex_node_p node);
+int synctex_node_child_count(synctex_node_p node);
 
-    /** \defgroup AdvancedGeometry Node geometry (advance)
-     *
-     *   Available in `synctex_parser_advanced.h`.
-     * @{
-     */
-    int synctex_node_box_h(synctex_node_p node);
-    int synctex_node_box_v(synctex_node_p node);
-    int synctex_node_box_width(synctex_node_p node);
-    int synctex_node_box_height(synctex_node_p node);
-    int synctex_node_box_depth(synctex_node_p node);
+/** \defgroup AdvancedGeometry Node geometry (advance)
+ *
+ *   Available in `synctex_parser_advanced.h`.
+ * @{
+ */
+int synctex_node_box_h(synctex_node_p node);
+int synctex_node_box_v(synctex_node_p node);
+int synctex_node_box_width(synctex_node_p node);
+int synctex_node_box_height(synctex_node_p node);
+int synctex_node_box_depth(synctex_node_p node);
 
-    int synctex_node_hbox_h(synctex_node_p node);
-    int synctex_node_hbox_v(synctex_node_p node);
-    int synctex_node_hbox_width(synctex_node_p node);
-    int synctex_node_hbox_height(synctex_node_p node);
-    int synctex_node_hbox_depth(synctex_node_p node);
-    /** @} */
+int synctex_node_hbox_h(synctex_node_p node);
+int synctex_node_hbox_v(synctex_node_p node);
+int synctex_node_hbox_width(synctex_node_p node);
+int synctex_node_hbox_height(synctex_node_p node);
+int synctex_node_hbox_depth(synctex_node_p node);
+/** @} */
 
-    synctex_node_p synctex_node_new(synctex_scanner_p scanner,synctex_node_type_t type);
+synctex_node_p synctex_node_new(synctex_scanner_p scanner, synctex_node_type_t type);
 
-    /**
-     * @brief Designated scanner constructor.
-     *
-     * @return synctex_scanner_p
-     */
-    synctex_scanner_p synctex_scanner_new(void);
+/**
+ * @brief Designated scanner constructor.
+ *
+ * @return synctex_scanner_p
+ */
+synctex_scanner_p synctex_scanner_new(void);
 
-    /** \addtogroup Scanner
-     * @{
-     */
+/** \addtogroup Scanner
+ * @{
+ */
 
 /** @defgroup Iterator Managing the answer to queries.
  *
@@ -543,27 +538,27 @@ extern "C" {
  * @{
  */
 
-    /**
-     * @brief Scanner display switcher getter
-     *
-     * @param scanR
-     * @return int
-     * @see `synctex_scanner_set_display_switcher`
-     */
-    int synctex_scanner_display_switcher(synctex_scanner_p scanR);
+/**
+ * @brief Scanner display switcher getter
+ *
+ * @param scanR
+ * @return int
+ * @see `synctex_scanner_set_display_switcher`
+ */
+int synctex_scanner_display_switcher(synctex_scanner_p scanR);
 
-    /**
-     * @brief Scanner display switcher setter.
-     *
-     * @param scanR
-     * @param switcher
-     * If the switcher is 0, `synctex_node_display` is disabled.
-     * If the switcher is <0, `synctex_node_display` has no limit.
-     * If the switcher is >0, only the first switcher (as number) nodes are displayed.
-     */
-    void synctex_scanner_set_display_switcher(synctex_scanner_p scanR, int switcher);
+/**
+ * @brief Scanner display switcher setter.
+ *
+ * @param scanR
+ * @param switcher
+ * If the switcher is 0, `synctex_node_display` is disabled.
+ * If the switcher is <0, `synctex_node_display` has no limit.
+ * If the switcher is >0, only the first switcher (as number) nodes are displayed.
+ */
+void synctex_scanner_set_display_switcher(synctex_scanner_p scanR, int switcher);
 
-    /** @} */
+/** @} */
 
 /** @defgroup Iterator Managing the answer to queries.
  *
@@ -571,117 +566,116 @@ extern "C" {
  * @{
  */
 
-    /**
-     * @brief Structure used to traverse the answer to client queries.
-     *
-     * First answers are the best matches, according
-     * to criteria explained below.
-     * Next answers are not ordered.
-     * Objects are handles to nodes in the synctex node tree starting at scanner.
-     */
-    typedef struct synctex_iterator_t synctex_iterator_s;
+/**
+ * @brief Structure used to traverse the answer to client queries.
+ *
+ * First answers are the best matches, according
+ * to criteria explained below.
+ * Next answers are not ordered.
+ * Objects are handles to nodes in the synctex node tree starting at scanner.
+ */
+typedef struct synctex_iterator_t synctex_iterator_s;
 
-    /**
-     * @brief Pointer to an iterator structure.
-     *
-     */
-    typedef synctex_iterator_s * synctex_iterator_p;
+/**
+ * @brief Pointer to an iterator structure.
+ *
+ */
+typedef synctex_iterator_s *synctex_iterator_p;
 
-    /**
-     * Designated creator for a display query.
-     *
-     * A display query is used in forward navigation from source to output.
-     *
-     * Returns NULL if the query has no answer.
-     * Code example:
-     * ```
-     *    synctex_iterator_p iterator = NULL;
-     *    if ((iterator = synctex_iterator_new_display(...)) {
-     *      synctex_node_p node = NULL;
-     *      while((node = synctex_iterator_next_result(iterator))) {
-     *        <do something with node...>
-     *      }
-     *      synctex_iterator_free(iterator);
-     *    }
-     * ```
-     */
-    synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner,const char *  name,int line,int column, int page_hint);
-    /**
-     *  Designated creator for an  edit query.
-     *
-     * An edit query is used in backward navigation from output to source.
-     *  Code example:
-     * ```
-     *    synctex_iterator_p iterator = NULL;
-     *    if ((iterator = synctex_iterator_new_edit(...)) {
-     *      synctex_node_p node = NULL;
-     *      while((node = synctex_iterator_next_result(iterator))) {
-     *        <do something with node...>
-     *      }
-     *      synctex_iterator_free(iterator);
-     *    }
-     * ```
-     */
-    synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner,int page,float h,float v);
+/**
+ * Designated creator for a display query.
+ *
+ * A display query is used in forward navigation from source to output.
+ *
+ * Returns NULL if the query has no answer.
+ * Code example:
+ * ```
+ *    synctex_iterator_p iterator = NULL;
+ *    if ((iterator = synctex_iterator_new_display(...)) {
+ *      synctex_node_p node = NULL;
+ *      while((node = synctex_iterator_next_result(iterator))) {
+ *        <do something with node...>
+ *      }
+ *      synctex_iterator_free(iterator);
+ *    }
+ * ```
+ */
+synctex_iterator_p synctex_iterator_new_display(synctex_scanner_p scanner, const char *name, int line, int column, int page_hint);
+/**
+ *  Designated creator for an  edit query.
+ *
+ * An edit query is used in backward navigation from output to source.
+ *  Code example:
+ * ```
+ *    synctex_iterator_p iterator = NULL;
+ *    if ((iterator = synctex_iterator_new_edit(...)) {
+ *      synctex_node_p node = NULL;
+ *      while((node = synctex_iterator_next_result(iterator))) {
+ *        <do something with node...>
+ *      }
+ *      synctex_iterator_free(iterator);
+ *    }
+ * ```
+ */
+synctex_iterator_p synctex_iterator_new_edit(synctex_scanner_p scanner, int page, float h, float v);
 
-    /*
-     *
-     *  - argument iterator: the object to free...
-     */
+/*
+ *
+ *  - argument iterator: the object to free...
+ */
 
-    /**
-     * @brief Free all the resources associate to the iterator.
-     *
-     * You should free the iterator before the scanner
-     * owning the nodes it iterates with.
-     *
-     * @param iterator the object to free...
-     */
-    void synctex_iterator_free(synctex_iterator_p iterator);
+/**
+ * @brief Free all the resources associate to the iterator.
+ *
+ * You should free the iterator before the scanner
+ * owning the nodes it iterates with.
+ *
+ * @param iterator the object to free...
+ */
+void synctex_iterator_free(synctex_iterator_p iterator);
 
-    /**
-     * @brief Whether the iterator actually points to a node.
-     *
-     * @param iterator the object to iterate on...
-     * @return synctex_bool_t
-     */
-    synctex_bool_t synctex_iterator_has_next(synctex_iterator_p iterator);
+/**
+ * @brief Whether the iterator actually points to a node.
+ *
+ * @param iterator the object to iterate on...
+ * @return synctex_bool_t
+ */
+synctex_bool_t synctex_iterator_has_next(synctex_iterator_p iterator);
 
-    /**
-     * @brief Get the next query result.
-     *
-     * Returns the pointed object and advance the cursor
-     * to the next object. Returns NULL and does nothing
-     * if the end has already been reached.
-     *
-     * @param iterator the object to iterate on...
-     * @return synctex_node_p
-     */
-    synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator);
+/**
+ * @brief Get the next query result.
+ *
+ * Returns the pointed object and advance the cursor
+ * to the next object. Returns NULL and does nothing
+ * if the end has already been reached.
+ *
+ * @param iterator the object to iterate on...
+ * @return synctex_node_p
+ */
+synctex_node_p synctex_iterator_next_result(synctex_iterator_p iterator);
 
-    /**
-     * @brief Reset the cursor position to the first result.
-     *
-     * @param iterator the object to iterate on...
-     * @return int the number of results
-     */
-    int synctex_iterator_reset(synctex_iterator_p iterator);
+/**
+ * @brief Reset the cursor position to the first result.
+ *
+ * @param iterator the object to iterate on...
+ * @return int the number of results
+ */
+int synctex_iterator_reset(synctex_iterator_p iterator);
 
 /** @} */ // end of group Iterator
 
-    /**
-     * @brief The number of objects left.
-     *
-     * @param iterator the object to iterate on...
-     * @return int
-     */
-    int synctex_iterator_count(synctex_iterator_p iterator);
+/**
+ * @brief The number of objects left.
+ *
+ * @param iterator the object to iterate on...
+ * @return int
+ */
+int synctex_iterator_count(synctex_iterator_p iterator);
 
-
-    /**
-     *  The target of the node, either a handle or a proxy.
-     */
-    synctex_node_p synctex_node_target(synctex_node_p node);
+/**
+ *  The target of the node, either a handle or a proxy.
+ */
+synctex_node_p synctex_node_target(synctex_node_p node);
 
 #ifndef SYNCTEX_NO_UPDATER
 /** @defgroup Updater A way to alter synctex files.
@@ -693,78 +687,76 @@ extern "C" {
  * that could occur while postprocessing files by dvipdf like filters.
  * @{
  */
-   /**
-    * @brief Updater data structure.
-    *
-    */
-    typedef struct _synctex_updater_t _synctex_updater_s;
-   /**
-    * @brief Pointer to a `synctex_updater_s` updater data structure.
-    *
-    */
-    typedef _synctex_updater_s * synctex_updater_p;
+/**
+ * @brief Updater data structure.
+ *
+ */
+typedef struct _synctex_updater_t _synctex_updater_s;
+/**
+ * @brief Pointer to a `synctex_updater_s` updater data structure.
+ *
+ */
+typedef _synctex_updater_s *synctex_updater_p;
 
-    /**
-     * @brief Updater designated creator.
-     *
-     * Once you are done with your whole job, free the updater.
-     *
-     * @param output name of a pdf file
-     * @param directory optional directory where the pdf file is,
-     *   defaults to the current working directory.
-     * @return synctex_updater_p
-     * @see synctex_updater_free
-     */
-    synctex_updater_p synctex_updater_new_with_output_file(const char * output, const char * directory);
+/**
+ * @brief Updater designated creator.
+ *
+ * Once you are done with your whole job, free the updater.
+ *
+ * @param output name of a pdf file
+ * @param directory optional directory where the pdf file is,
+ *   defaults to the current working directory.
+ * @return synctex_updater_p
+ * @see synctex_updater_free
+ */
+synctex_updater_p synctex_updater_new_with_output_file(const char *output, const char *directory);
 
-    /**
-     * @brief Append a magnification record.
-     *
-     * @param updater
-     * @param magnification
-     */
-    void synctex_updater_append_magnification(synctex_updater_p updater, char *  magnification);
+/**
+ * @brief Append a magnification record.
+ *
+ * @param updater
+ * @param magnification
+ */
+void synctex_updater_append_magnification(synctex_updater_p updater, char *magnification);
 
-    /**
-     * @brief Append an x-offset record.
-     *
-     * @param updater
-     * @param x_offset
-     */
-    void synctex_updater_append_x_offset(synctex_updater_p updater, char *  x_offset);
+/**
+ * @brief Append an x-offset record.
+ *
+ * @param updater
+ * @param x_offset
+ */
+void synctex_updater_append_x_offset(synctex_updater_p updater, char *x_offset);
 
-    /**
-     * @brief Append an y-offset record.
-     *
-     * @param updater
-     * @param y_offset
-     */
-    void synctex_updater_append_y_offset(synctex_updater_p updater, char *  y_offset);
+/**
+ * @brief Append an y-offset record.
+ *
+ * @param updater
+ * @param y_offset
+ */
+void synctex_updater_append_y_offset(synctex_updater_p updater, char *y_offset);
 
-    /*  You MUST free the updater, once everything is properly appended */
+/*  You MUST free the updater, once everything is properly appended */
 
-    /**
-     * @brief Updater designated destructor.
-     *
-     * @param updater
-     */
-    void synctex_updater_free(synctex_updater_p updater);
+/**
+ * @brief Updater designated destructor.
+ *
+ * @param updater
+ */
+void synctex_updater_free(synctex_updater_p updater);
 /** @} */ // end of group Updater
 #endif
 
 #if defined(SYNCTEX_DEBUG)
-#   include "assert.h"
-#   define SYNCTEX_ASSERT assert
+#include "assert.h"
+#define SYNCTEX_ASSERT assert
 #else
-#   define SYNCTEX_ASSERT(UNUSED)
+#define SYNCTEX_ASSERT(UNUSED)
 #endif
 
 #if defined(SYNCTEX_TESTING)
 #warning TESTING IS PROHIBITED
 #if __clang__
-#define __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
-_Pragma("clang diagnostic push") \
-_Pragma("clang diagnostic ignored \"-Wformat-extra-args\"")
+#define __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wformat-extra-args\"")
 
 #define __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS _Pragma("clang diagnostic pop")
 #else
@@ -772,30 +764,30 @@ _Pragma("clang diagnostic ignored \"-Wformat-extra-args\"")
 #define __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS
 #endif
 
-#   define SYNCTEX_TEST_BODY(counter, condition, desc, ...) \
-    do {				\
-        __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
-        if (!(condition)) {		\
-            ++counter;  \
-            printf("**** Test failed: %s\nfile %s\nfunction %s\nline %i\n",#condition,__FILE__,__FUNCTION__,__LINE__); \
-            printf((desc), ##__VA_ARGS__); \
-        }				\
-        __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
-    } while(0)
+#define SYNCTEX_TEST_BODY(counter, condition, desc, ...)                                                                                                       \
+    do {                                                                                                                                                       \
+        __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS                                                                                                                    \
+        if (!(condition)) {                                                                                                                                    \
+            ++counter;                                                                                                                                         \
+            printf("**** Test failed: %s\nfile %s\nfunction %s\nline %i\n", #condition, __FILE__, __FUNCTION__, __LINE__);                                     \
+            printf((desc), ##__VA_ARGS__);                                                                                                                     \
+        }                                                                                                                                                      \
+        __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS                                                                                                                     \
+    } while (0)
 
-#   define SYNCTEX_TEST_PARAMETER(counter, condition) SYNCTEX_TEST_BODY(counter, (condition), "Invalid parameter not satisfying: %s", #condition)
+#define SYNCTEX_TEST_PARAMETER(counter, condition) SYNCTEX_TEST_BODY(counter, (condition), "Invalid parameter not satisfying: %s", #condition)
 
-    int synctex_test_input(synctex_scanner_p scanner);
-    int synctex_test_proxy(synctex_scanner_p scanner);
-    int synctex_test_tree(synctex_scanner_p scanner);
-    int synctex_test_page(synctex_scanner_p scanner);
-    int synctex_test_handle(synctex_scanner_p scanner);
-    int synctex_test_display_query(synctex_scanner_p scanner);
-    int synctex_test_charindex();
-    int synctex_test_sheet_1();
-    int synctex_test_sheet_2();
-    int synctex_test_sheet_3();
-    int synctex_test_form();
+int synctex_test_input(synctex_scanner_p scanner);
+int synctex_test_proxy(synctex_scanner_p scanner);
+int synctex_test_tree(synctex_scanner_p scanner);
+int synctex_test_page(synctex_scanner_p scanner);
+int synctex_test_handle(synctex_scanner_p scanner);
+int synctex_test_display_query(synctex_scanner_p scanner);
+int synctex_test_charindex();
+int synctex_test_sheet_1();
+int synctex_test_sheet_2();
+int synctex_test_sheet_3();
+int synctex_test_form();
 #endif
 
 #ifdef __cplusplus

--- a/synctex_parser_c-auto.h
+++ b/synctex_parser_c-auto.h
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright (c) 2005 jerome DOT laurens AT u-bourgogne DOT fr
 
 This file is part of the SyncTeX package.
@@ -31,9 +31,9 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE
 
-Except as contained in this notice, the name of the copyright holder  
-shall not be used in advertising or otherwise to promote the sale,  
-use or other dealings in this Software without prior written  
+Except as contained in this notice, the name of the copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written
 authorization from the copyright holder.
 
 */

--- a/synctex_parser_local.h
+++ b/synctex_parser_local.h
@@ -39,6 +39,6 @@
  */
 
 /* This local header file is for TEXLIVE, use your own header to fit your system */
-#   include <w2c/c-auto.h> /* for inline && HAVE_xxx */
+#include <w2c/c-auto.h> /* for inline && HAVE_xxx */
 /*	No inlining for synctex tool in texlive. */
-#	define SYNCTEX_INLINE
+#define SYNCTEX_INLINE

--- a/synctex_parser_local.h
+++ b/synctex_parser_local.h
@@ -1,13 +1,13 @@
-/* 
+/*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the SyncTeX package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See synctex_parser_readme.txt for more details
- 
+
  License:
  --------
  Permission is hereby granted, free of charge, to any person
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,12 +30,12 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
  authorization from the copyright holder.
- 
+
  */
 
 /* This local header file is for TEXLIVE, use your own header to fit your system */

--- a/synctex_parser_readme.txt
+++ b/synctex_parser_readme.txt
@@ -103,7 +103,7 @@ Note that version 1.7 was delivered privately.
 - Various typo fixed
 - OutputDebugString replaced by OutputDebugStringA to deliberately disable unicode preprocessing
 - New conditional created because OutputDebugStringA is only available since Windows 2K professional
-1.10: Sun Jan  10 10:12:32 UTC 2010 
+1.10: Sun Jan  10 10:12:32 UTC 2010
 - Bug fix in synctex_parser.c to solve a synchronization problem with amsmath's gather environment.
   Concerns the synctex tool.
 1.11: Sun Jan  17 09:12:31 UTC 2010
@@ -133,7 +133,7 @@ TeX and friends are not concerned by these changes.
 1.17: Fri Oct 14 08:15:16 UTC 2011
 This concerns the synctex command line tool and 3rd party developers.
 TeX and friends are not concerned by these changes.
-- synctex_parser.c: cosmetic changes to enhance code readability 
+- synctex_parser.c: cosmetic changes to enhance code readability
 - Better forward synchronization.
   The problem occurs for example with LaTeX \item command.
   The fact is that this command creates nodes at parse time but these nodes are used only

--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -40,7 +40,7 @@
 
 /*  In this file, we find all the functions that may depend on the operating system. */
 
-#include <synctex_parser_utils.h>
+#include "synctex_parser_utils.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>

--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -1,15 +1,15 @@
-/* 
+/*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
- 
+
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation
  files (the "Software"), to deal in the Software without
@@ -18,10 +18,10 @@
  copies of the Software, and to permit persons to whom the
  Software is furnished to do so, subject to the following
  conditions:
- 
+
  The above copyright notice and this permission notice shall be
  included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,7 +30,7 @@
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE
- 
+
  Except as contained in this notice, the name of the copyright holder
  shall not be used in advertising or otherwise to promote the sale,
  use or other dealings in this Software without prior written
@@ -371,7 +371,7 @@ char * _synctex_merge_strings(const char * first,...) {
 		_synctex_error("!  _synctex_merge_strings: Memory problem");
 		return NULL;
 	}
-	return NULL;	
+	return NULL;
 }
 
 /*  The purpose of _synctex_get_name is to find the name of the synctex file.
@@ -552,7 +552,7 @@ int _synctex_get_name(const char * output, const char * build_directory, char **
 }
 
 const char * _synctex_get_io_mode_name(synctex_io_mode_t io_mode) {
-    static const char * synctex_io_modes[4] = {"r","rb","a","ab"}; 
+    static const char * synctex_io_modes[4] = {"r","rb","a","ab"};
     unsigned index = ((io_mode & synctex_io_gz_mask)?1:0) + ((io_mode & synctex_io_append_mask)?2:0);// bug pointed out by Jose Alliste
     return synctex_io_modes[index];
 }
@@ -564,7 +564,7 @@ static int _synctex_parse_int_C(char * ptr, char ** endptr) {
 }
 /**
  * This was initially suggested by user202729.
- * 
+ *
  */
 static int _synctex_parse_int_raw1(char * ptr, char ** endptr) {
   int result = 0;

--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -41,13 +41,13 @@
 /*  In this file, we find all the functions that may depend on the operating system. */
 
 #include "synctex_parser_utils.h"
-#include <stdlib.h>
-#include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include <limits.h>
 #include <ctype.h>
+#include <limits.h>
 
 #include <sys/stat.h>
 
@@ -64,147 +64,154 @@
 #endif
 
 #ifdef SYNCTEX_WINDOWS
-#include <windows.h>
 #include <shlwapi.h> /* Use shlwapi.lib */
+#include <windows.h>
 #endif
 
-void *_synctex_malloc(size_t size) {
-    void * ptr = malloc(size);
-    if(ptr) {
-        memset(ptr,0, size);/* ensures null termination of strings */
+void *_synctex_malloc(size_t size)
+{
+    void *ptr = malloc(size);
+    if (ptr) {
+        memset(ptr, 0, size); /* ensures null termination of strings */
     }
     return (void *)ptr;
 }
 
-void _synctex_free(void * ptr) {
-  free(ptr);
+void _synctex_free(void *ptr)
+{
+    free(ptr);
 }
 
 #if !defined(_WIN32)
-#   include <syslog.h>
+#include <syslog.h>
 #endif
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(3, 0)
-static int _synctex_log(int level, const char * prompt, const char * reason,va_list arg) {
-	int result;
-#	ifdef SYNCTEX_RECENT_WINDOWS
-	{/*	This code is contributed by William Blum.
-        As it does not work on some older computers,
-        the _WIN32 conditional here is replaced with a SYNCTEX_RECENT_WINDOWS one.
-        According to http://msdn.microsoft.com/en-us/library/aa363362(VS.85).aspx
-        Minimum supported client	Windows 2000 Professional
-        Minimum supported server	Windows 2000 Server
-        People running Windows 2K standard edition will not have OutputDebugStringA.
-        JL.*/
-		char *buff;
-		size_t len;
-		OutputDebugStringA(prompt);
-		len = _vscprintf(reason, arg) + 1;
-		buff = (char*)malloc( len * sizeof(char) );
-		result = vsprintf(buff, reason, arg) +strlen(prompt);
-		OutputDebugStringA(buff);
-		OutputDebugStringA("\n");
-		free(buff);
-	}
-#   elif SYNCTEX_USE_SYSLOG
-    char * buffer1 = NULL;
-    char * buffer2 = NULL;
-    openlog ("SyncTeX", LOG_CONS | LOG_PID | LOG_PERROR | LOG_NDELAY, LOG_LOCAL0);
-    if (vasprintf(&buffer1,reason,arg)>=0
-        && asprintf(&buffer2,"%s%s",prompt, buffer1)>=0) {
-        syslog (level, "%s", buffer2);
+static int _synctex_log(int level, const char *prompt, const char *reason, va_list arg)
+{
+    int result;
+#ifdef SYNCTEX_RECENT_WINDOWS
+    { /*	This code is contributed by William Blum.
+         As it does not work on some older computers,
+         the _WIN32 conditional here is replaced with a SYNCTEX_RECENT_WINDOWS one.
+         According to http://msdn.microsoft.com/en-us/library/aa363362(VS.85).aspx
+         Minimum supported client	Windows 2000 Professional
+         Minimum supported server	Windows 2000 Server
+         People running Windows 2K standard edition will not have OutputDebugStringA.
+         JL.*/
+        char *buff;
+        size_t len;
+        OutputDebugStringA(prompt);
+        len = _vscprintf(reason, arg) + 1;
+        buff = (char *)malloc(len * sizeof(char));
+        result = vsprintf(buff, reason, arg) + strlen(prompt);
+        OutputDebugStringA(buff);
+        OutputDebugStringA("\n");
+        free(buff);
+    }
+#elif SYNCTEX_USE_SYSLOG
+    char *buffer1 = NULL;
+    char *buffer2 = NULL;
+    openlog("SyncTeX", LOG_CONS | LOG_PID | LOG_PERROR | LOG_NDELAY, LOG_LOCAL0);
+    if (vasprintf(&buffer1, reason, arg) >= 0 && asprintf(&buffer2, "%s%s", prompt, buffer1) >= 0) {
+        syslog(level, "%s", buffer2);
         result = (int)strlen(buffer2);
     } else {
-        syslog (level, "%s",prompt);
-        vsyslog(level,reason,arg);
+        syslog(level, "%s", prompt);
+        vsyslog(level, reason, arg);
         result = (int)strlen(prompt);
     }
     free(buffer1);
     free(buffer2);
     closelog();
-#   else
-    FILE * where = level == LOG_ERR? stderr: stdout;
-    result = fputs(prompt,where);
+#else
+    FILE *where = level == LOG_ERR ? stderr : stdout;
+    result = fputs(prompt, where);
     result += vfprintf(where, reason, arg);
-    result += fprintf(where,"\n");
-#   endif
-	return result;
+    result += fprintf(where, "\n");
+#endif
+    return result;
 }
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_error(const char * reason,...) {
+int _synctex_error(const char *reason, ...)
+{
     va_list arg;
     int result;
-    va_start (arg, reason);
+    va_start(arg, reason);
 #if defined(SYNCTEX_RECENT_WINDOWS) /* LOG_ERR is not used */
     result = _synctex_log(0, "! SyncTeX Error : ", reason, arg);
 #else
     result = _synctex_log(LOG_ERR, "! SyncTeX Error : ", reason, arg);
 #endif
-    va_end (arg);
+    va_end(arg);
     return result;
 }
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_debug(const char * reason,...) {
+int _synctex_debug(const char *reason, ...)
+{
     va_list arg;
     int result;
-    va_start (arg, reason);
+    va_start(arg, reason);
 #if defined(SYNCTEX_RECENT_WINDOWS) /* LOG_DEBUG is not used */
     result = _synctex_log(0, "! SyncTeX Error : ", reason, arg);
 #else
     result = _synctex_log(LOG_DEBUG, "! SyncTeX Error : ", reason, arg);
 #endif
-    va_end (arg);
+    va_end(arg);
     return result;
 }
 
 /*  strip the last extension of the given string, this string is modified! */
-void _synctex_strip_last_path_extension(char * string) {
-	if(NULL != string){
-		char * last_component = NULL;
-		char * last_extension = NULL;
-#       if defined(SYNCTEX_WINDOWS)
-		last_component = PathFindFileName(string);
-		last_extension = PathFindExtension(string);
-		if(last_extension == NULL)return;
-		if(last_component == NULL)last_component = string;
-		if(last_extension>last_component){/* filter out paths like "my/dir/.hidden" */
-			last_extension[0] = '\0';
-		}
-#       else
-		char * next = NULL;
-		/*  first we find the last path component */
-		if(NULL == (last_component = strstr(string,"/"))){
-			last_component = string;
-		} else {
-			++last_component;
-			while((next = strstr(last_component,"/"))){
-				last_component = next+1;
-			}
-		}
-#               if defined(SYNCTEX_OS2)
-		/*  On OS2, the '\' is also a path separator. */
-		while((next = strstr(last_component,"\\"))){
-			last_component = next+1;
-		}
-#               endif /* SYNCTEX_OS2 */
-		/*  then we find the last path extension */
-		if((last_extension = strstr(last_component,"."))){
-			++last_extension;
-			while((next = strstr(last_extension,"."))){
-				last_extension = next+1;
-			}
-			--last_extension;/*  back to the "." */
-			if(last_extension>last_component){/*  filter out paths like ....my/dir/.hidden"*/
-				last_extension[0] = '\0';
-			}
-		}
-#       endif /* SYNCTEX_WINDOWS */
-	}
+void _synctex_strip_last_path_extension(char *string)
+{
+    if (NULL != string) {
+        char *last_component = NULL;
+        char *last_extension = NULL;
+#if defined(SYNCTEX_WINDOWS)
+        last_component = PathFindFileName(string);
+        last_extension = PathFindExtension(string);
+        if (last_extension == NULL)
+            return;
+        if (last_component == NULL)
+            last_component = string;
+        if (last_extension > last_component) { /* filter out paths like "my/dir/.hidden" */
+            last_extension[0] = '\0';
+        }
+#else
+        char *next = NULL;
+        /*  first we find the last path component */
+        if (NULL == (last_component = strstr(string, "/"))) {
+            last_component = string;
+        } else {
+            ++last_component;
+            while ((next = strstr(last_component, "/"))) {
+                last_component = next + 1;
+            }
+        }
+#if defined(SYNCTEX_OS2)
+        /*  On OS2, the '\' is also a path separator. */
+        while ((next = strstr(last_component, "\\"))) {
+            last_component = next + 1;
+        }
+#endif /* SYNCTEX_OS2 */
+        /*  then we find the last path extension */
+        if ((last_extension = strstr(last_component, "."))) {
+            ++last_extension;
+            while ((next = strstr(last_extension, "."))) {
+                last_extension = next + 1;
+            }
+            --last_extension; /*  back to the "." */
+            if (last_extension > last_component) { /*  filter out paths like ....my/dir/.hidden"*/
+                last_extension[0] = '\0';
+            }
+        }
+#endif /* SYNCTEX_WINDOWS */
+    }
 }
 
-synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name_ref)
+synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char **name_ref)
 {
     if (SYNCTEX_IS_DOT((*name_ref)[0]) && SYNCTEX_IS_PATH_SEPARATOR((*name_ref)[1])) {
         do {
@@ -212,7 +219,7 @@ synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name_ref)
             while (SYNCTEX_IS_PATH_SEPARATOR((*name_ref)[0])) {
                 ++(*name_ref);
             }
-        } while(SYNCTEX_IS_DOT((*name_ref)[0]) && SYNCTEX_IS_PATH_SEPARATOR((*name_ref)[1]));
+        } while (SYNCTEX_IS_DOT((*name_ref)[0]) && SYNCTEX_IS_PATH_SEPARATOR((*name_ref)[1]));
         return synctex_YES;
     }
     return synctex_NO;
@@ -222,8 +229,9 @@ synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name_ref)
  *  path is a '\0' terminated string
  *  The return value is the trailing part of the argument,
  *  just following the first occurrence of the regexp pattern "[^|/|\].[\|/]+".*/
-const char * _synctex_base_name(const char *path) {
-    const char * ptr = path;
+const char *_synctex_base_name(const char *path)
+{
+    const char *ptr = path;
     do {
         if (synctex_ignore_leading_dot_slash_in_path(&ptr)) {
             return ptr;
@@ -238,438 +246,446 @@ const char * _synctex_base_name(const char *path) {
 }
 
 /*  Compare two file names, windows is sometimes case insensitive... */
-synctex_bool_t _synctex_is_equivalent_file_name(const char *lhs, const char *rhs) {
+synctex_bool_t _synctex_is_equivalent_file_name(const char *lhs, const char *rhs)
+{
     /*  Remove the leading regex '(\./+)*' in both rhs and lhs */
     synctex_ignore_leading_dot_slash_in_path(&lhs);
     synctex_ignore_leading_dot_slash_in_path(&rhs);
 next_character:
-	if (SYNCTEX_IS_PATH_SEPARATOR(*lhs)) {/*  lhs points to a path separator */
-		if (!SYNCTEX_IS_PATH_SEPARATOR(*rhs)) {/*  but not rhs */
-			return synctex_NO;
-		}
+    if (SYNCTEX_IS_PATH_SEPARATOR(*lhs)) { /*  lhs points to a path separator */
+        if (!SYNCTEX_IS_PATH_SEPARATOR(*rhs)) { /*  but not rhs */
+            return synctex_NO;
+        }
         ++lhs;
         ++rhs;
         synctex_ignore_leading_dot_slash_in_path(&lhs);
         synctex_ignore_leading_dot_slash_in_path(&rhs);
         goto next_character;
-	} else if (SYNCTEX_IS_PATH_SEPARATOR(*rhs)) {/*  rhs points to a path separator but not lhs */
-		return synctex_NO;
-	} else if (SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(*lhs,*rhs)){/*  uppercase do not match */
-		return synctex_NO;
-	} else if (!*lhs) {/*  lhs is at the end of the string */
-		return *rhs ? synctex_NO : synctex_YES;
-	} else if(!*rhs) {/*  rhs is at the end of the string but not lhs */
-		return synctex_NO;
-	}
-	++lhs;
-	++rhs;
-	goto next_character;
+    } else if (SYNCTEX_IS_PATH_SEPARATOR(*rhs)) { /*  rhs points to a path separator but not lhs */
+        return synctex_NO;
+    } else if (SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(*lhs, *rhs)) { /*  uppercase do not match */
+        return synctex_NO;
+    } else if (!*lhs) { /*  lhs is at the end of the string */
+        return *rhs ? synctex_NO : synctex_YES;
+    } else if (!*rhs) { /*  rhs is at the end of the string but not lhs */
+        return synctex_NO;
+    }
+    ++lhs;
+    ++rhs;
+    goto next_character;
 }
 
-synctex_bool_t _synctex_path_is_absolute(const char * name) {
-	if(!strlen(name)) {
-		return synctex_NO;
-	}
-#	if defined(SYNCTEX_WINDOWS) || defined(SYNCTEX_OS2)
-	if(strlen(name)>2) {
-		return (name[1]==':' && SYNCTEX_IS_PATH_SEPARATOR(name[2]))?synctex_YES:synctex_NO;
-	}
-	return synctex_NO;
-#	else
-    return SYNCTEX_IS_PATH_SEPARATOR(name[0])?synctex_YES:synctex_NO;
-#	endif
+synctex_bool_t _synctex_path_is_absolute(const char *name)
+{
+    if (!strlen(name)) {
+        return synctex_NO;
+    }
+#if defined(SYNCTEX_WINDOWS) || defined(SYNCTEX_OS2)
+    if (strlen(name) > 2) {
+        return (name[1] == ':' && SYNCTEX_IS_PATH_SEPARATOR(name[2])) ? synctex_YES : synctex_NO;
+    }
+    return synctex_NO;
+#else
+    return SYNCTEX_IS_PATH_SEPARATOR(name[0]) ? synctex_YES : synctex_NO;
+#endif
 }
 
 /*  We do not take care of UTF-8 */
-const char * _synctex_last_path_component(const char * name) {
-	const char * c = name+strlen(name);
-	if(c>name) {
-		if(!SYNCTEX_IS_PATH_SEPARATOR(*c)) {
-			do {
-				--c;
-				if(SYNCTEX_IS_PATH_SEPARATOR(*c)) {
-					return c+1;
-				}
-			} while(c>name);
-		}
-		return c;/* the last path component is the void string*/
-	}
-	return c;
+const char *_synctex_last_path_component(const char *name)
+{
+    const char *c = name + strlen(name);
+    if (c > name) {
+        if (!SYNCTEX_IS_PATH_SEPARATOR(*c)) {
+            do {
+                --c;
+                if (SYNCTEX_IS_PATH_SEPARATOR(*c)) {
+                    return c + 1;
+                }
+            } while (c > name);
+        }
+        return c; /* the last path component is the void string*/
+    }
+    return c;
 }
 
-int _synctex_copy_with_quoting_last_path_component(const char * src, char ** dest_ref, size_t size) {
-  if(src && dest_ref) {
-      const char * lpc;
-#		define dest (*dest_ref)
-		dest = NULL;	/*	Default behavior: no change and success. */
-		lpc = _synctex_last_path_component(src);
-		if(strlen(lpc)) {
-			if(strchr(lpc,' ') && lpc[0]!='"' && lpc[strlen(lpc)-1]!='"') {
-				/*	We are in the situation where adding the quotes is allowed.	*/
-				/*	Time to add the quotes.	*/
-				/*  Consistency test: we must have dest+size>dest+strlen(dest)+2
-				 *	or equivalently: strlen(dest)+2<size (see below) */
-				if(strlen(src)<size) {
-					if((dest = (char *)malloc(size+2))) {
-						char * dpc = dest + (lpc-src);	/*	dpc is the last path component of dest.	*/
-						memcpy(dest,src,size);
-						memmove(dpc+1,dpc,strlen(dpc)+1);	/*	Also move the null terminating character. */
-						dpc[0]='"';
-						dpc[strlen(dpc)+1]='\0';/*	Consistency test */
-						dpc[strlen(dpc)]='"';
-						return 0;	/*	Success. */
-					}
-					return -1;	/*	Memory allocation error.	*/
-				}
-				_synctex_error("!  _synctex_copy_with_quoting_last_path_component: Internal inconsistency");
-				return -2;
-			}
-			return 0;	/*	Success. */
-		}
-		return 0;	/*	No last path component. */
-#		undef dest
-	}
-	return 1; /*  Bad parameter, this value is subject to changes. */
+int _synctex_copy_with_quoting_last_path_component(const char *src, char **dest_ref, size_t size)
+{
+    if (src && dest_ref) {
+        const char *lpc;
+#define dest (*dest_ref)
+        dest = NULL; /*	Default behavior: no change and success. */
+        lpc = _synctex_last_path_component(src);
+        if (strlen(lpc)) {
+            if (strchr(lpc, ' ') && lpc[0] != '"' && lpc[strlen(lpc) - 1] != '"') {
+                /*	We are in the situation where adding the quotes is allowed.	*/
+                /*	Time to add the quotes.	*/
+                /*  Consistency test: we must have dest+size>dest+strlen(dest)+2
+                 *	or equivalently: strlen(dest)+2<size (see below) */
+                if (strlen(src) < size) {
+                    if ((dest = (char *)malloc(size + 2))) {
+                        char *dpc = dest + (lpc - src); /*	dpc is the last path component of dest.	*/
+                        memcpy(dest, src, size);
+                        memmove(dpc + 1, dpc, strlen(dpc) + 1); /*	Also move the null terminating character. */
+                        dpc[0] = '"';
+                        dpc[strlen(dpc) + 1] = '\0'; /*	Consistency test */
+                        dpc[strlen(dpc)] = '"';
+                        return 0; /*	Success. */
+                    }
+                    return -1; /*	Memory allocation error.	*/
+                }
+                _synctex_error("!  _synctex_copy_with_quoting_last_path_component: Internal inconsistency");
+                return -2;
+            }
+            return 0; /*	Success. */
+        }
+        return 0; /*	No last path component. */
+#undef dest
+    }
+    return 1; /*  Bad parameter, this value is subject to changes. */
 }
 
-char * _synctex_merge_strings(const char * first,...) {
-	va_list arg;
-	size_t size = 0;
-	const char * temp;
-	/*   First retrieve the size necessary to store the merged string */
-	va_start (arg, first);
-	temp = first;
-	do {
-		size_t len = strlen(temp);
-		if(UINT_MAX-len<size) {
-			_synctex_error("!  _synctex_merge_strings: Capacity exceeded.");
-			va_end(arg);
-			return NULL;
-		}
-		size+=len;
-	} while( (temp = va_arg(arg, const char *)) != NULL);
-	va_end(arg);
-	if(size>0) {
-		char * result = NULL;
-		++size;
-		/*  Create the memory storage */
-		if(NULL!=(result = (char *)malloc(size))) {
-			char * dest = result;
-			va_start (arg, first);
-			temp = first;
-			do {
-				if((size = strlen(temp))>0) {
-					/*  There is something to merge */
-					memcpy(dest,temp,size);
-					dest += size;
-				}
-			} while( (temp = va_arg(arg, const char *)) != NULL);
-			va_end(arg);
-			dest[0]='\0';/*  Terminate the merged string */
-			return result;
-		}
-		_synctex_error("!  _synctex_merge_strings: Memory problem");
-		return NULL;
-	}
-	return NULL;
+char *_synctex_merge_strings(const char *first, ...)
+{
+    va_list arg;
+    size_t size = 0;
+    const char *temp;
+    /*   First retrieve the size necessary to store the merged string */
+    va_start(arg, first);
+    temp = first;
+    do {
+        size_t len = strlen(temp);
+        if (UINT_MAX - len < size) {
+            _synctex_error("!  _synctex_merge_strings: Capacity exceeded.");
+            va_end(arg);
+            return NULL;
+        }
+        size += len;
+    } while ((temp = va_arg(arg, const char *)) != NULL);
+    va_end(arg);
+    if (size > 0) {
+        char *result = NULL;
+        ++size;
+        /*  Create the memory storage */
+        if (NULL != (result = (char *)malloc(size))) {
+            char *dest = result;
+            va_start(arg, first);
+            temp = first;
+            do {
+                if ((size = strlen(temp)) > 0) {
+                    /*  There is something to merge */
+                    memcpy(dest, temp, size);
+                    dest += size;
+                }
+            } while ((temp = va_arg(arg, const char *)) != NULL);
+            va_end(arg);
+            dest[0] = '\0'; /*  Terminate the merged string */
+            return result;
+        }
+        _synctex_error("!  _synctex_merge_strings: Memory problem");
+        return NULL;
+    }
+    return NULL;
 }
 
 /*  The purpose of _synctex_get_name is to find the name of the synctex file.
  *  There is a list of possible filenames from which we return the most recent one and try to remove all the others.
  *  With two runs of pdftex or xetex we are sure the synctex file is really the most appropriate.
  */
-int _synctex_get_name(const char * output, const char * build_directory, char ** synctex_name_ref, synctex_io_mode_t * io_mode_ref)
+int _synctex_get_name(const char *output, const char *build_directory, char **synctex_name_ref, synctex_io_mode_t *io_mode_ref)
 {
-	if(output && synctex_name_ref && io_mode_ref) {
-		/*  If output is already absolute, we just have to manage the quotes and the compress mode */
-		size_t size = 0;
-        char * synctex_name = NULL;
+    if (output && synctex_name_ref && io_mode_ref) {
+        /*  If output is already absolute, we just have to manage the quotes and the compress mode */
+        size_t size = 0;
+        char *synctex_name = NULL;
         synctex_io_mode_t io_mode = *io_mode_ref;
-		const char * base_name = _synctex_last_path_component(output); /*  do not free, output is the owner. base name of output*/
-		/*  Do we have a real base name ? */
-		if(strlen(base_name)>0) {
-			/*  Yes, we do. */
-			const char * temp = NULL;
-			char * core_name = NULL; /*  base name of output without path extension. */
-			char * dir_name = NULL; /*  dir name of output */
-			char * quoted_core_name = NULL;
-			char * basic_name = NULL;
-			char * gz_name = NULL;
-			char * quoted_name = NULL;
-			char * quoted_gz_name = NULL;
-			char * build_name = NULL;
-			char * build_gz_name = NULL;
-			char * build_quoted_name = NULL;
-			char * build_quoted_gz_name = NULL;
-			struct stat buf;
-			time_t the_time = 0;
-			/*  Create core_name: let temp point to the dot before the path extension of base_name;
-			 *  We start form the \0 terminating character and scan the string upward until we find a dot.
-			 *  The leading dot is not accepted. */
-			if((temp = strrchr(base_name,'.')) && (size = temp - base_name)>0) {
-				/*  There is a dot and it is not at the leading position    */
-				if(NULL == (core_name = (char *)malloc(size+1))) {
-					_synctex_error("!  _synctex_get_name: Memory problem 1");
-					return -1;
-				}
-				if(core_name != strncpy(core_name,base_name,size)) {
-					_synctex_error("!  _synctex_get_name: Copy problem 1");
-					free(core_name);
-					dir_name = NULL;
-					return -2;
-				}
-				core_name[size] = '\0';
-			} else {
-				/*  There is no path extension,
-				 *  Just make a copy of base_name */
-				core_name = _synctex_merge_strings(base_name);
-			}
-			/*  core_name is properly set up, owned by "self". */
-			/*  creating dir_name. */
-			size = strlen(output)-strlen(base_name);
-			if(size>0) {
-				/*  output contains more than one path component */
-				if(NULL == (dir_name = (char *)malloc(size+1))) {
-					_synctex_error("!  _synctex_get_name: Memory problem");
-					free(core_name);
-					return -1;
-				}
-				if(dir_name != strncpy(dir_name,output,size)) {
-					_synctex_error("!  _synctex_get_name: Copy problem");
-					free(dir_name);
-					dir_name = NULL;
-					free(core_name);
-					dir_name = NULL;
-					return -2;
-				}
-				dir_name[size] = '\0';
-			}
-			/*  dir_name is properly set up. It ends with a path separator, if non void. */
-			/*  creating quoted_core_name. */
-			if(strchr(core_name,' ')) {
-				quoted_core_name = _synctex_merge_strings("\"",core_name,"\"");
-			}
-			/*  quoted_core_name is properly set up. */
-			if(dir_name &&strlen(dir_name)>0) {
-				basic_name = _synctex_merge_strings(dir_name,core_name,synctex_suffix,NULL);
-				if(quoted_core_name && strlen(quoted_core_name)>0) {
-					quoted_name = _synctex_merge_strings(dir_name,quoted_core_name,synctex_suffix,NULL);
-				}
-			} else {
-				basic_name = _synctex_merge_strings(core_name,synctex_suffix,NULL);
-				if(quoted_core_name && strlen(quoted_core_name)>0) {
-					quoted_name = _synctex_merge_strings(quoted_core_name,synctex_suffix,NULL);
-				}
-			}
-			if(!_synctex_path_is_absolute(output) && build_directory && (size = strlen(build_directory))) {
-				temp = build_directory + size - 1;
-				if(_synctex_path_is_absolute(temp)) {
-					build_name = _synctex_merge_strings(build_directory,basic_name,NULL);
-					if(quoted_core_name && strlen(quoted_core_name)>0) {
-						build_quoted_name = _synctex_merge_strings(build_directory,quoted_name,NULL);
-					}
-				} else {
-					build_name = _synctex_merge_strings(build_directory,"/",basic_name,NULL);
-					if(quoted_core_name && strlen(quoted_core_name)>0) {
-						build_quoted_name = _synctex_merge_strings(build_directory,"/",quoted_name,NULL);
-					}
-				}
-			}
-			if(basic_name) {
-				gz_name = _synctex_merge_strings(basic_name,synctex_suffix_gz,NULL);
-			}
-			if(quoted_name) {
-				quoted_gz_name = _synctex_merge_strings(quoted_name,synctex_suffix_gz,NULL);
-			}
-			if(build_name) {
-				build_gz_name = _synctex_merge_strings(build_name,synctex_suffix_gz,NULL);
-			}
-			if(build_quoted_name) {
-				build_quoted_gz_name = _synctex_merge_strings(build_quoted_name,synctex_suffix_gz,NULL);
-			}
-			/*  All the others names are properly set up... */
-			/*  retain the most recently modified file */
-#			define TEST(FILENAME,COMPRESS_MODE) \
-			if(FILENAME) {\
-				if (stat(FILENAME, &buf)) { \
-					free(FILENAME);\
-					FILENAME = NULL;\
-				} else if (buf.st_mtime>the_time) { \
-                    the_time=buf.st_mtime; \
-                    synctex_name = FILENAME; \
-                    if (COMPRESS_MODE) { \
-                        io_mode |= synctex_io_gz_mask; \
-                    } else { \
-                        io_mode &= ~synctex_io_gz_mask; \
-                    } \
-				} \
-			}
-			TEST(basic_name,synctex_DONT_COMPRESS);
-			TEST(gz_name,synctex_COMPRESS);
-			TEST(quoted_name,synctex_DONT_COMPRESS);
-			TEST(quoted_gz_name,synctex_COMPRESS);
-			TEST(build_name,synctex_DONT_COMPRESS);
-			TEST(build_gz_name,synctex_COMPRESS);
-			TEST(build_quoted_name,synctex_DONT_COMPRESS);
-			TEST(build_quoted_gz_name,synctex_COMPRESS);
-#			undef TEST
-			/*  Free all the intermediate filenames, except the one that will be used as returned value. */
-#			define CLEAN_AND_REMOVE(FILENAME) \
-			if(FILENAME && (FILENAME!=synctex_name)) {\
-				remove(FILENAME);\
-				printf("synctex tool info: %s removed\n",FILENAME);\
-				free(FILENAME);\
-				FILENAME = NULL;\
-			}
-			CLEAN_AND_REMOVE(basic_name);
-			CLEAN_AND_REMOVE(gz_name);
-			CLEAN_AND_REMOVE(quoted_name);
-			CLEAN_AND_REMOVE(quoted_gz_name);
-			CLEAN_AND_REMOVE(build_name);
-			CLEAN_AND_REMOVE(build_gz_name);
-			CLEAN_AND_REMOVE(build_quoted_name);
-			CLEAN_AND_REMOVE(build_quoted_gz_name);
-#			undef CLEAN_AND_REMOVE
+        const char *base_name = _synctex_last_path_component(output); /*  do not free, output is the owner. base name of output*/
+        /*  Do we have a real base name ? */
+        if (strlen(base_name) > 0) {
+            /*  Yes, we do. */
+            const char *temp = NULL;
+            char *core_name = NULL; /*  base name of output without path extension. */
+            char *dir_name = NULL; /*  dir name of output */
+            char *quoted_core_name = NULL;
+            char *basic_name = NULL;
+            char *gz_name = NULL;
+            char *quoted_name = NULL;
+            char *quoted_gz_name = NULL;
+            char *build_name = NULL;
+            char *build_gz_name = NULL;
+            char *build_quoted_name = NULL;
+            char *build_quoted_gz_name = NULL;
+            struct stat buf;
+            time_t the_time = 0;
+            /*  Create core_name: let temp point to the dot before the path extension of base_name;
+             *  We start form the \0 terminating character and scan the string upward until we find a dot.
+             *  The leading dot is not accepted. */
+            if ((temp = strrchr(base_name, '.')) && (size = temp - base_name) > 0) {
+                /*  There is a dot and it is not at the leading position    */
+                if (NULL == (core_name = (char *)malloc(size + 1))) {
+                    _synctex_error("!  _synctex_get_name: Memory problem 1");
+                    return -1;
+                }
+                if (core_name != strncpy(core_name, base_name, size)) {
+                    _synctex_error("!  _synctex_get_name: Copy problem 1");
+                    free(core_name);
+                    dir_name = NULL;
+                    return -2;
+                }
+                core_name[size] = '\0';
+            } else {
+                /*  There is no path extension,
+                 *  Just make a copy of base_name */
+                core_name = _synctex_merge_strings(base_name);
+            }
+            /*  core_name is properly set up, owned by "self". */
+            /*  creating dir_name. */
+            size = strlen(output) - strlen(base_name);
+            if (size > 0) {
+                /*  output contains more than one path component */
+                if (NULL == (dir_name = (char *)malloc(size + 1))) {
+                    _synctex_error("!  _synctex_get_name: Memory problem");
+                    free(core_name);
+                    return -1;
+                }
+                if (dir_name != strncpy(dir_name, output, size)) {
+                    _synctex_error("!  _synctex_get_name: Copy problem");
+                    free(dir_name);
+                    dir_name = NULL;
+                    free(core_name);
+                    dir_name = NULL;
+                    return -2;
+                }
+                dir_name[size] = '\0';
+            }
+            /*  dir_name is properly set up. It ends with a path separator, if non void. */
+            /*  creating quoted_core_name. */
+            if (strchr(core_name, ' ')) {
+                quoted_core_name = _synctex_merge_strings("\"", core_name, "\"");
+            }
+            /*  quoted_core_name is properly set up. */
+            if (dir_name && strlen(dir_name) > 0) {
+                basic_name = _synctex_merge_strings(dir_name, core_name, synctex_suffix, NULL);
+                if (quoted_core_name && strlen(quoted_core_name) > 0) {
+                    quoted_name = _synctex_merge_strings(dir_name, quoted_core_name, synctex_suffix, NULL);
+                }
+            } else {
+                basic_name = _synctex_merge_strings(core_name, synctex_suffix, NULL);
+                if (quoted_core_name && strlen(quoted_core_name) > 0) {
+                    quoted_name = _synctex_merge_strings(quoted_core_name, synctex_suffix, NULL);
+                }
+            }
+            if (!_synctex_path_is_absolute(output) && build_directory && (size = strlen(build_directory))) {
+                temp = build_directory + size - 1;
+                if (_synctex_path_is_absolute(temp)) {
+                    build_name = _synctex_merge_strings(build_directory, basic_name, NULL);
+                    if (quoted_core_name && strlen(quoted_core_name) > 0) {
+                        build_quoted_name = _synctex_merge_strings(build_directory, quoted_name, NULL);
+                    }
+                } else {
+                    build_name = _synctex_merge_strings(build_directory, "/", basic_name, NULL);
+                    if (quoted_core_name && strlen(quoted_core_name) > 0) {
+                        build_quoted_name = _synctex_merge_strings(build_directory, "/", quoted_name, NULL);
+                    }
+                }
+            }
+            if (basic_name) {
+                gz_name = _synctex_merge_strings(basic_name, synctex_suffix_gz, NULL);
+            }
+            if (quoted_name) {
+                quoted_gz_name = _synctex_merge_strings(quoted_name, synctex_suffix_gz, NULL);
+            }
+            if (build_name) {
+                build_gz_name = _synctex_merge_strings(build_name, synctex_suffix_gz, NULL);
+            }
+            if (build_quoted_name) {
+                build_quoted_gz_name = _synctex_merge_strings(build_quoted_name, synctex_suffix_gz, NULL);
+            }
+            /*  All the others names are properly set up... */
+            /*  retain the most recently modified file */
+#define TEST(FILENAME, COMPRESS_MODE)                                                                                                                          \
+    if (FILENAME) {                                                                                                                                            \
+        if (stat(FILENAME, &buf)) {                                                                                                                            \
+            free(FILENAME);                                                                                                                                    \
+            FILENAME = NULL;                                                                                                                                   \
+        } else if (buf.st_mtime > the_time) {                                                                                                                  \
+            the_time = buf.st_mtime;                                                                                                                           \
+            synctex_name = FILENAME;                                                                                                                           \
+            if (COMPRESS_MODE) {                                                                                                                               \
+                io_mode |= synctex_io_gz_mask;                                                                                                                 \
+            } else {                                                                                                                                           \
+                io_mode &= ~synctex_io_gz_mask;                                                                                                                \
+            }                                                                                                                                                  \
+        }                                                                                                                                                      \
+    }
+            TEST(basic_name, synctex_DONT_COMPRESS);
+            TEST(gz_name, synctex_COMPRESS);
+            TEST(quoted_name, synctex_DONT_COMPRESS);
+            TEST(quoted_gz_name, synctex_COMPRESS);
+            TEST(build_name, synctex_DONT_COMPRESS);
+            TEST(build_gz_name, synctex_COMPRESS);
+            TEST(build_quoted_name, synctex_DONT_COMPRESS);
+            TEST(build_quoted_gz_name, synctex_COMPRESS);
+#undef TEST
+            /*  Free all the intermediate filenames, except the one that will be used as returned value. */
+#define CLEAN_AND_REMOVE(FILENAME)                                                                                                                             \
+    if (FILENAME && (FILENAME != synctex_name)) {                                                                                                              \
+        remove(FILENAME);                                                                                                                                      \
+        printf("synctex tool info: %s removed\n", FILENAME);                                                                                                   \
+        free(FILENAME);                                                                                                                                        \
+        FILENAME = NULL;                                                                                                                                       \
+    }
+            CLEAN_AND_REMOVE(basic_name);
+            CLEAN_AND_REMOVE(gz_name);
+            CLEAN_AND_REMOVE(quoted_name);
+            CLEAN_AND_REMOVE(quoted_gz_name);
+            CLEAN_AND_REMOVE(build_name);
+            CLEAN_AND_REMOVE(build_gz_name);
+            CLEAN_AND_REMOVE(build_quoted_name);
+            CLEAN_AND_REMOVE(build_quoted_gz_name);
+#undef CLEAN_AND_REMOVE
             /* set up the returned values */
-            * synctex_name_ref = synctex_name;
+            *synctex_name_ref = synctex_name;
             /* synctex_name won't always end in .gz, even when compressed. */
-            FILE * F = fopen(synctex_name, "r");
+            FILE *F = fopen(synctex_name, "r");
             if (F != NULL) {
-                if (!feof(F)
-                && 31 == fgetc(F)
-                && !feof(F)
-                && 139 == fgetc(F)) {
+                if (!feof(F) && 31 == fgetc(F) && !feof(F) && 139 == fgetc(F)) {
                     io_mode = synctex_compress_mode_gz;
                 }
                 fclose(F);
             }
-            * io_mode_ref = io_mode;
-			return 0;
-		}
-		return -1;/*  bad argument */
-	}
-	return -2;
+            *io_mode_ref = io_mode;
+            return 0;
+        }
+        return -1; /*  bad argument */
+    }
+    return -2;
 }
 
-const char * _synctex_get_io_mode_name(synctex_io_mode_t io_mode) {
-    static const char * synctex_io_modes[4] = {"r","rb","a","ab"};
-    unsigned index = ((io_mode & synctex_io_gz_mask)?1:0) + ((io_mode & synctex_io_append_mask)?2:0);// bug pointed out by Jose Alliste
+const char *_synctex_get_io_mode_name(synctex_io_mode_t io_mode)
+{
+    static const char *synctex_io_modes[4] = {"r", "rb", "a", "ab"};
+    unsigned index = ((io_mode & synctex_io_gz_mask) ? 1 : 0) + ((io_mode & synctex_io_append_mask) ? 2 : 0); // bug pointed out by Jose Alliste
     return synctex_io_modes[index];
 }
 
-typedef int(*synctex_parse_int_f)(char * ptr, char ** endptr);
+typedef int (*synctex_parse_int_f)(char *ptr, char **endptr);
 
-static int _synctex_parse_int_C(char * ptr, char ** endptr) {
-	return (int)strtol(ptr, endptr, 10);
+static int _synctex_parse_int_C(char *ptr, char **endptr)
+{
+    return (int)strtol(ptr, endptr, 10);
 }
 /**
  * This was initially suggested by user202729.
  *
  */
-static int _synctex_parse_int_raw1(char * ptr, char ** endptr) {
-  int result = 0;
-	while (*ptr==' ') {
-    ptr++;
-  }
-  synctex_bool_t negative = (*ptr=='-');
-  if (negative) {
-    ptr++;
-  } else if (*ptr=='+') {
-    ptr++;
-  }
-  while (*ptr>='0' && *ptr<='9') {
-    result = 10 * result + (*ptr - '0');
-    ptr++;
-  }
-	if (endptr) {
-    *endptr = ptr;
-	}
-  return negative? -result : result;
-}
-
-static int _synctex_parse_int_raw2(char * ptr, char ** endptr) {
-  int result = 0;
-	unsigned digits = 10;
-  while (*ptr==' ') {
-    ptr++;
-  }
-  synctex_bool_t negative = (*ptr=='-');
-  if (negative) {
-    ptr++;
-  } else if (*ptr=='+') {
-    ptr++;
-  }
-  while (*ptr>='0' && *ptr<='9') {
-    result = (result << 3) + (result << 1) + (*ptr - '0');
-    ptr++;
-		digits--;
-		if (digits) {
-			continue;
-		}
-  	// We got nine digits so far
-		// Shall we overflow or underflow?
-		const int max = negative ? -INT_MIN : INT_MAX;
-		while (*ptr>='0' && *ptr<='9') {
-			int i = *ptr - '0';
-			// We test if result * 10 + (*ptr - '0') <= max
-			if ( result < (max - i) / 10 ) {
-in_range:
-				result = result * 10 + i;
+static int _synctex_parse_int_raw1(char *ptr, char **endptr)
+{
+    int result = 0;
+    while (*ptr == ' ') {
         ptr++;
-			} else if ( result > (max - i) / 10 ) {
-				result = max;
-out_of_range:
-				ptr++;
-        while (*ptr>='0' && *ptr<='9') {
-					ptr++;
-				}
-				goto will_return;
-			} else if ( result % 10 > (max - i) %10 ) {
-				goto out_of_range;
-			} else {
-				goto in_range;
-			}
-		}
-		break;
-  }
+    }
+    synctex_bool_t negative = (*ptr == '-');
+    if (negative) {
+        ptr++;
+    } else if (*ptr == '+') {
+        ptr++;
+    }
+    while (*ptr >= '0' && *ptr <= '9') {
+        result = 10 * result + (*ptr - '0');
+        ptr++;
+    }
+    if (endptr) {
+        *endptr = ptr;
+    }
+    return negative ? -result : result;
+}
+
+static int _synctex_parse_int_raw2(char *ptr, char **endptr)
+{
+    int result = 0;
+    unsigned digits = 10;
+    while (*ptr == ' ') {
+        ptr++;
+    }
+    synctex_bool_t negative = (*ptr == '-');
+    if (negative) {
+        ptr++;
+    } else if (*ptr == '+') {
+        ptr++;
+    }
+    while (*ptr >= '0' && *ptr <= '9') {
+        result = (result << 3) + (result << 1) + (*ptr - '0');
+        ptr++;
+        digits--;
+        if (digits) {
+            continue;
+        }
+        // We got nine digits so far
+        // Shall we overflow or underflow?
+        const int max = negative ? -INT_MIN : INT_MAX;
+        while (*ptr >= '0' && *ptr <= '9') {
+            int i = *ptr - '0';
+            // We test if result * 10 + (*ptr - '0') <= max
+            if (result < (max - i) / 10) {
+            in_range:
+                result = result * 10 + i;
+                ptr++;
+            } else if (result > (max - i) / 10) {
+                result = max;
+            out_of_range:
+                ptr++;
+                while (*ptr >= '0' && *ptr <= '9') {
+                    ptr++;
+                }
+                goto will_return;
+            } else if (result % 10 > (max - i) % 10) {
+                goto out_of_range;
+            } else {
+                goto in_range;
+            }
+        }
+        break;
+    }
 will_return:
-	if (endptr) {
-    *endptr = ptr;
-	}
-  return negative? -result : result;
+    if (endptr) {
+        *endptr = ptr;
+    }
+    return negative ? -result : result;
 }
 
-static synctex_parse_int_f synctex_parse_int_do = & _synctex_parse_int_C;
+static synctex_parse_int_f synctex_parse_int_do = &_synctex_parse_int_C;
 
-synctex_parse_int_policy_t synctex_parse_int_policy(synctex_parse_int_policy_t policy) {
-	if (policy == synctex_parse_int_policy_request) {
-		if ( ( synctex_parse_int_do = &_synctex_parse_int_raw1 ) ) {
-			return synctex_parse_int_policy_raw1;
-		}
-		if ( ( synctex_parse_int_do = &_synctex_parse_int_raw2 ) ) {
-			return synctex_parse_int_policy_raw2;
-		}
-		return synctex_parse_int_policy_C;
-	} else if (policy == synctex_parse_int_policy_raw1) {
+synctex_parse_int_policy_t synctex_parse_int_policy(synctex_parse_int_policy_t policy)
+{
+    if (policy == synctex_parse_int_policy_request) {
+        if ((synctex_parse_int_do = &_synctex_parse_int_raw1)) {
+            return synctex_parse_int_policy_raw1;
+        }
+        if ((synctex_parse_int_do = &_synctex_parse_int_raw2)) {
+            return synctex_parse_int_policy_raw2;
+        }
+        return synctex_parse_int_policy_C;
+    } else if (policy == synctex_parse_int_policy_raw1) {
 #if SYNCTEX_DEBUG > 500
-    printf("synctex_parse_int_policy: raw1");
+        printf("synctex_parse_int_policy: raw1");
 #endif
-		synctex_parse_int_do = &_synctex_parse_int_raw1;
-	} else if (policy == synctex_parse_int_policy_raw2) {
+        synctex_parse_int_do = &_synctex_parse_int_raw1;
+    } else if (policy == synctex_parse_int_policy_raw2) {
 #if SYNCTEX_DEBUG > 500
-    printf("synctex_parse_int_policy: raw2");
+        printf("synctex_parse_int_policy: raw2");
 #endif
-		synctex_parse_int_do = &_synctex_parse_int_raw2;
-	} else {
+        synctex_parse_int_do = &_synctex_parse_int_raw2;
+    } else {
 #if SYNCTEX_DEBUG > 500
-    printf("synctex_parse_int_policy: C");
+        printf("synctex_parse_int_policy: C");
 #endif
-		synctex_parse_int_do = &_synctex_parse_int_C;
-	  return synctex_parse_int_policy_C;
-	}
-	return policy;
+        synctex_parse_int_do = &_synctex_parse_int_C;
+        return synctex_parse_int_policy_C;
+    }
+    return policy;
 }
 
-int synctex_parse_int(char * ptr, char ** endptr) {
-	return (*synctex_parse_int_do)(ptr, endptr);
+int synctex_parse_int(char *ptr, char **endptr)
+{
+    return (*synctex_parse_int_do)(ptr, endptr);
 }

--- a/synctex_parser_utils.h
+++ b/synctex_parser_utils.h
@@ -49,16 +49,16 @@ authorization from the copyright holder.
 #include "synctex_version.h"
 
 typedef int synctex_bool_t;
-#	define synctex_YES (0==0)
-#	define synctex_NO (0==1)
+#define synctex_YES (0 == 0)
+#define synctex_NO (0 == 1)
 
-#	define synctex_ADD_QUOTES -1
-#	define synctex_COMPRESS -1
-#	define synctex_DONT_ADD_QUOTES 0
-#	define synctex_DONT_COMPRESS 0
+#define synctex_ADD_QUOTES -1
+#define synctex_COMPRESS -1
+#define synctex_DONT_ADD_QUOTES 0
+#define synctex_DONT_COMPRESS 0
 
 #ifndef __SYNCTEX_PARSER_UTILS__
-#   define __SYNCTEX_PARSER_UTILS__
+#define __SYNCTEX_PARSER_UTILS__
 
 #include <stdlib.h>
 
@@ -66,31 +66,31 @@ typedef int synctex_bool_t;
 extern "C" {
 #endif
 
-#	if defined(_WIN32) || defined(__OS2__)
-#   define SYNCTEX_CASE_SENSITIVE_PATH 0
-#		define SYNCTEX_IS_PATH_SEPARATOR(c) ('/' == c || '\\' == c)
-#	else
-#   define SYNCTEX_CASE_SENSITIVE_PATH 1
-#		define SYNCTEX_IS_PATH_SEPARATOR(c) ('/' == c)
-#	endif
+#if defined(_WIN32) || defined(__OS2__)
+#define SYNCTEX_CASE_SENSITIVE_PATH 0
+#define SYNCTEX_IS_PATH_SEPARATOR(c) ('/' == c || '\\' == c)
+#else
+#define SYNCTEX_CASE_SENSITIVE_PATH 1
+#define SYNCTEX_IS_PATH_SEPARATOR(c) ('/' == c)
+#endif
 
-#	if defined(_WIN32) || defined(__OS2__)
-#		define SYNCTEX_IS_DOT(c) ('.' == c)
-#	else
-#		define SYNCTEX_IS_DOT(c) ('.' == c)
-#	endif
+#if defined(_WIN32) || defined(__OS2__)
+#define SYNCTEX_IS_DOT(c) ('.' == c)
+#else
+#define SYNCTEX_IS_DOT(c) ('.' == c)
+#endif
 
-#	if SYNCTEX_CASE_SENSITIVE_PATH
-#		define SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(left,right) (left != right)
-#	else
-#		define SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(left,right) (toupper(left) != toupper(right))
-#	endif
+#if SYNCTEX_CASE_SENSITIVE_PATH
+#define SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(left, right) (left != right)
+#else
+#define SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(left, right) (toupper(left) != toupper(right))
+#endif
 
-#	if defined(_MSC_VER)
-#		define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK)
-#	else
-#		define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) __attribute__((__format__ (__printf__, (STRING_INDEX), (FIRST_TO_CHECK))))
-#	endif
+#if defined(_MSC_VER)
+#define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK)
+#else
+#define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) __attribute__((__format__(__printf__, (STRING_INDEX), (FIRST_TO_CHECK))))
+#endif
 
 /*  This custom malloc functions initializes to 0 the newly allocated memory.
  *  There is no bzero function on windows. */
@@ -98,18 +98,18 @@ void *_synctex_malloc(size_t size);
 
 /*  To balance _synctex_malloc.
  *  ptr might be NULL.   */
-void _synctex_free(void * ptr);
+void _synctex_free(void *ptr);
 
 /*  This is used to log some informational message to the standard error stream.
  *  On Windows, the stderr stream is not exposed and another method is used.
  *	The return value is the number of characters printed.	*/
-    int _synctex_error(const char * reason,...);
-    int _synctex_debug(const char * reason,...);
+int _synctex_error(const char *reason, ...);
+int _synctex_debug(const char *reason, ...);
 
 /*  strip the last extension of the given string, this string is modified!
  *  This function depends on the OS because the path separator may differ.
  *  This should be discussed more precisely. */
-void _synctex_strip_last_path_extension(char * string);
+void _synctex_strip_last_path_extension(char *string);
 
 /*  Compare two file names, windows is sometimes case insensitive...
  *  The given strings may differ stricto sensu, but represent the same file name.
@@ -121,16 +121,16 @@ synctex_bool_t _synctex_is_equivalent_file_name(const char *lhs, const char *rhs
 /**
  * The client is responsible of the management of the returned string, if any.
  */
-char * _synctex_merge_strings(const char * first,...);
+char *_synctex_merge_strings(const char *first, ...);
 
 /*	Description forthcoming.*/
-synctex_bool_t _synctex_path_is_absolute(const char * name);
+synctex_bool_t _synctex_path_is_absolute(const char *name);
 
 /*	Description forthcoming...*/
-const char * _synctex_last_path_component(const char * name);
+const char *_synctex_last_path_component(const char *name);
 
 /*	Description forthcoming...*/
-const char * _synctex_base_name(const char *path);
+const char *_synctex_base_name(const char *path);
 
 /*	If the core of the last path component of src is not already enclosed with double quotes ('"')
  *  and contains a space character (' '), then a new buffer is created, the src is copied and quotes are added.
@@ -141,44 +141,44 @@ const char * _synctex_base_name(const char *path);
  *  On success, the caller owns the buffer pointed to by dest_ref (is any) and
  *  is responsible of freeing the memory when done.
  *	The size argument is the size of the src buffer. On return the dest_ref points to a buffer sized size+2.*/
-int _synctex_copy_with_quoting_last_path_component(const char * src, char ** dest_ref, size_t size);
+int _synctex_copy_with_quoting_last_path_component(const char *src, char **dest_ref, size_t size);
 
 /*  These are the possible extensions of the synctex file */
-extern const char * synctex_suffix;
-extern const char * synctex_suffix_gz;
+extern const char *synctex_suffix;
+extern const char *synctex_suffix_gz;
 
 typedef unsigned int synctex_io_mode_t;
 
 typedef enum {
-	synctex_io_append_mask = 1,
-    synctex_io_gz_mask = synctex_io_append_mask<<1
+    synctex_io_append_mask = 1,
+    synctex_io_gz_mask = synctex_io_append_mask << 1
 } synctex_io_mode_masks_t;
 
 typedef enum {
-	synctex_compress_mode_none = 0,
-	synctex_compress_mode_gz = 1
+    synctex_compress_mode_none = 0,
+    synctex_compress_mode_gz = 1
 } synctex_compress_mode_t;
 
-int _synctex_get_name(const char * output, const char * build_directory, char ** synctex_name_ref, synctex_io_mode_t * io_mode_ref);
+int _synctex_get_name(const char *output, const char *build_directory, char **synctex_name_ref, synctex_io_mode_t *io_mode_ref);
 
 /*  returns the correct mode required by fopen and gzopen from the given io_mode */
-const char * _synctex_get_io_mode_name(synctex_io_mode_t io_mode);
+const char *_synctex_get_io_mode_name(synctex_io_mode_t io_mode);
 
-synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name);
+synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char **name);
 
-synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name);
-int synctex_parse_int(char * ptr, char ** endptr);
+synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char **name);
+int synctex_parse_int(char *ptr, char **endptr);
 
 typedef enum {
-	synctex_parse_int_policy_request = -1,
-	synctex_parse_int_policy_C = 0,
-	synctex_parse_int_policy_raw1 = 1,
-	synctex_parse_int_policy_raw2 = 2,
+    synctex_parse_int_policy_request = -1,
+    synctex_parse_int_policy_C = 0,
+    synctex_parse_int_policy_raw1 = 1,
+    synctex_parse_int_policy_raw2 = 2,
 } synctex_parse_int_policy_t;
 
 synctex_parse_int_policy_t synctex_parse_int_policy(synctex_parse_int_policy_t policy);
 
-int synctex_parse_int(char * ptr, char ** endptr);
+int synctex_parse_int(char *ptr, char **endptr);
 
 #ifdef __cplusplus
 }

--- a/synctex_parser_utils.h
+++ b/synctex_parser_utils.h
@@ -1,13 +1,13 @@
-/* 
+/*
  Copyright (c) 2008-2024 jerome DOT laurens AT u-bourgogne DOT fr
- 
+
  This file is part of the __SyncTeX__ package.
- 
+
  Version: see synctex_version.h
  Latest Revision: Thu Mar 21 14:12:58 UTC 2024
 
  See `synctex_parser_readme.md` for more details
- 
+
  ## License
 
 Permission is hereby granted, free of charge, to any person
@@ -31,9 +31,9 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE
 
-Except as contained in this notice, the name of the copyright holder  
-shall not be used in advertising or otherwise to promote the sale,  
-use or other dealings in this Software without prior written  
+Except as contained in this notice, the name of the copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written
 authorization from the copyright holder.
 
 */
@@ -73,13 +73,13 @@ extern "C" {
 #   define SYNCTEX_CASE_SENSITIVE_PATH 1
 #		define SYNCTEX_IS_PATH_SEPARATOR(c) ('/' == c)
 #	endif
-    
+
 #	if defined(_WIN32) || defined(__OS2__)
 #		define SYNCTEX_IS_DOT(c) ('.' == c)
 #	else
 #		define SYNCTEX_IS_DOT(c) ('.' == c)
 #	endif
-    
+
 #	if SYNCTEX_CASE_SENSITIVE_PATH
 #		define SYNCTEX_ARE_PATH_CHARACTERS_EQUAL(left,right) (left != right)
 #	else
@@ -91,7 +91,7 @@ extern "C" {
 #	else
 #		define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) __attribute__((__format__ (__printf__, (STRING_INDEX), (FIRST_TO_CHECK))))
 #	endif
-    
+
 /*  This custom malloc functions initializes to 0 the newly allocated memory.
  *  There is no bzero function on windows. */
 void *_synctex_malloc(size_t size);
@@ -165,7 +165,7 @@ int _synctex_get_name(const char * output, const char * build_directory, char **
 const char * _synctex_get_io_mode_name(synctex_io_mode_t io_mode);
 
 synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name);
-    
+
 synctex_bool_t synctex_ignore_leading_dot_slash_in_path(const char ** name);
 int synctex_parse_int(char * ptr, char ** endptr);
 

--- a/synctex_version.h
+++ b/synctex_version.h
@@ -47,29 +47,28 @@ I would appreciate to be listed as contributor and see "__SyncTeX__" highlighted
 */
 
 #ifndef _SYNCTEX_VERSION_H_
-#   define _SYNCTEX_VERSION_H_
+#define _SYNCTEX_VERSION_H_
 
 /* The version of .synctex files contents. */
-#   define SYNCTEX_VERSION 1
-#   define SYNCTEX_FILE_VERSION SYNCTEX_VERSION
-
+#define SYNCTEX_VERSION 1
+#define SYNCTEX_FILE_VERSION SYNCTEX_VERSION
 
 /* The version of the synctex parser library */
-#   define SYNCTEX_VERSION_MAJOR 1
-#   define SYNCTEX_VERSION_MINOR 30
+#define SYNCTEX_VERSION_MAJOR 1
+#define SYNCTEX_VERSION_MINOR 30
 
 /* Keep next value in synch with `synctex_parser_version.txt` contents. */
-#   define SYNCTEX_VERSION_STRING "1.30"
+#define SYNCTEX_VERSION_STRING "1.30"
 
 /* The version of the synctex CLI tool */
-#   define SYNCTEX_CLI_VERSION_MAJOR 1
-#   define SYNCTEX_CLI_VERSION_MINOR 7
-#   define SYNCTEX_CLI_VERSION_STRING "1.7"
+#define SYNCTEX_CLI_VERSION_MAJOR 1
+#define SYNCTEX_CLI_VERSION_MINOR 7
+#define SYNCTEX_CLI_VERSION_STRING "1.7"
 
 /* The version of the synctex support,
  * how synctex is embedded in various TeX engines. */
-#   define SYNCTEX_SUPPORT_VERSION_MAJOR 1
-#   define SYNCTEX_SUPPORT_VERSION_MINOR 0
-#   define SYNCTEX_SUPPORT_VERSION_STRING "1.0"
+#define SYNCTEX_SUPPORT_VERSION_MAJOR 1
+#define SYNCTEX_SUPPORT_VERSION_MINOR 0
+#define SYNCTEX_SUPPORT_VERSION_STRING "1.0"
 
 #endif


### PR DESCRIPTION
This MR introduces clang-format with KDE-based settings which in turn are based on WebKit.

Since clang-format is very opinionated, and there were a lot to fix up, I carefully managed to prepare the repo before the blank formatting by merging simpler patches manually first:

- open file in a text editor and instantly save it to remove trailing whitespaces (this alone contributed a lot).
- wrap table-like data in `// clang-format off` & `// clang-format on` so its formatting doesn't get destroyed.
- add trailing comma to struct initializers. It prevents clang-format from indenting the fields all the way to the
right.
- Add semicolons to top-level standalone macro calls
While not syntactically required *after* macro expansion, in the form of
source code *before* the expansion it makes syntax highlighters and
clang-format quite confused that those macros might expand to some
attributes for a next function or variable definition, and it messes up
colors/indentation.

After that I added .clang-format config files, applied them in separate commits.

I encourage you to check out this pull request locally, rewind it to the "Add clang-format configuration" commit, and running `cd meson; meson setup --wipe build; ninja -C build clang-format` yourself — it should yield identical results to the last commit on this branch.

Closes #96 