### PR TITLE
Fix Windows build of synctex.dll: Link with shlwapi.dll

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -6,6 +6,7 @@ project('synctex', 'c', version: 'see synctex_version.h')
 
 synctex_dir = '..'
 
+cc = meson.get_compiler('c')
 fs = import('fs')
 
 foreach line: fs.read(synctex_dir / 'synctex_version.h').split('\n')
@@ -36,12 +37,19 @@ synctex_main = files(
 
 zdep = dependency('zlib', version: '>=1.2.8')
 
+# for PathFindExtension
+if host_machine.system() == 'windows'
+  shlwapi = cc.find_library('shlwapi')
+else
+  shlwapi = []
+endif
+
 synctex_inc = include_directories(synctex_dir)
 synctex_name = 'synctex'
 synctex_lib = library(synctex_name,
   synctex_sources,
   install: true,
-  dependencies: [ zdep ],
+  dependencies: [ shlwapi, zdep ],
   include_directories: [ synctex_inc ],
 )
 

--- a/synctex_main.c
+++ b/synctex_main.c
@@ -104,12 +104,7 @@ inline static double my_fmax(double x, double y)
 }
 #endif
 
-/* I use the definition in kpathsea --ak
-#ifdef WIN32
-#   define snprintf _snprintf
-#endif
-*/
-
+/* I use the definition in kpathsea --ak */
 #if defined(WIN32) && defined(SYNCTEX_STANDALONE)
 #define snprintf _snprintf
 #endif


### PR DESCRIPTION
Copy pasted from evince, which is, interestingly, the only other example
of meson linking with winapi I could find.

https://gitlab.gnome.org/GNOME/evince/-/blob/48.0/cut-n-paste/synctex/meson.build

Second commit is "Remove commented out and duplicated define", and I have no idea what's up with that kpathsea reference, but almost the same code if not commented out right below it.

Relates to #107