### PR TITLE
Enable static analysis & add printf format SAL for MSVC

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -44,6 +44,11 @@ else
   shlwapi = []
 endif
 
+# for good measure
+if (cc.get_id() == 'msvc')
+  add_global_arguments('/analyze', language : 'c')
+endif
+
 synctex_inc = include_directories(synctex_dir)
 synctex_name = 'synctex'
 synctex_lib = library(synctex_name,

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -9221,7 +9221,7 @@ struct _synctex_updater_t {
 };
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(2, 3)
-static int _synctex_updater_print(synctex_updater_p updater, const char *format, ...)
+static int _synctex_updater_print(synctex_updater_p updater, SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *format, ...)
 {
     int result = 0;
     if (updater) {
@@ -9257,7 +9257,7 @@ static int vasprintf(char **ret, const char *format, va_list ap)
  *  gzvprintf is not available until OSX 10.10
  */
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(2, 3)
-static int _synctex_updater_print_gz(synctex_updater_p updater, const char *format, ...)
+static int _synctex_updater_print_gz(synctex_updater_p updater, SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *format, ...)
 {
     int result = 0;
     if (updater) {

--- a/synctex_parser_utils.c
+++ b/synctex_parser_utils.c
@@ -86,8 +86,8 @@ void _synctex_free(void *ptr)
 #include <syslog.h>
 #endif
 
-SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(3, 0)
-static int _synctex_log(int level, const char *prompt, const char *reason, va_list arg)
+SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(3, 0) // Should be (3, 4) but GCC doesn't support va_list
+static int _synctex_log(int level, const char *prompt, SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *reason, va_list arg)
 {
     int result;
 #ifdef SYNCTEX_RECENT_WINDOWS
@@ -134,7 +134,7 @@ static int _synctex_log(int level, const char *prompt, const char *reason, va_li
 }
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_error(const char *reason, ...)
+int _synctex_error(SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *reason, ...)
 {
     va_list arg;
     int result;
@@ -149,7 +149,7 @@ int _synctex_error(const char *reason, ...)
 }
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_debug(const char *reason, ...)
+int _synctex_debug(SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *reason, ...)
 {
     va_list arg;
     int result;

--- a/synctex_parser_utils.h
+++ b/synctex_parser_utils.h
@@ -86,8 +86,10 @@ extern "C" {
 // Microsoft C/C++ does not support __attribute__((__format__)), there is no drop-in replacement.
 // See https://learn.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values?view=msvc-170
 #define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK)
+#define SYNCTEX_ANNOTATION_FORMAT_PRINTF _Printf_format_string_
 #else
 #define SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(STRING_INDEX, FIRST_TO_CHECK) __attribute__((__format__(__printf__, (STRING_INDEX), (FIRST_TO_CHECK))))
+#define SYNCTEX_ANNOTATION_FORMAT_PRINTF
 #endif
 
 /*  This custom malloc functions initializes to 0 the newly allocated memory.
@@ -102,10 +104,10 @@ void _synctex_free(void *ptr);
  *  On Windows, the stderr stream is not exposed and another method is used.
  *	The return value is the number of characters printed.	*/
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_error(const char *reason, ...);
+int _synctex_error(SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *reason, ...);
 
 SYNCTEX_ATTRIBUTE_FORMAT_PRINTF(1, 2)
-int _synctex_debug(const char *reason, ...);
+int _synctex_debug(SYNCTEX_ANNOTATION_FORMAT_PRINTF const char *reason, ...);
 
 /*  strip the last extension of the given string, this string is modified!
  *  This function depends on the OS because the path separator may differ.


### PR DESCRIPTION
On the topic of improving Windows/MSC support (related to #107 and #110)

 - Enable static analysis on MSC/MSVC compiler (/analyze option)
 - Add printf format SAL annotations for Microsoft C/C++
