### PR TITLE
Fix SYNCTEX_ATTRIBUTE_FORMAT_PRINTF on Microsoft C compiler (again)

### DIFF
--- a/synctex_parser_utils.h
+++ b/synctex_parser_utils.h
@@ -83,7 +83,9 @@ extern "C" {
 #endif
 
 #if defined(_MSC_VER)
-#define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK)
+// Microsoft C/C++ does not support __attribute__((__format__)), there is no drop-in replacement.
+// See https://learn.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values?view=msvc-170
+#define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK)
 #else
 #define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) __attribute__((__format__(__printf__, (STRING_INDEX), (FIRST_TO_CHECK))))
 #endif


### PR DESCRIPTION
The replacement `ATTRIBUTE_FORMAT_PRINTF` is not defined, and in fact was the previous name of the macro.

See commits

- dce42b9ceeb53fa3fc754bda8735ef1210c6b3d3
- 38ee6dc53b8f71883db9ec0fe33cb0c334744b5f
- 7f5a4cb97faa26dbbcd61cbe1605292b494b27d7

CC @stloeffler

---

there are more patches I made locally, but I don't want them to be squashed like the clang-format PR, so I'm sending them one by one in separate PRs.