### PR TITLE
Add attributes/annotations to function declarations in header files too

### DIFF
--- a/synctex_parser_utils.h
+++ b/synctex_parser_utils.h
@@ -99,7 +99,10 @@ void _synctex_free(void *ptr);
 /*  This is used to log some informational message to the standard error stream.
  *  On Windows, the stderr stream is not exposed and another method is used.
  *	The return value is the number of characters printed.	*/
+SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
 int _synctex_error(const char *reason, ...);
+
+SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
 int _synctex_debug(const char *reason, ...);
 
 /*  strip the last extension of the given string, this string is modified!


### PR DESCRIPTION
That's where they actually matter for API users.


---


Tried adding [SAL Annotations](https://learn.microsoft.com/en-us/cpp/c-runtime-library/sal-annotations?view=msvc-170) for Windows, and MSC complained about missing annotations in function declarations, so I figured GCC/clang attributes could be added there too.