### PR TITLE
Fix memory management in synctex_reader_init_with_output_file

### DIFF
--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -1225,10 +1225,10 @@ static void synctex_reader_free(synctex_reader_p reader)
     }
 }
 /*
- *  Return reader on success.
- *  Deallocate reader and return NULL on failure.
+ *  Returns true on success, returns false on failure.
+ *  Sometimes deallocates reader on failure.
  */
-static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p reader, const char *output, const char *build_directory)
+static synctex_bool_t synctex_reader_init_with_output_file(synctex_reader_p reader, const char *output, const char *build_directory)
 {
     if (reader) {
         /*  now open the synctex file */
@@ -1236,7 +1236,7 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
         if (open.status < SYNCTEX_STATUS_OK) {
             open = _synctex_open_v2(output, build_directory, 0, synctex_DONT_ADD_QUOTES);
             if (open.status < SYNCTEX_STATUS_OK) {
-                return NULL;
+                return synctex_NO;
             }
         }
         reader->synctex = open.synctex;
@@ -1254,10 +1254,10 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
         if (NULL == reader->start) {
             _synctex_error("!  malloc error in synctex_reader_init_with_output_file.");
 #ifdef SYNCTEX_DEBUG
-            return reader;
+            return synctex_YES;
 #else
             synctex_reader_free(reader);
-            return NULL;
+            return synctex_NO;
 #endif
         }
         reader->end = reader->start + reader->size;
@@ -1268,7 +1268,7 @@ static synctex_reader_p synctex_reader_init_with_output_file(synctex_reader_p re
         reader->charindex_offset = -reader->size;
 #endif
     }
-    return reader;
+    return synctex_YES;
 }
 
 /** @cond */

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -1226,7 +1226,6 @@ static void synctex_reader_free(synctex_reader_p reader)
 }
 /*
  *  Returns true on success, returns false on failure.
- *  Sometimes deallocates reader on failure.
  */
 static synctex_bool_t synctex_reader_init_with_output_file(synctex_reader_p reader, const char *output, const char *build_directory)
 {
@@ -1253,12 +1252,7 @@ static synctex_bool_t synctex_reader_init_with_output_file(synctex_reader_p read
         reader->start = reader->current = (char *)_synctex_malloc(reader->size + 1); /*  one more character for null termination */
         if (NULL == reader->start) {
             _synctex_error("!  malloc error in synctex_reader_init_with_output_file.");
-#ifdef SYNCTEX_DEBUG
-            return synctex_YES;
-#else
-            synctex_reader_free(reader);
             return synctex_NO;
-#endif
         }
         reader->end = reader->start + reader->size;
         /*  reader->end always points to a null terminating character.

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -6676,12 +6676,11 @@ synctex_scanner_p synctex_scanner_new()
             _synctex_free(scanner);
             return NULL;
         }
-#ifdef SYNCTEX_NOTHING
-#pragma mark -
-#endif
+
 #define DEFINE_synctex_scanner_class(NAME)                                                                                                                     \
     scanner->class_[synctex_node_type_##NAME] = _synctex_class_##NAME;                                                                                         \
     (scanner->class_[synctex_node_type_##NAME]).scanner = scanner
+
         DEFINE_synctex_scanner_class(input);
         DEFINE_synctex_scanner_class(sheet);
         DEFINE_synctex_scanner_class(form);

--- a/synctex_parser.c
+++ b/synctex_parser.c
@@ -6781,18 +6781,12 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner)
     status = _synctex_scan_preamble(scanner);
     if (status < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad preamble\n");
-    bailey:
-#ifdef SYNCTEX_DEBUG
-        return scanner;
-#else
-        synctex_scanner_free(scanner);
-        return NULL;
-#endif
+        goto return_on_error;
     }
     status = _synctex_scan_content(scanner);
     if (status < SYNCTEX_STATUS_OK) {
         _synctex_error("Bad content\n");
-        goto bailey;
+        goto return_on_error;
     }
     status = _synctex_scan_postamble(scanner);
     if (status < SYNCTEX_STATUS_OK) {
@@ -6836,8 +6830,17 @@ synctex_scanner_p synctex_scanner_parse(synctex_scanner_p scanner)
         scanner->y_offset /= 65781.76f;
     }
     return scanner;
-#undef SYNCTEX_FILE
+
+return_on_error:
+#ifdef SYNCTEX_DEBUG
+        return scanner;
+#else
+        synctex_scanner_free(scanner);
+        return NULL;
+#endif
 }
+
+#undef SYNCTEX_FILE
 
 /*  Scanner accessors.
  */


### PR DESCRIPTION
### Fix memory management in synctex_reader_init_with_output_file

Don't free the the reader one of two failure code paths and only in
release build.

This function is internal and is only called from a single place which
doesn't even care to reset the reader pointer on failure, so there was
a potential double-free problem as well.

---

there are other drive-by patches on this branch:

### Simplify return type of synctex_reader_init_with_output_file to bool

This function is only called from one place which is an `if` expression.

~~It is concerning that deallocation on failure is inconsistent.~~ (fixed in the title patch)

### Put error path for goto at the end of the function where it belongs

Don't define the goto label at the first occurrence and then jump into
that middle of nowhere from all over the place. It is a common practice
in C to place error handling code paths at the end.

Also, move random #undef out of the function body. What is it even doing
here, nowhere around its corresponding #define?

Same as 19464aeeaa7f1dd77c49a602b1478b83f4f1fd91

### Remove random preprocessor marks in the middle of a function